### PR TITLE
feat(roam-ws): add auto-reconnecting WebSocket client

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@types/node':
         specifier: ^22
         version: 22.19.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.3)
 
   typescript/subject:
     dependencies:

--- a/typescript/packages/roam-postcard/tsconfig.json
+++ b/typescript/packages/roam-postcard/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/typescript/packages/roam-ws/package.json
+++ b/typescript/packages/roam-ws/package.json
@@ -7,13 +7,15 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "check": "tsgo --noEmit"
+    "check": "tsgo --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@bearcove/roam-core": "workspace:*",
     "@bearcove/roam-tcp": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^22"
+    "@types/node": "^22",
+    "vitest": "^2.1.0"
   }
 }

--- a/typescript/packages/roam-ws/src/index.ts
+++ b/typescript/packages/roam-ws/src/index.ts
@@ -4,3 +4,12 @@
 // r[impl transport.message.binary] - Uses binary WebSocket frames.
 
 export { WsTransport, connectWs } from "./transport.ts";
+export {
+  ReconnectingWsClient,
+  createReconnectingClient,
+  type ReconnectingClientConfig,
+  type ConnectionState,
+  type BackoffConfig,
+  ClientClosedError,
+  ReconnectFailedError,
+} from "./reconnecting.ts";

--- a/typescript/packages/roam-ws/src/reconnecting.test.ts
+++ b/typescript/packages/roam-ws/src/reconnecting.test.ts
@@ -1,0 +1,276 @@
+// Tests for auto-reconnecting WebSocket client.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  ReconnectingWsClient,
+  createReconnectingClient,
+  ClientClosedError,
+  ReconnectFailedError,
+  type ConnectionState,
+} from "./reconnecting.ts";
+
+// Mock WebSocket for testing
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  binaryType: string = "blob";
+  readyState: number = 0; // CONNECTING
+
+  private listeners: Map<string, Set<(event: unknown) => void>> = new Map();
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
+    }
+    this.listeners.get(type)!.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  send(_data: ArrayBuffer | Uint8Array): void {
+    if (this.readyState !== 1) {
+      throw new Error("WebSocket not open");
+    }
+  }
+
+  close(): void {
+    this.readyState = 3; // CLOSED
+    this.emit("close", {});
+  }
+
+  // Test helpers
+  simulateOpen(): void {
+    this.readyState = 1; // OPEN
+    this.emit("open", {});
+  }
+
+  simulateError(): void {
+    this.emit("error", new Error("Connection error"));
+  }
+
+  simulateClose(): void {
+    this.readyState = 3;
+    this.emit("close", {});
+  }
+
+  private emit(type: string, event: unknown): void {
+    const listeners = this.listeners.get(type);
+    if (listeners) {
+      for (const listener of listeners) {
+        listener(event);
+      }
+    }
+  }
+
+  static clear(): void {
+    MockWebSocket.instances = [];
+  }
+
+  static get latest(): MockWebSocket | undefined {
+    return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  }
+}
+
+describe("ReconnectingWsClient", () => {
+  let originalWebSocket: typeof globalThis.WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+    // @ts-expect-error - Mock WebSocket
+    globalThis.WebSocket = MockWebSocket;
+    MockWebSocket.clear();
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+  });
+
+  describe("createReconnectingClient", () => {
+    it("creates a client with default config", () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+      expect(client).toBeInstanceOf(ReconnectingWsClient);
+      expect(client.getState()).toBe("disconnected");
+      expect(client.isClosed()).toBe(false);
+    });
+
+    it("creates a client with custom config", () => {
+      const stateChanges: ConnectionState[] = [];
+      const client = createReconnectingClient({
+        url: "ws://localhost:8080",
+        reconnect: {
+          enabled: true,
+          maxAttempts: 5,
+          backoff: { initial: 500, max: 10000, factor: 1.5, jitter: 0 },
+        },
+        onStateChange: (state) => stateChanges.push(state),
+        requestTimeout: 5000,
+      });
+      expect(client).toBeInstanceOf(ReconnectingWsClient);
+    });
+  });
+
+  describe("connection state", () => {
+    it("transitions to connecting when connect is called", () => {
+      const stateChanges: ConnectionState[] = [];
+      const client = createReconnectingClient({
+        url: "ws://localhost:8080",
+        onStateChange: (state) => stateChanges.push(state),
+      });
+
+      // Start connecting (don't await)
+      client.connect();
+
+      // Should be connecting now
+      expect(stateChanges).toContain("connecting");
+      expect(client.getState()).toBe("connecting");
+
+      // Clean up
+      client.close();
+    });
+
+    it("stays disconnected initially", () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+      expect(client.getState()).toBe("disconnected");
+    });
+
+    it("creates WebSocket with correct URL", () => {
+      const client = createReconnectingClient({ url: "ws://example.com:9000/roam" });
+      client.connect();
+
+      expect(MockWebSocket.latest?.url).toBe("ws://example.com:9000/roam");
+
+      client.close();
+    });
+  });
+
+  describe("close", () => {
+    it("marks client as closed", () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+      expect(client.isClosed()).toBe(false);
+
+      client.close();
+
+      expect(client.isClosed()).toBe(true);
+      expect(client.getState()).toBe("disconnected");
+    });
+
+    it("throws ClientClosedError on connect after close", async () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+      client.close();
+
+      await expect(client.connect()).rejects.toThrow(ClientClosedError);
+    });
+
+    it("throws ClientClosedError on call after close", async () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+      client.close();
+
+      await expect(client.call(1n, new Uint8Array())).rejects.toThrow(ClientClosedError);
+    });
+
+    it("is idempotent", () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+
+      client.close();
+      client.close();
+      client.close();
+
+      expect(client.isClosed()).toBe(true);
+    });
+
+    it("closes underlying WebSocket when connecting", () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+      client.connect();
+
+      const ws = MockWebSocket.latest!;
+      expect(ws).toBeDefined();
+
+      // Close before connection completes
+      client.close();
+
+      // WebSocket should be closed
+      expect(ws.readyState).toBe(3); // CLOSED
+    });
+  });
+
+  describe("reconnect disabled", () => {
+    it("does not reconnect when disabled", async () => {
+      const stateChanges: ConnectionState[] = [];
+      const client = createReconnectingClient({
+        url: "ws://localhost:8080",
+        reconnect: { enabled: false },
+        onStateChange: (state) => stateChanges.push(state),
+      });
+
+      const connectPromise = client.connect();
+
+      // Connection fails
+      MockWebSocket.latest?.simulateError();
+
+      await expect(connectPromise).rejects.toThrow();
+      expect(stateChanges).toContain("disconnected");
+      expect(stateChanges).not.toContain("reconnecting");
+    });
+  });
+
+  describe("getNegotiated", () => {
+    it("returns null when not connected", () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+      expect(client.getNegotiated()).toBeNull();
+    });
+  });
+
+  describe("error types", () => {
+    it("ClientClosedError has correct name", () => {
+      const error = new ClientClosedError();
+      expect(error.name).toBe("ClientClosedError");
+      expect(error.message).toBe("Client is closed");
+    });
+
+    it("ReconnectFailedError includes attempt count and last error", () => {
+      const lastError = new Error("Connection refused");
+      const error = new ReconnectFailedError(5, lastError);
+      expect(error.name).toBe("ReconnectFailedError");
+      expect(error.attempts).toBe(5);
+      expect(error.lastError).toBe(lastError);
+      expect(error.message).toContain("5 attempts");
+      expect(error.message).toContain("Connection refused");
+    });
+  });
+
+  describe("config defaults", () => {
+    it("uses default request timeout of 30000", () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+      // The default is used internally - we can verify by checking the client exists
+      expect(client).toBeInstanceOf(ReconnectingWsClient);
+    });
+
+    it("allows custom request timeout", () => {
+      const client = createReconnectingClient({
+        url: "ws://localhost:8080",
+        requestTimeout: 5000,
+      });
+      expect(client).toBeInstanceOf(ReconnectingWsClient);
+    });
+  });
+
+  describe("multiple connect calls", () => {
+    it("returns same promise when already connecting", () => {
+      const client = createReconnectingClient({ url: "ws://localhost:8080" });
+
+      const promise1 = client.connect();
+      const promise2 = client.connect();
+
+      // Should be the same underlying connection attempt
+      expect(MockWebSocket.instances.length).toBe(1);
+
+      client.close();
+    });
+  });
+});

--- a/typescript/packages/roam-ws/src/reconnecting.ts
+++ b/typescript/packages/roam-ws/src/reconnecting.ts
@@ -1,0 +1,457 @@
+// Auto-reconnecting WebSocket client for roam.
+//
+// Provides automatic reconnection with exponential backoff, connection state
+// events, and request queuing during reconnection.
+
+import {
+  Connection,
+  helloExchangeInitiator,
+  defaultHello,
+  ConnectionError,
+  type Negotiated,
+} from "@bearcove/roam-core";
+import { WsTransport } from "./transport.ts";
+
+/** Connection state. */
+export type ConnectionState = "disconnected" | "connecting" | "connected" | "reconnecting";
+
+/** Backoff configuration for reconnection attempts. */
+export interface BackoffConfig {
+  /** Initial delay in milliseconds. Default: 1000 */
+  initial: number;
+  /** Maximum delay in milliseconds. Default: 30000 */
+  max: number;
+  /** Multiplier for exponential backoff. Default: 2 */
+  factor: number;
+  /** Jitter factor (0-1) to randomize delays. Default: 0.1 */
+  jitter: number;
+}
+
+/** Configuration for the reconnecting client. */
+export interface ReconnectingClientConfig {
+  /** WebSocket URL to connect to. */
+  url: string;
+
+  /** Reconnection configuration. */
+  reconnect?: {
+    /** Whether reconnection is enabled. Default: true */
+    enabled?: boolean;
+    /** Maximum number of reconnection attempts. Default: Infinity */
+    maxAttempts?: number;
+    /** Backoff configuration. */
+    backoff?: Partial<BackoffConfig>;
+  };
+
+  /** Called when connection state changes. */
+  onStateChange?: (state: ConnectionState) => void;
+
+  /** Called when a reconnection attempt starts. */
+  onReconnectAttempt?: (attempt: number, delay: number) => void;
+
+  /** Called when reconnection fails permanently. */
+  onReconnectFailed?: (error: Error) => void;
+
+  /** Timeout for pending requests in milliseconds. Default: 30000 */
+  requestTimeout?: number;
+}
+
+/** Error thrown when client is permanently closed. */
+export class ClientClosedError extends Error {
+  constructor() {
+    super("Client is closed");
+    this.name = "ClientClosedError";
+  }
+}
+
+/** Error thrown when reconnection fails. */
+export class ReconnectFailedError extends Error {
+  constructor(
+    public attempts: number,
+    public lastError: Error,
+  ) {
+    super(`Reconnection failed after ${attempts} attempts: ${lastError.message}`);
+    this.name = "ReconnectFailedError";
+  }
+}
+
+interface PendingRequest {
+  methodId: bigint;
+  payload: Uint8Array;
+  resolve: (value: Uint8Array) => void;
+  reject: (error: Error) => void;
+  timeoutId: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Auto-reconnecting WebSocket client.
+ *
+ * This client automatically handles connection failures and reconnects
+ * with exponential backoff. Requests made during disconnection are queued
+ * and sent once the connection is re-established.
+ */
+export class ReconnectingWsClient {
+  private url: string;
+  private config: Required<
+    Pick<ReconnectingClientConfig, "requestTimeout"> & {
+      reconnect: {
+        enabled: boolean;
+        maxAttempts: number;
+        backoff: BackoffConfig;
+      };
+    }
+  >;
+
+  private onStateChange?: (state: ConnectionState) => void;
+  private onReconnectAttempt?: (attempt: number, delay: number) => void;
+  private onReconnectFailed?: (error: Error) => void;
+
+  private state: ConnectionState = "disconnected";
+  private connection: Connection<WsTransport> | null = null;
+  private ws: WebSocket | null = null;
+  private pendingWs: WebSocket | null = null; // WebSocket being connected
+  private closed = false;
+  private reconnectAttempts = 0;
+  private pendingRequests: PendingRequest[] = [];
+  private connectPromise: Promise<void> | null = null;
+
+  constructor(config: ReconnectingClientConfig) {
+    this.url = config.url;
+    this.onStateChange = config.onStateChange;
+    this.onReconnectAttempt = config.onReconnectAttempt;
+    this.onReconnectFailed = config.onReconnectFailed;
+
+    const backoff = config.reconnect?.backoff ?? {};
+    this.config = {
+      requestTimeout: config.requestTimeout ?? 30000,
+      reconnect: {
+        enabled: config.reconnect?.enabled ?? true,
+        maxAttempts: config.reconnect?.maxAttempts ?? Infinity,
+        backoff: {
+          initial: backoff.initial ?? 1000,
+          max: backoff.max ?? 30000,
+          factor: backoff.factor ?? 2,
+          jitter: backoff.jitter ?? 0.1,
+        },
+      },
+    };
+  }
+
+  /** Get the current connection state. */
+  getState(): ConnectionState {
+    return this.state;
+  }
+
+  /** Get the negotiated parameters (only valid when connected). */
+  getNegotiated(): Negotiated | null {
+    return this.connection?.negotiated() ?? null;
+  }
+
+  /** Check if the client has been permanently closed. */
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  /**
+   * Connect to the server.
+   *
+   * This is called automatically on first request, but can be called
+   * explicitly to establish the connection eagerly.
+   */
+  async connect(): Promise<void> {
+    if (this.closed) {
+      throw new ClientClosedError();
+    }
+
+    if (this.state === "connected") {
+      return;
+    }
+
+    // If already connecting, wait for that attempt
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
+
+    this.connectPromise = this.doConnect();
+    try {
+      await this.connectPromise;
+    } finally {
+      this.connectPromise = null;
+    }
+  }
+
+  private async doConnect(): Promise<void> {
+    const isReconnect = this.state === "reconnecting";
+    this.setState(isReconnect ? "reconnecting" : "connecting");
+
+    try {
+      // Create WebSocket
+      const ws = new WebSocket(this.url);
+      ws.binaryType = "arraybuffer";
+      this.pendingWs = ws;
+
+      // Wait for open
+      await new Promise<void>((resolve, reject) => {
+        const onOpen = () => {
+          ws.removeEventListener("open", onOpen);
+          ws.removeEventListener("error", onError);
+          resolve();
+        };
+        const onError = () => {
+          ws.removeEventListener("open", onOpen);
+          ws.removeEventListener("error", onError);
+          reject(new Error(`Failed to connect to ${this.url}`));
+        };
+        ws.addEventListener("open", onOpen);
+        ws.addEventListener("error", onError);
+      });
+
+      // Check if closed while waiting
+      if (this.closed) {
+        ws.close();
+        this.pendingWs = null;
+        return;
+      }
+
+      // Perform Hello exchange
+      const transport = new WsTransport(ws);
+      const connection = await helloExchangeInitiator(transport, defaultHello());
+
+      this.pendingWs = null;
+      this.ws = ws;
+      this.connection = connection;
+      this.reconnectAttempts = 0;
+      this.setState("connected");
+
+      // Set up disconnect handler
+      this.setupDisconnectHandler(ws);
+
+      // Flush pending requests
+      await this.flushPendingRequests();
+    } catch (error) {
+      // Connection failed
+      if (this.config.reconnect.enabled && !this.closed) {
+        await this.scheduleReconnect(error as Error);
+      } else {
+        this.setState("disconnected");
+        throw error;
+      }
+    }
+  }
+
+  private setupDisconnectHandler(ws: WebSocket): void {
+    const handleDisconnect = () => {
+      if (this.ws !== ws) return; // Stale handler
+
+      this.connection = null;
+      this.ws = null;
+
+      if (this.closed) {
+        this.setState("disconnected");
+        return;
+      }
+
+      if (this.config.reconnect.enabled) {
+        this.setState("reconnecting");
+        this.scheduleReconnect(new Error("Connection lost"));
+      } else {
+        this.setState("disconnected");
+        this.failPendingRequests(new Error("Connection lost"));
+      }
+    };
+
+    ws.addEventListener("close", handleDisconnect);
+    ws.addEventListener("error", handleDisconnect);
+  }
+
+  private async scheduleReconnect(lastError: Error): Promise<void> {
+    this.reconnectAttempts++;
+
+    if (this.reconnectAttempts > this.config.reconnect.maxAttempts) {
+      const error = new ReconnectFailedError(this.reconnectAttempts - 1, lastError);
+      this.onReconnectFailed?.(error);
+      this.failPendingRequests(error);
+      this.setState("disconnected");
+      return;
+    }
+
+    const delay = this.calculateBackoff();
+    this.onReconnectAttempt?.(this.reconnectAttempts, delay);
+
+    await this.sleep(delay);
+
+    if (this.closed) return;
+
+    try {
+      await this.doConnect();
+    } catch {
+      // doConnect handles scheduling the next attempt
+    }
+  }
+
+  private calculateBackoff(): number {
+    const { initial, max, factor, jitter } = this.config.reconnect.backoff;
+    const base = Math.min(initial * Math.pow(factor, this.reconnectAttempts - 1), max);
+    const jitterAmount = base * jitter * (Math.random() * 2 - 1);
+    return Math.max(0, Math.floor(base + jitterAmount));
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private setState(state: ConnectionState): void {
+    if (this.state !== state) {
+      this.state = state;
+      this.onStateChange?.(state);
+    }
+  }
+
+  private async flushPendingRequests(): Promise<void> {
+    const pending = [...this.pendingRequests];
+    this.pendingRequests = [];
+
+    for (const request of pending) {
+      // Don't await - let them run concurrently
+      this.doCall(request.methodId, request.payload).then(request.resolve, request.reject);
+    }
+  }
+
+  private failPendingRequests(error: Error): void {
+    const pending = [...this.pendingRequests];
+    this.pendingRequests = [];
+
+    for (const request of pending) {
+      clearTimeout(request.timeoutId);
+      request.reject(error);
+    }
+  }
+
+  /**
+   * Make an RPC call.
+   *
+   * If not connected, this will attempt to connect first. If disconnected
+   * during the call, it will be retried after reconnection (up to the
+   * request timeout).
+   */
+  async call(methodId: bigint, payload: Uint8Array): Promise<Uint8Array> {
+    if (this.closed) {
+      throw new ClientClosedError();
+    }
+
+    // If connected, try the call directly
+    if (this.state === "connected" && this.connection) {
+      return this.doCall(methodId, payload);
+    }
+
+    // Otherwise, queue the request and ensure we're connecting
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        const idx = this.pendingRequests.findIndex(
+          (r) => r.resolve === resolve && r.reject === reject,
+        );
+        if (idx !== -1) {
+          this.pendingRequests.splice(idx, 1);
+          reject(new Error("Request timed out waiting for connection"));
+        }
+      }, this.config.requestTimeout);
+
+      this.pendingRequests.push({
+        methodId,
+        payload,
+        resolve,
+        reject,
+        timeoutId,
+      });
+
+      // Trigger connection if not already connecting
+      if (!this.connectPromise) {
+        this.connect().catch(() => {
+          // Error handling is done via pending request rejection
+        });
+      }
+    });
+  }
+
+  private async doCall(methodId: bigint, payload: Uint8Array): Promise<Uint8Array> {
+    if (!this.connection) {
+      throw new Error("Not connected");
+    }
+
+    try {
+      return await this.connection.call(methodId, payload, this.config.requestTimeout);
+    } catch (error) {
+      // If connection error and reconnect is enabled, queue for retry
+      if (error instanceof ConnectionError && this.config.reconnect.enabled && !this.closed) {
+        return new Promise((resolve, reject) => {
+          const timeoutId = setTimeout(() => {
+            const idx = this.pendingRequests.findIndex(
+              (r) => r.resolve === resolve && r.reject === reject,
+            );
+            if (idx !== -1) {
+              this.pendingRequests.splice(idx, 1);
+              reject(new Error("Request timed out during reconnection"));
+            }
+          }, this.config.requestTimeout);
+
+          this.pendingRequests.push({
+            methodId,
+            payload,
+            resolve,
+            reject,
+            timeoutId,
+          });
+        });
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Close the client permanently.
+   *
+   * This stops all reconnection attempts and fails any pending requests.
+   */
+  close(): void {
+    if (this.closed) return;
+
+    this.closed = true;
+    this.failPendingRequests(new ClientClosedError());
+
+    // Close any pending WebSocket (still connecting)
+    if (this.pendingWs) {
+      this.pendingWs.close();
+      this.pendingWs = null;
+    }
+
+    // Close established WebSocket
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.connection = null;
+    this.setState("disconnected");
+  }
+}
+
+/**
+ * Create a reconnecting WebSocket client.
+ *
+ * @example
+ * ```typescript
+ * const client = createReconnectingClient({
+ *   url: "ws://localhost:8080/roam",
+ *   reconnect: {
+ *     enabled: true,
+ *     maxAttempts: 10,
+ *     backoff: { initial: 1000, max: 30000, factor: 2 },
+ *   },
+ *   onStateChange: (state) => console.log("Connection:", state),
+ * });
+ *
+ * // Calls automatically wait for connection or fail after timeout
+ * const response = await client.call(methodId, payload);
+ * ```
+ */
+export function createReconnectingClient(config: ReconnectingClientConfig): ReconnectingWsClient {
+  return new ReconnectingWsClient(config);
+}

--- a/typescript/packages/roam-ws/tsconfig.json
+++ b/typescript/packages/roam-ws/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/typescript/tests/playwright/test-results/.last-run.json
+++ b/typescript/tests/playwright/test-results/.last-run.json
@@ -1,6 +1,4 @@
 {
-  "status": "failed",
-  "failedTests": [
-    "58e8dc1668882f4daf0d-fec818a9ad7ede8c5bcf"
-  ]
+  "status": "passed",
+  "failedTests": []
 }

--- a/typescript/tests/playwright/test-results/websocket-browser-can-conn-71783-erver-and-call-echo-methods-chromium/error-context.md
+++ b/typescript/tests/playwright/test-results/websocket-browser-can-conn-71783-erver-and-call-echo-methods-chromium/error-context.md
@@ -1,5 +1,0 @@
-# Page snapshot
-
-```yaml
-- generic [ref=e3]: Loading...
-```


### PR DESCRIPTION
## Summary

Adds auto-reconnecting WebSocket client infrastructure to `@bearcove/roam-ws`.

## Changes

### New: `ReconnectingWsClient`

A WebSocket client that automatically handles connection failures with:

- **Exponential backoff** with configurable initial delay, max delay, factor, and jitter
- **Connection state events** - `disconnected`, `connecting`, `connected`, `reconnecting`
- **Request queuing** - calls made during disconnection are queued and sent after reconnection
- **Configurable limits** - max reconnection attempts and request timeout
- **Proper cleanup** - `close()` properly closes both pending and established WebSocket connections

### Usage

```typescript
import { createReconnectingClient } from "@bearcove/roam-ws";

const client = createReconnectingClient({
  url: "ws://localhost:8080/roam",
  reconnect: {
    enabled: true,
    maxAttempts: 10,
    backoff: { initial: 1000, max: 30000, factor: 2, jitter: 0.1 },
  },
  onStateChange: (state) => console.log("Connection:", state),
  onReconnectAttempt: (attempt, delay) => console.log(`Reconnect #${attempt} in ${delay}ms`),
  onReconnectFailed: (error) => console.error("Gave up:", error),
});

// Calls automatically wait for connection
const response = await client.call(methodId, payload);

// Clean shutdown
client.close();
```

### Also included

- Added missing `tsconfig.json` files for `roam-ws` and `roam-postcard` packages
- Added vitest to `roam-ws` for testing
- 17 unit tests for the reconnecting client

## Test Plan

- [x] All 17 new unit tests pass
- [x] Type-check passes (`pnpm check`)
- [x] All existing tests pass (`pnpm -r test`)

Fixes #13
