### PR TITLE
fix: run stress_concurrent_send_recv test normally, skip only under Miri

### DIFF
--- a/rust/roam-shm/tests/stress.rs
+++ b/rust/roam-shm/tests/stress.rs
@@ -267,8 +267,12 @@ fn stress_guest_attach_detach_cycle() {
 }
 
 #[test]
-#[ignore] // This test uses threads and may not work under Miri
 fn stress_concurrent_send_recv() {
+    // Skip under Miri - this test uses threads which Miri doesn't handle well
+    if cfg!(miri) {
+        return;
+    }
+
     let config = SegmentConfig {
         ring_size: 256,
         ..SegmentConfig::default()


### PR DESCRIPTION
## Summary
- Replace `#[ignore]` attribute with `cfg!(miri)` runtime check
- Test now runs in normal CI and local `cargo nextest run`
- Test still skips when running under Miri

Fixes #26