### PR TITLE
fix(roam-shm): implement std::error::Error for ShmConnectionError

### DIFF
--- a/rust/roam-shm/src/driver.rs
+++ b/rust/roam-shm/src/driver.rs
@@ -60,6 +60,27 @@ pub enum ShmConnectionError {
     Closed,
 }
 
+impl std::fmt::Display for ShmConnectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShmConnectionError::Io(e) => write!(f, "IO error: {}", e),
+            ShmConnectionError::ProtocolViolation { rule_id, context } => {
+                write!(f, "protocol violation [{}]: {}", rule_id, context)
+            }
+            ShmConnectionError::Closed => write!(f, "connection closed"),
+        }
+    }
+}
+
+impl std::error::Error for ShmConnectionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ShmConnectionError::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<std::io::Error> for ShmConnectionError {
     fn from(e: std::io::Error) -> Self {
         ShmConnectionError::Io(e)


### PR DESCRIPTION
## Summary

Implements `std::fmt::Display` and `std::error::Error` for `ShmConnectionError`, enabling the use of the `?` operator in async main functions that return `Result<(), Box<dyn std::error::Error>>`.

## Changes

- Added `Display` impl with human-readable error messages
- Added `Error` impl with proper `source()` chaining for the `Io` variant

## Example

This now works:

```rust
#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let (handle, driver) = establish_guest(transport, dispatcher);
    driver.run().await?;  // Previously failed to compile
    Ok(())
}
```

Closes #22