### PR TITLE
feat: add ur-taking-me-with-you crate for parent death handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,6 +1848,7 @@ dependencies = [
  "shm-primitives",
  "tempfile",
  "tokio",
+ "ur-taking-me-with-you",
 ]
 
 [[package]]
@@ -2504,6 +2505,15 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ur-taking-me-with-you"
+version = "0.5.0"
+dependencies = [
+ "libc",
+ "tokio",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "rust/roam-http-bridge",
     "rust/subject-rust",
     "rust/shm-primitives",
+    "rust/ur-taking-me-with-you",
     # Compliance suite
     "spec/spec-proto",
     "spec/spec-tests",

--- a/rust/roam-shm/Cargo.toml
+++ b/rust/roam-shm/Cargo.toml
@@ -19,6 +19,7 @@ tokio = ["dep:tokio", "dep:roam-session", "dep:roam-stream"]
 [dependencies]
 shm-primitives = { path = "../shm-primitives", default-features = false }
 roam-frame = { path = "../roam-frame" }
+ur-taking-me-with-you = { path = "../ur-taking-me-with-you" }
 roam-wire = { path = "../roam-wire" }
 roam-session = { path = "../roam-session", optional = true }
 roam-stream = { path = "../roam-stream", optional = true }

--- a/rust/roam-shm/src/lib.rs
+++ b/rust/roam-shm/src/lib.rs
@@ -119,9 +119,13 @@ pub use transport::{
 };
 
 #[cfg(all(feature = "std", unix))]
-pub use spawn::{AddPeerOptions, DeathCallback, SpawnArgs, SpawnArgsError, SpawnTicket};
+pub use spawn::{
+    AddPeerOptions, DeathCallback, SpawnArgs, SpawnArgsError, SpawnTicket, die_with_parent,
+};
 #[cfg(all(feature = "std", windows))]
-pub use spawn_windows::{AddPeerOptions, DeathCallback, SpawnArgs, SpawnArgsError, SpawnTicket};
+pub use spawn_windows::{
+    AddPeerOptions, DeathCallback, SpawnArgs, SpawnArgsError, SpawnTicket, die_with_parent,
+};
 
 #[cfg(feature = "std")]
 pub use wait::{

--- a/rust/roam-shm/src/spawn.rs
+++ b/rust/roam-shm/src/spawn.rs
@@ -6,13 +6,23 @@
 //! 3. Pass spawn arguments to the child process
 //! 4. Register death callbacks for crash notification
 //!
+//! # Ensuring child processes die with parent
+//!
+//! Use [`SpawnTicket::spawn`] to spawn a child that will automatically be
+//! terminated when the parent dies (even via SIGKILL). The child should call
+//! [`die_with_parent`] early in its main function.
+//!
 //! shm[impl shm.spawn.ticket]
 
+use std::io;
 use std::os::unix::io::RawFd;
 use std::path::PathBuf;
+use std::process::{Child, Command};
 use std::sync::Arc;
 
 use crate::peer::PeerId;
+
+pub use ur_taking_me_with_you::die_with_parent;
 
 /// Callback invoked when a peer dies.
 ///
@@ -84,6 +94,30 @@ impl SpawnTicket {
             format!("--peer-id={}", self.peer_id.get()),
             format!("--doorbell-fd={}", self.doorbell_fd),
         ]
+    }
+
+    /// Spawn a child process using this ticket.
+    ///
+    /// This is a convenience method that:
+    /// 1. Adds the spawn arguments to the command
+    /// 2. Spawns the child with die-with-parent behavior
+    ///
+    /// The spawned child will automatically be terminated when the parent dies,
+    /// even if the parent is killed with SIGKILL. The child should call
+    /// [`die_with_parent`] early in its main function.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let ticket = host.add_peer(AddPeerOptions::default())?;
+    /// let mut cmd = Command::new("my-cell");
+    /// let child = ticket.spawn(cmd)?;
+    /// ```
+    ///
+    /// shm[impl shm.spawn.ticket]
+    pub fn spawn(&self, mut command: Command) -> io::Result<Child> {
+        command.args(self.to_args());
+        ur_taking_me_with_you::spawn_dying_with_parent(command)
     }
 }
 

--- a/rust/ur-taking-me-with-you/Cargo.toml
+++ b/rust/ur-taking-me-with-you/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ur-taking-me-with-you"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Ensure child processes die when their parent dies"
+keywords = ["process", "child", "parent", "death", "cleanup"]
+categories = ["os", "development-tools"]
+
+[package.metadata]
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[features]
+tokio = ["dep:tokio"]
+
+[dependencies]
+tokio = { workspace = true, features = ["process"], optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/rust/ur-taking-me-with-you/arborium-header.html
+++ b/rust/ur-taking-me-with-you/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@1/dist/arborium.iife.js"></script>

--- a/rust/ur-taking-me-with-you/src/lib.rs
+++ b/rust/ur-taking-me-with-you/src/lib.rs
@@ -1,0 +1,150 @@
+//! Ensure child processes die when their parent dies.
+//!
+//! Child processes normally continue running even after their parent exits (on Unix they get
+//! reparented to init/PID 1). This crate provides mechanisms to ensure child processes are
+//! terminated when their parent dies, even if the parent is killed with SIGKILL.
+//!
+//! ## Platform Support
+//!
+//! - **Linux**: Uses `prctl(PR_SET_PDEATHSIG, SIGKILL)` - the child receives SIGKILL when its
+//!   parent thread dies
+//! - **macOS**: Uses a pipe-based approach - the child monitors a pipe from the parent and exits
+//!   when the pipe closes (indicating parent death)
+//! - **Windows**: Uses job objects with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` - all processes in
+//!   the job are terminated when the last handle closes
+//!
+//! ## Usage
+//!
+//! ### For the child process (call early in main):
+//!
+//! ```rust
+//! ur_taking_me_with_you::die_with_parent();
+//! ```
+//!
+//! ### For spawning children with std::process::Command:
+//!
+//! ```rust,no_run
+//! use std::process::Command;
+//!
+//! let mut cmd = Command::new("my-plugin");
+//! cmd.arg("--foo");
+//!
+//! let child = ur_taking_me_with_you::spawn_dying_with_parent(cmd)
+//!     .expect("failed to spawn");
+//! ```
+
+// This crate requires unsafe for platform-specific FFI (libc calls for pipe/process management)
+#![allow(unsafe_code)]
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+mod unsupported;
+
+use std::io;
+use std::process::{Child, Command};
+
+/// Configure the current process to die when its parent dies.
+///
+/// This should be called early in the child process's main function.
+///
+/// # Platform Behavior
+///
+/// - **Linux**: Calls `prctl(PR_SET_PDEATHSIG, SIGKILL)`. The process will receive
+///   SIGKILL when its parent thread terminates.
+/// - **macOS**: Checks for a death-watch pipe passed via environment variable and
+///   starts a watchdog thread if present. Use `spawn_dying_with_parent` to set this up.
+/// - **Windows**: Creates a job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and
+///   assigns the current process to it.
+/// - **Other platforms**: No-op with a warning.
+///
+/// # Example
+///
+/// ```no_run
+/// ur_taking_me_with_you::die_with_parent();
+/// // ... rest of plugin code
+/// ```
+pub fn die_with_parent() {
+    #[cfg(target_os = "linux")]
+    linux::die_with_parent();
+
+    #[cfg(target_os = "macos")]
+    macos::die_with_parent();
+
+    #[cfg(target_os = "windows")]
+    windows::die_with_parent();
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    unsupported::die_with_parent();
+}
+
+/// Spawn a child process that will die when this (parent) process dies.
+///
+/// This wraps `Command::spawn()` with platform-specific setup to ensure the child
+/// is terminated when the parent exits, even if the parent is killed with SIGKILL.
+///
+/// # Platform Behavior
+///
+/// - **Linux**: Uses `pre_exec` to call `prctl(PR_SET_PDEATHSIG, SIGKILL)` in the
+///   child before exec.
+/// - **macOS**: Creates a pipe and passes the read end to the child via environment.
+///   The child must call `die_with_parent()` to start the watchdog thread.
+/// - **Windows**: Creates a job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and
+///   assigns the child process to it. Note: small race window between spawn and assignment.
+///
+/// # Example
+///
+/// ```no_run
+/// use std::process::Command;
+///
+/// let mut cmd = Command::new("my-plugin");
+/// cmd.arg("--config").arg("/path/to/config");
+///
+/// let child = ur_taking_me_with_you::spawn_dying_with_parent(cmd)
+///     .expect("failed to spawn plugin");
+/// ```
+pub fn spawn_dying_with_parent(command: Command) -> io::Result<Child> {
+    #[cfg(target_os = "linux")]
+    return linux::spawn_dying_with_parent(command);
+
+    #[cfg(target_os = "macos")]
+    return macos::spawn_dying_with_parent(command);
+
+    #[cfg(target_os = "windows")]
+    return windows::spawn_dying_with_parent(command);
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    return unsupported::spawn_dying_with_parent(command);
+}
+
+/// Environment variable name used on macOS to pass the death-watch pipe FD.
+#[cfg(target_os = "macos")]
+pub const DEATH_PIPE_ENV: &str = "UR_TAKING_ME_WITH_YOU_FD";
+
+/// Spawn a child process (async) that will die when this (parent) process dies.
+///
+/// Same as `spawn_dying_with_parent` but takes a `tokio::process::Command` and
+/// returns a `tokio::process::Child` with async `wait()`.
+#[cfg(feature = "tokio")]
+pub fn spawn_dying_with_parent_async(
+    command: tokio::process::Command,
+) -> io::Result<tokio::process::Child> {
+    #[cfg(target_os = "linux")]
+    return linux::spawn_dying_with_parent_async(command);
+
+    #[cfg(target_os = "macos")]
+    return macos::spawn_dying_with_parent_async(command);
+
+    #[cfg(target_os = "windows")]
+    return windows::spawn_dying_with_parent_async(command);
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    return unsupported::spawn_dying_with_parent_async(command);
+}

--- a/rust/ur-taking-me-with-you/src/linux.rs
+++ b/rust/ur-taking-me-with-you/src/linux.rs
@@ -1,0 +1,40 @@
+//! Linux implementation using prctl(PR_SET_PDEATHSIG)
+
+use std::io;
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command};
+
+/// The pre_exec hook that sets up parent death signal.
+/// SAFETY: prctl(PR_SET_PDEATHSIG) is async-signal-safe.
+fn set_pdeathsig() -> io::Result<()> {
+    let result = unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Configure the current process to receive SIGKILL when parent dies.
+pub fn die_with_parent() {
+    if let Err(e) = set_pdeathsig() {
+        eprintln!(
+            "ur-taking-me-with-you: prctl(PR_SET_PDEATHSIG) failed: {}",
+            e
+        );
+    }
+}
+
+/// Spawn a child that will die when this process dies.
+pub fn spawn_dying_with_parent(mut command: Command) -> io::Result<Child> {
+    unsafe { command.pre_exec(set_pdeathsig) };
+    command.spawn()
+}
+
+/// Spawn a child (async) that will die when this process dies.
+#[cfg(feature = "tokio")]
+pub fn spawn_dying_with_parent_async(
+    mut command: tokio::process::Command,
+) -> io::Result<tokio::process::Child> {
+    unsafe { command.pre_exec(set_pdeathsig) };
+    command.spawn()
+}

--- a/rust/ur-taking-me-with-you/src/macos.rs
+++ b/rust/ur-taking-me-with-you/src/macos.rs
@@ -1,0 +1,117 @@
+//! macOS implementation using pipe-based parent death detection.
+//!
+//! Since macOS doesn't have PR_SET_PDEATHSIG, we use a pipe:
+//! 1. Parent creates a pipe before spawning the child
+//! 2. Parent keeps the write end open (it's automatically closed on parent death)
+//! 3. Child inherits the read end and spawns a watchdog thread
+//! 4. Watchdog blocks on read() - when parent dies, pipe closes, read returns 0
+//! 5. Watchdog calls exit() to terminate the child
+
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+
+use std::process::{Child, Command};
+
+use crate::DEATH_PIPE_ENV;
+
+/// Check for death pipe and start watchdog if present.
+///
+/// This should be called early in the child process. If the parent used
+/// `spawn_dying_with_parent`, this will start a background thread that
+/// monitors the pipe and exits when the parent dies.
+pub fn die_with_parent() {
+    if let Ok(fd_str) = std::env::var(DEATH_PIPE_ENV)
+        && let Ok(fd) = fd_str.parse::<RawFd>()
+    {
+        // Take ownership of the FD
+        let owned_fd = unsafe { OwnedFd::from_raw_fd(fd) };
+        start_watchdog(owned_fd);
+    }
+}
+
+/// Start the watchdog thread that monitors the death pipe.
+fn start_watchdog(fd: OwnedFd) {
+    std::thread::spawn(move || {
+        let raw_fd = fd.as_raw_fd();
+        let mut buf = [0u8; 1];
+
+        // Block on read - this will return 0 (EOF) when parent closes the pipe
+        // (either explicitly or by dying)
+        loop {
+            let result = unsafe { libc::read(raw_fd, buf.as_mut_ptr() as *mut _, 1) };
+
+            if result <= 0 {
+                // EOF or error - parent is gone, time to die
+                std::process::exit(0);
+            }
+            // If we somehow got data, just keep reading
+        }
+    });
+}
+
+/// Death pipe file descriptors.
+struct DeathPipe {
+    read_fd: RawFd,
+    write_fd: RawFd,
+}
+
+/// Create a death pipe and configure FD flags.
+fn create_death_pipe() -> io::Result<DeathPipe> {
+    let mut fds = [0 as libc::c_int; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let read_fd = fds[0];
+    let write_fd = fds[1];
+
+    // Clear FD_CLOEXEC on the read end so child inherits it
+    unsafe {
+        let flags = libc::fcntl(read_fd, libc::F_GETFD);
+        if flags != -1 {
+            libc::fcntl(read_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC);
+        }
+    }
+
+    // Set FD_CLOEXEC on write end so it stays in parent only
+    unsafe {
+        let flags = libc::fcntl(write_fd, libc::F_GETFD);
+        if flags != -1 {
+            libc::fcntl(write_fd, libc::F_SETFD, flags | libc::FD_CLOEXEC);
+        }
+    }
+
+    Ok(DeathPipe { read_fd, write_fd })
+}
+
+/// Finalize the death pipe after spawning the child.
+fn finalize_death_pipe(pipe: DeathPipe) {
+    // Close read end in parent - child has its own copy
+    unsafe { libc::close(pipe.read_fd) };
+
+    // Keep write_fd open in parent - it will close when parent exits
+    // Leak it intentionally so it stays open for the lifetime of the parent
+    std::mem::forget(unsafe { OwnedFd::from_raw_fd(pipe.write_fd) });
+}
+
+/// Spawn a child that will die when this process dies.
+pub fn spawn_dying_with_parent(mut command: Command) -> io::Result<Child> {
+    let pipe = create_death_pipe()?;
+    command.env(DEATH_PIPE_ENV, pipe.read_fd.to_string());
+    let child = command.spawn()?;
+    finalize_death_pipe(pipe);
+    Ok(child)
+}
+
+/// Spawn a child (async) that will die when this process dies.
+#[cfg(feature = "tokio")]
+pub fn spawn_dying_with_parent_async(
+    mut command: tokio::process::Command,
+) -> io::Result<tokio::process::Child> {
+    let pipe = create_death_pipe()?;
+    command.env(DEATH_PIPE_ENV, pipe.read_fd.to_string());
+    let child = command.spawn()?;
+    finalize_death_pipe(pipe);
+    Ok(child)
+}

--- a/rust/ur-taking-me-with-you/src/unsupported.rs
+++ b/rust/ur-taking-me-with-you/src/unsupported.rs
@@ -1,0 +1,27 @@
+//! Fallback for unsupported platforms
+
+use std::io;
+use std::process::{Child, Command};
+
+pub fn die_with_parent() {
+    eprintln!("ur-taking-me-with-you: die_with_parent() not supported on this platform");
+}
+
+pub fn spawn_dying_with_parent(mut command: Command) -> io::Result<Child> {
+    eprintln!(
+        "ur-taking-me-with-you: spawn_dying_with_parent() not supported on this platform, \
+         child may outlive parent"
+    );
+    command.spawn()
+}
+
+#[cfg(feature = "tokio")]
+pub fn spawn_dying_with_parent_async(
+    mut command: tokio::process::Command,
+) -> io::Result<tokio::process::Child> {
+    eprintln!(
+        "ur-taking-me-with-you: spawn_dying_with_parent_async() not supported on this platform, \
+         child may outlive parent"
+    );
+    command.spawn()
+}

--- a/rust/ur-taking-me-with-you/src/windows.rs
+++ b/rust/ur-taking-me-with-you/src/windows.rs
@@ -1,0 +1,100 @@
+use std::io;
+use std::process::{Child, Command};
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+    SetInformationJobObject,
+};
+
+/// Create a job object configured to kill processes when closed.
+fn create_job_object() -> io::Result<HANDLE> {
+    unsafe {
+        let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+        if job == std::ptr::null_mut() {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        let result = SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &info as *const _ as *const _,
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        );
+
+        if result == 0 {
+            let err = io::Error::last_os_error();
+            CloseHandle(job);
+            return Err(err);
+        }
+
+        Ok(job)
+    }
+}
+
+/// Assign a process to a job and leak the job handle.
+fn assign_and_leak_job(job: HANDLE, process_handle: HANDLE) -> io::Result<()> {
+    unsafe {
+        let result = AssignProcessToJobObject(job, process_handle);
+        if result == 0 {
+            let err = io::Error::last_os_error();
+            CloseHandle(job);
+            return Err(err);
+        }
+        // Intentionally leak the job handle: we never call CloseHandle(job),
+        // so the kernel job object stays alive until this process exits.
+        // (HANDLE is Copy/isize, so drop/forget are no-ops—the "leak" is
+        // simply not calling CloseHandle.)
+        let _leaked = job;
+        Ok(())
+    }
+}
+
+/// Configure the current process to die when its parent dies.
+pub fn die_with_parent() {
+    let job = match create_job_object() {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("ur-taking-me-with-you: Failed to create job object: {}", e);
+            return;
+        }
+    };
+
+    let current_process = unsafe { windows_sys::Win32::System::Threading::GetCurrentProcess() };
+    if let Err(e) = assign_and_leak_job(job, current_process) {
+        eprintln!(
+            "ur-taking-me-with-you: Failed to assign process to job: {}",
+            e
+        );
+    }
+}
+
+/// Spawn a child process that will die when this (parent) process dies.
+pub fn spawn_dying_with_parent(mut command: Command) -> io::Result<Child> {
+    let job = create_job_object()?;
+    let child = command.spawn()?;
+
+    use std::os::windows::io::AsRawHandle;
+    let child_handle = child.as_raw_handle() as HANDLE;
+    assign_and_leak_job(job, child_handle)?;
+
+    Ok(child)
+}
+
+/// Spawn a child process (async) that will die when this (parent) process dies.
+#[cfg(feature = "tokio")]
+pub fn spawn_dying_with_parent_async(
+    command: tokio::process::Command,
+) -> io::Result<tokio::process::Child> {
+    let job = create_job_object()?;
+    let child = command.spawn()?;
+
+    use std::os::windows::io::AsRawHandle;
+    let child_handle = child.as_raw_handle() as HANDLE;
+    assign_and_leak_job(job, child_handle)?;
+
+    Ok(child)
+}


### PR DESCRIPTION
## Summary

Add new crate `ur-taking-me-with-you` that ensures child processes die when their parent dies, even if the parent is killed with SIGKILL. This addresses a common problem where orphaned child processes continue running after their parent exits.

## Changes

- **New crate `ur-taking-me-with-you`**: Cross-platform implementation with:
  - Linux: Uses `prctl(PR_SET_PDEATHSIG, SIGKILL)` for kernel-level enforcement
  - macOS: Pipe-based watchdog thread that detects parent death
  - Windows: Job objects with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
  - Graceful fallback for unsupported platforms

- **roam-shm integration**: 
  - `SpawnTicket::spawn()` method now spawns children with automatic die-with-parent behavior
  - Re-exports `die_with_parent()` for child processes to call

- **Async support**: Optional tokio feature for async process spawning

## Test plan

- [ ] Verify Linux implementation with `prctl` behavior
- [ ] Test macOS pipe-based approach
- [ ] Test Windows job object implementation
- [ ] Integration test with roam-shm spawn workflow

Closes #34