### PR TITLE
fix: make RoutedDispatcher own its method IDs

### DIFF
--- a/rust/roam-macros/src/lib.rs
+++ b/rust/roam-macros/src/lib.rs
@@ -259,11 +259,27 @@ fn generate_dispatcher(parsed: &ServiceTrait, roam: &TokenStream2) -> TokenStrea
         })
         .collect();
 
+    // Generate method ID calls for method_ids()
+    let method_id_calls: Vec<TokenStream2> = parsed
+        .methods()
+        .map(|m| {
+            let method_name = format_ident!("{}", m.name().to_snake_case());
+            quote! { #method_id_mod::#method_name() }
+        })
+        .collect();
+
     quote! {
         /// Dispatcher for this service.
         #[derive(Clone)]
         pub struct #dispatcher_name<H> {
             handler: H,
+        }
+
+        impl<H> #dispatcher_name<H> {
+            /// Returns all method IDs handled by this dispatcher.
+            pub fn method_ids() -> Vec<u64> {
+                vec![#(#method_id_calls),*]
+            }
         }
 
         impl<H> #dispatcher_name<H>

--- a/rust/roam-session/src/lib.rs
+++ b/rust/roam-session/src/lib.rs
@@ -1250,14 +1250,14 @@ pub trait ServiceDispatcher: Send + Sync {
 pub struct RoutedDispatcher<A, B> {
     first: A,
     second: B,
-    first_methods: &'static [u64],
+    first_methods: Vec<u64>,
 }
 
 impl<A, B> RoutedDispatcher<A, B> {
     /// Create a new routed dispatcher.
     ///
     /// Methods in `first_methods` are routed to `first`, all others to `second`.
-    pub fn new(first: A, second: B, first_methods: &'static [u64]) -> Self {
+    pub fn new(first: A, second: B, first_methods: Vec<u64>) -> Self {
         Self {
             first,
             second,

--- a/rust/roam-shm/src/driver.rs
+++ b/rust/roam-shm/src/driver.rs
@@ -642,7 +642,7 @@ struct PeerConnectionState {
 ///     .add_peer(ticket2.peer_id(), RoutedDispatcher::new(
 ///         CellLifecycleDispatcher::new(lifecycle.clone()),
 ///         TemplateHostDispatcher::new(template_host),
-///         &CELL_LIFECYCLE_METHODS,
+///         CellLifecycleDispatcher::<HostCellLifecycle>::method_ids(),
 ///     ))
 ///     .build();
 ///


### PR DESCRIPTION
## Summary

Makes `RoutedDispatcher` usable for combining dispatchers by having it own its method IDs instead of requiring a static slice.

Fixes #29

## Changes

- Changed `RoutedDispatcher.first_methods` from `&'static [u64]` to `Vec<u64>`
- Added `method_ids()` function to generated dispatchers via `#[roam::service]` macro
- Updated docstring example to use the new API

## Usage after fix

```rust
let dispatcher = RoutedDispatcher::new(
    CellLifecycleDispatcher::new(lifecycle),
    TemplateHostDispatcher::new(template_host),
    CellLifecycleDispatcher::<HostCellLifecycle>::method_ids(),
);
```

## Testing

All existing tests pass. The change is backwards-compatible at the API level (callers just need to pass a `Vec` instead of a static slice).