### PR TITLE
feat(session): improve RoutedDispatcher API with automatic method routing

### DIFF
--- a/rust/roam-macros/src/lib.rs
+++ b/rust/roam-macros/src/lib.rs
@@ -297,6 +297,10 @@ fn generate_dispatcher(parsed: &ServiceTrait, roam: &TokenStream2) -> TokenStrea
         where
             H: #trait_name + Clone + 'static,
         {
+            fn method_ids(&self) -> Vec<u64> {
+                Self::method_ids()
+            }
+
             fn dispatch(
                 &self,
                 method_id: u64,

--- a/rust/roam-shm/src/driver.rs
+++ b/rust/roam-shm/src/driver.rs
@@ -639,10 +639,10 @@ struct PeerConnectionState {
 ///     // Simple peer only needs lifecycle dispatcher
 ///     .add_peer(ticket1.peer_id(), CellLifecycleDispatcher::new(lifecycle.clone()))
 ///     // Complex peer needs routed dispatcher for bidirectional RPC
+///     // The primary dispatcher's method_ids() determines routing; fallback handles the rest
 ///     .add_peer(ticket2.peer_id(), RoutedDispatcher::new(
-///         CellLifecycleDispatcher::new(lifecycle.clone()),
-///         TemplateHostDispatcher::new(template_host),
-///         CellLifecycleDispatcher::<HostCellLifecycle>::method_ids(),
+///         CellLifecycleDispatcher::new(lifecycle.clone()),  // primary: handles lifecycle methods
+///         TemplateHostDispatcher::new(template_host),       // fallback: handles everything else
 ///     ))
 ///     .build();
 ///

--- a/rust/roam-shm/tests/driver.rs
+++ b/rust/roam-shm/tests/driver.rs
@@ -22,6 +22,10 @@ use roam_shm::transport::ShmGuestTransport;
 struct TestService;
 
 impl ServiceDispatcher for TestService {
+    fn method_ids(&self) -> Vec<u64> {
+        vec![1, 2, 3, 4]
+    }
+
     fn dispatch(
         &self,
         method_id: u64,

--- a/rust/roam-stream/src/driver.rs
+++ b/rust/roam-stream/src/driver.rs
@@ -1220,6 +1220,10 @@ where
 pub struct NoDispatcher;
 
 impl ServiceDispatcher for NoDispatcher {
+    fn method_ids(&self) -> Vec<u64> {
+        vec![]
+    }
+
     fn dispatch(
         &self,
         _method_id: u64,

--- a/rust/roam-stream/tests/reconnecting.rs
+++ b/rust/roam-stream/tests/reconnecting.rs
@@ -36,6 +36,10 @@ impl TestService {
 }
 
 impl ServiceDispatcher for TestService {
+    fn method_ids(&self) -> Vec<u64> {
+        vec![1]
+    }
+
     fn dispatch(
         &self,
         method_id: u64,


### PR DESCRIPTION
## Summary

This PR improves the `RoutedDispatcher` API by making it automatically derive method routing from the primary dispatcher. Instead of manually specifying which method IDs to route, the dispatcher now uses the `method_ids()` trait method to determine routing.

## Changes

- Add `method_ids(&self) -> Vec<u64>` method to `ServiceDispatcher` trait
- Rename `RoutedDispatcher` fields from `first`/`second` to `primary`/`fallback` for clarity
- Simplify `RoutedDispatcher::new()` to take just two dispatchers - routing is derived from `primary.method_ids()`
- Update all `ServiceDispatcher` implementations with the new `method_ids()` method
- Update documentation examples to reflect the cleaner API

## Test plan

- [x] All existing tests pass (roam-shm and roam-stream tests updated to implement `method_ids()`)
- [x] Pre-commit checks pass