### PR TITLE
feat(roam-shm): add MultiPeerHostDriver for hub topology

### DIFF
--- a/rust/roam-shm/src/driver.rs
+++ b/rust/roam-shm/src/driver.rs
@@ -26,7 +26,9 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::host::ShmHost;
 use crate::peer::PeerId;
-use crate::transport::{OwnedShmHostTransport, ShmGuestTransport};
+use crate::transport::{
+    OwnedShmHostTransport, ShmGuestTransport, frame_to_message, message_to_frame,
+};
 
 /// Negotiated connection parameters from SHM segment header.
 ///
@@ -555,4 +557,566 @@ where
     );
 
     (handle, driver)
+}
+
+// ============================================================================
+// Multi-Peer Host Driver
+// ============================================================================
+
+/// Per-peer state for the multi-peer host driver.
+struct PeerConnectionState<D> {
+    /// Dispatcher for handling incoming requests from this peer.
+    dispatcher: D,
+
+    /// Channel for receiving commands from the ConnectionHandle.
+    command_rx: mpsc::Receiver<HandleCommand>,
+
+    /// Channel for receiving task messages from spawned handlers.
+    task_rx: mpsc::Receiver<TaskMessage>,
+
+    /// Server-side stream registry for this peer.
+    server_channel_registry: ChannelRegistry,
+
+    /// Pending responses for outgoing calls we made to this peer.
+    pending_responses: HashMap<u64, oneshot::Sender<Result<Vec<u8>, CallError>>>,
+
+    /// In-flight requests we're serving for this peer.
+    in_flight_server_requests: std::collections::HashSet<u64>,
+
+    /// The connection handle (kept for stream routing).
+    handle: ConnectionHandle,
+}
+
+/// Multi-peer host driver for hub topology.
+///
+/// Unlike `ShmDriver` which handles a single peer, this driver manages
+/// multiple peers over a single `ShmHost`. Each peer gets its own
+/// `ConnectionHandle` for making RPC calls.
+///
+/// # Example
+///
+/// ```ignore
+/// use roam_shm::{ShmHost, SegmentConfig};
+/// use roam_shm::driver::MultiPeerHostDriver;
+///
+/// let host = ShmHost::create("/dev/shm/myapp", SegmentConfig::default())?;
+///
+/// // Add peers and get tickets for spawning
+/// let ticket1 = host.add_peer(options1)?;
+/// let ticket2 = host.add_peer(options2)?;
+///
+/// // Create driver with dispatchers for each peer
+/// let (driver, handles) = MultiPeerHostDriver::new(host)
+///     .add_peer(ticket1.peer_id(), dispatcher1)
+///     .add_peer(ticket2.peer_id(), dispatcher2)
+///     .build();
+///
+/// // Spawn the driver
+/// tokio::spawn(driver.run());
+///
+/// // Use handles to make calls to specific peers
+/// let client1 = MyServiceClient::new(handles[&ticket1.peer_id()].clone());
+/// client1.do_thing().await?;
+/// ```
+pub struct MultiPeerHostDriver<D> {
+    /// The SHM host (owned).
+    host: ShmHost,
+
+    /// Negotiated parameters from segment config.
+    negotiated: ShmNegotiated,
+
+    /// Per-peer connection state.
+    peers: HashMap<PeerId, PeerConnectionState<D>>,
+
+    /// Buffer for last decoded bytes (for error detection).
+    last_decoded: Vec<u8>,
+}
+
+/// Builder for `MultiPeerHostDriver`.
+pub struct MultiPeerHostDriverBuilder<D> {
+    host: ShmHost,
+    peers: Vec<(PeerId, D)>,
+}
+
+impl<D> MultiPeerHostDriverBuilder<D>
+where
+    D: ServiceDispatcher,
+{
+    /// Add a peer with its dispatcher.
+    pub fn add_peer(mut self, peer_id: PeerId, dispatcher: D) -> Self {
+        self.peers.push((peer_id, dispatcher));
+        self
+    }
+
+    /// Build the driver and return connection handles for each peer.
+    pub fn build(self) -> (MultiPeerHostDriver<D>, HashMap<PeerId, ConnectionHandle>) {
+        let config = self.host.config();
+        let negotiated = ShmNegotiated {
+            max_payload_size: config.max_payload_size,
+            initial_credit: config.initial_credit,
+        };
+
+        let mut peers = HashMap::new();
+        let mut handles = HashMap::new();
+
+        for (peer_id, dispatcher) in self.peers {
+            let (command_tx, command_rx) = mpsc::channel(64);
+            let (task_tx, task_rx) = mpsc::channel(64);
+
+            // Host is acceptor (uses even stream IDs)
+            let initial_credit = u32::MAX;
+            let handle =
+                ConnectionHandle::new(command_tx, Role::Acceptor, initial_credit, task_tx.clone());
+
+            handles.insert(peer_id, handle.clone());
+
+            peers.insert(
+                peer_id,
+                PeerConnectionState {
+                    dispatcher,
+                    command_rx,
+                    task_rx,
+                    server_channel_registry: ChannelRegistry::new(task_tx),
+                    pending_responses: HashMap::new(),
+                    in_flight_server_requests: std::collections::HashSet::new(),
+                    handle,
+                },
+            );
+        }
+
+        let driver = MultiPeerHostDriver {
+            host: self.host,
+            negotiated,
+            peers,
+            last_decoded: Vec::new(),
+        };
+
+        (driver, handles)
+    }
+}
+
+impl<D> MultiPeerHostDriver<D>
+where
+    D: ServiceDispatcher,
+{
+    /// Create a new builder for the multi-peer host driver.
+    pub fn new(host: ShmHost) -> MultiPeerHostDriverBuilder<D> {
+        MultiPeerHostDriverBuilder {
+            host,
+            peers: Vec::new(),
+        }
+    }
+
+    /// Run the driver until all peers disconnect or an error occurs.
+    pub async fn run(mut self) -> Result<(), ShmConnectionError> {
+        loop {
+            // Process all pending work in one pass, then yield
+            let mut did_work = false;
+
+            // 1. Process task messages from all peers
+            let task_msgs: Vec<_> = self
+                .peers
+                .iter_mut()
+                .filter_map(|(peer_id, state)| {
+                    state.task_rx.try_recv().ok().map(|msg| (*peer_id, msg))
+                })
+                .collect();
+
+            for (peer_id, msg) in task_msgs {
+                self.handle_task_message(peer_id, msg).await?;
+                did_work = true;
+            }
+
+            // 2. Process commands from all peers
+            let commands: Vec<_> = self
+                .peers
+                .iter_mut()
+                .filter_map(|(peer_id, state)| {
+                    state.command_rx.try_recv().ok().map(|cmd| (*peer_id, cmd))
+                })
+                .collect();
+
+            for (peer_id, cmd) in commands {
+                self.handle_command(peer_id, cmd).await?;
+                did_work = true;
+            }
+
+            // 3. Poll SHM host for incoming messages
+            let messages = self.host.poll();
+            for (peer_id, frame) in messages {
+                self.last_decoded = frame.payload_bytes().to_vec();
+
+                let msg = frame_to_message(frame).map_err(|e| {
+                    ShmConnectionError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+                })?;
+
+                self.handle_message(peer_id, msg).await?;
+                did_work = true;
+            }
+
+            // Check if all peers are gone
+            if self.peers.is_empty() {
+                return Ok(());
+            }
+
+            // Yield to avoid busy-spinning when idle
+            if !did_work {
+                tokio::task::yield_now().await;
+            }
+        }
+    }
+
+    /// Handle a task message from a spawned handler for a specific peer.
+    async fn handle_task_message(
+        &mut self,
+        peer_id: PeerId,
+        msg: TaskMessage,
+    ) -> Result<(), ShmConnectionError> {
+        let wire_msg = match msg {
+            TaskMessage::Data {
+                channel_id,
+                payload,
+            } => Message::Data {
+                channel_id,
+                payload,
+            },
+            TaskMessage::Close { channel_id } => Message::Close { channel_id },
+            TaskMessage::Response {
+                request_id,
+                payload,
+            } => {
+                // Only send if this request is still in-flight
+                if let Some(state) = self.peers.get_mut(&peer_id) {
+                    if !state.in_flight_server_requests.remove(&request_id) {
+                        return Ok(());
+                    }
+                }
+                Message::Response {
+                    request_id,
+                    metadata: Vec::new(),
+                    payload,
+                }
+            }
+        };
+
+        self.send_to_peer(peer_id, &wire_msg).await
+    }
+
+    /// Handle a command from a ConnectionHandle for a specific peer.
+    async fn handle_command(
+        &mut self,
+        peer_id: PeerId,
+        cmd: HandleCommand,
+    ) -> Result<(), ShmConnectionError> {
+        match cmd {
+            HandleCommand::Call {
+                request_id,
+                method_id,
+                metadata,
+                payload,
+                response_tx,
+            } => {
+                // Store the response channel
+                if let Some(state) = self.peers.get_mut(&peer_id) {
+                    state.pending_responses.insert(request_id, response_tx);
+                }
+
+                // Send the request
+                let req = Message::Request {
+                    request_id,
+                    method_id,
+                    metadata,
+                    payload,
+                };
+                self.send_to_peer(peer_id, &req).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Handle an incoming message from a specific peer.
+    async fn handle_message(
+        &mut self,
+        peer_id: PeerId,
+        msg: Message,
+    ) -> Result<(), ShmConnectionError> {
+        match msg {
+            Message::Hello(_) => {
+                return Err(self.goodbye(peer_id, "shm.handshake").await);
+            }
+            Message::Goodbye { .. } => {
+                // Fail all pending responses for this peer
+                if let Some(state) = self.peers.get_mut(&peer_id) {
+                    for (_, tx) in state.pending_responses.drain() {
+                        let _ = tx.send(Err(CallError::ConnectionClosed));
+                    }
+                }
+                // Remove the peer
+                self.peers.remove(&peer_id);
+                return Ok(());
+            }
+            Message::Request {
+                request_id,
+                method_id,
+                metadata,
+                payload,
+            } => {
+                self.handle_incoming_request(peer_id, request_id, method_id, metadata, payload)
+                    .await?;
+            }
+            Message::Response {
+                request_id,
+                metadata: _,
+                payload,
+            } => {
+                // Route to waiting caller
+                if let Some(state) = self.peers.get_mut(&peer_id) {
+                    if let Some(tx) = state.pending_responses.remove(&request_id) {
+                        let _ = tx.send(Ok(payload));
+                    }
+                }
+            }
+            Message::Cancel { request_id: _ } => {
+                // TODO: Implement cancellation
+            }
+            Message::Data {
+                channel_id,
+                payload,
+            } => {
+                self.handle_data(peer_id, channel_id, payload).await?;
+            }
+            Message::Close { channel_id } => {
+                self.handle_close(peer_id, channel_id).await?;
+            }
+            Message::Reset { channel_id } => {
+                self.handle_reset(peer_id, channel_id)?;
+            }
+            Message::Credit { .. } => {
+                return Err(self.goodbye(peer_id, "shm.flow.no-credit-message").await);
+            }
+        }
+        Ok(())
+    }
+
+    /// Handle an incoming request from a peer.
+    async fn handle_incoming_request(
+        &mut self,
+        peer_id: PeerId,
+        request_id: u64,
+        method_id: u64,
+        metadata: Vec<(String, roam_wire::MetadataValue)>,
+        payload: Vec<u8>,
+    ) -> Result<(), ShmConnectionError> {
+        let state = match self.peers.get_mut(&peer_id) {
+            Some(s) => s,
+            None => return Ok(()), // Peer gone
+        };
+
+        // Duplicate detection
+        if !state.in_flight_server_requests.insert(request_id) {
+            return Err(self
+                .goodbye(peer_id, "call.request-id.duplicate-detection")
+                .await);
+        }
+
+        // Validate metadata
+        if let Err(rule_id) = roam_wire::validate_metadata(&metadata) {
+            state.in_flight_server_requests.remove(&request_id);
+            return Err(self.goodbye(peer_id, rule_id).await);
+        }
+
+        // Validate payload size
+        if payload.len() as u32 > self.negotiated.max_payload_size {
+            state.in_flight_server_requests.remove(&request_id);
+            return Err(self.goodbye(peer_id, "flow.call.payload-limit").await);
+        }
+
+        // Dispatch - spawn as a task so message loop can continue.
+        let handler_fut = state.dispatcher.dispatch(
+            method_id,
+            payload,
+            request_id,
+            &mut state.server_channel_registry,
+        );
+        tokio::spawn(handler_fut);
+        Ok(())
+    }
+
+    /// Handle incoming Data message.
+    async fn handle_data(
+        &mut self,
+        peer_id: PeerId,
+        channel_id: u64,
+        payload: Vec<u8>,
+    ) -> Result<(), ShmConnectionError> {
+        if channel_id == 0 {
+            return Err(self.goodbye(peer_id, "streaming.id.zero-reserved").await);
+        }
+
+        if payload.len() as u32 > self.negotiated.max_payload_size {
+            return Err(self.goodbye(peer_id, "flow.call.payload-limit").await);
+        }
+
+        let state = match self.peers.get_mut(&peer_id) {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        // Try server registry first, then client registry
+        let result = if state.server_channel_registry.contains_incoming(channel_id) {
+            state
+                .server_channel_registry
+                .route_data(channel_id, payload)
+                .await
+        } else if state.handle.contains_channel(channel_id) {
+            state.handle.route_data(channel_id, payload).await
+        } else {
+            Err(ChannelError::Unknown)
+        };
+
+        match result {
+            Ok(()) => Ok(()),
+            Err(ChannelError::Unknown) => Err(self.goodbye(peer_id, "streaming.unknown").await),
+            Err(ChannelError::DataAfterClose) => {
+                Err(self.goodbye(peer_id, "streaming.data-after-close").await)
+            }
+            Err(ChannelError::CreditOverrun) => {
+                Err(self.goodbye(peer_id, "flow.stream.credit-overrun").await)
+            }
+        }
+    }
+
+    /// Handle incoming Close message.
+    async fn handle_close(
+        &mut self,
+        peer_id: PeerId,
+        channel_id: u64,
+    ) -> Result<(), ShmConnectionError> {
+        if channel_id == 0 {
+            return Err(self.goodbye(peer_id, "streaming.id.zero-reserved").await);
+        }
+
+        let state = match self.peers.get_mut(&peer_id) {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        if state.server_channel_registry.contains(channel_id) {
+            state.server_channel_registry.close(channel_id);
+        } else if state.handle.contains_channel(channel_id) {
+            state.handle.close_channel(channel_id);
+        } else {
+            return Err(self.goodbye(peer_id, "streaming.unknown").await);
+        }
+        Ok(())
+    }
+
+    /// Handle incoming Reset message.
+    fn handle_reset(&mut self, peer_id: PeerId, channel_id: u64) -> Result<(), ShmConnectionError> {
+        let state = match self.peers.get_mut(&peer_id) {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        if state.server_channel_registry.contains(channel_id) {
+            state.server_channel_registry.reset(channel_id);
+        } else if state.handle.contains_channel(channel_id) {
+            state.handle.reset_channel(channel_id);
+        }
+        Ok(())
+    }
+
+    /// Send a message to a specific peer.
+    async fn send_to_peer(
+        &mut self,
+        peer_id: PeerId,
+        msg: &Message,
+    ) -> Result<(), ShmConnectionError> {
+        let frame = message_to_frame(msg).map_err(|e| {
+            ShmConnectionError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        })?;
+
+        self.host.send(peer_id, frame).map_err(|e| {
+            ShmConnectionError::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("send error: {:?}", e),
+            ))
+        })
+    }
+
+    /// Send Goodbye to a peer and return error.
+    async fn goodbye(&mut self, peer_id: PeerId, rule_id: &'static str) -> ShmConnectionError {
+        // Fail all pending responses for this peer
+        if let Some(state) = self.peers.get_mut(&peer_id) {
+            for (_, tx) in state.pending_responses.drain() {
+                let _ = tx.send(Err(CallError::ConnectionClosed));
+            }
+        }
+
+        let _ = self
+            .send_to_peer(
+                peer_id,
+                &Message::Goodbye {
+                    reason: rule_id.into(),
+                },
+            )
+            .await;
+
+        ShmConnectionError::ProtocolViolation {
+            rule_id,
+            context: format!(
+                "SHM protocol violation from peer {:?}: {}",
+                peer_id, rule_id
+            ),
+        }
+    }
+}
+
+/// Establish a multi-peer host driver.
+///
+/// This is a convenience function that creates a `MultiPeerHostDriver` for
+/// scenarios where all peers use the same dispatcher type.
+///
+/// # Arguments
+///
+/// * `host` - The SHM host (takes ownership)
+/// * `peers` - Iterator of (PeerId, Dispatcher) pairs
+///
+/// # Returns
+///
+/// A tuple of (driver, handles) where handles is a map from PeerId to ConnectionHandle.
+///
+/// # Example
+///
+/// ```ignore
+/// let host = ShmHost::create("/dev/shm/myapp", config)?;
+/// let ticket1 = host.add_peer(options)?;
+/// let ticket2 = host.add_peer(options)?;
+///
+/// let (driver, handles) = establish_multi_peer_host(
+///     host,
+///     vec![
+///         (ticket1.peer_id(), dispatcher1),
+///         (ticket2.peer_id(), dispatcher2),
+///     ],
+/// );
+///
+/// tokio::spawn(driver.run());
+///
+/// // Make calls to specific peers
+/// let handle1 = handles.get(&ticket1.peer_id()).unwrap();
+/// ```
+pub fn establish_multi_peer_host<D, I>(
+    host: ShmHost,
+    peers: I,
+) -> (MultiPeerHostDriver<D>, HashMap<PeerId, ConnectionHandle>)
+where
+    D: ServiceDispatcher,
+    I: IntoIterator<Item = (PeerId, D)>,
+{
+    let mut builder = MultiPeerHostDriver::new(host);
+    for (peer_id, dispatcher) in peers {
+        builder = builder.add_peer(peer_id, dispatcher);
+    }
+    builder.build()
 }


### PR DESCRIPTION
## Summary

Implements the multi-peer host driver needed for dodeca's cell architecture, where ~15 cell processes communicate with a host via shared memory.

## New APIs

- **`MultiPeerHostDriver<D>`** - owns the `ShmHost`, routes messages to/from multiple peers
- **`MultiPeerHostDriverBuilder<D>`** - fluent builder with `.add_peer(peer_id, dispatcher)`  
- **`establish_multi_peer_host()`** - convenience function for common cases

Each peer gets its own `ConnectionHandle` for making RPC calls. The host can call any peer, and any peer can call the host (bidirectional RPC).

## Usage

```rust
let host = ShmHost::create("/dev/shm/myapp", config)?;
let ticket1 = host.add_peer(options)?;
let ticket2 = host.add_peer(options)?;

// Spawn guest processes with tickets...

let (driver, handles) = establish_multi_peer_host(host, vec![
    (ticket1.peer_id(), dispatcher1),
    (ticket2.peer_id(), dispatcher2),
]);
tokio::spawn(driver.run());

// Call specific peers
let client = MyService::new(handles[&ticket1.peer_id()].clone());
client.do_thing().await?;
```

## Testing

- `multi_peer_host_two_guests` - verifies bidirectional RPC with two guests
- `multi_peer_concurrent_calls` - verifies concurrent calls from multiple guests

Closes #16
