### PR TITLE
fix: handle recursive types in shape encoding (issue #50)

### DIFF
--- a/docs/content/rust-spec/_index.md
+++ b/docs/content/rust-spec/_index.md
@@ -139,6 +139,22 @@ This allows renaming types without breaking compatibility.
 
 Variants MUST be encoded in declaration order.
 
+## Recursive Types
+
+> r[signature.recursive]
+>
+> When encoding types that reference themselves (directly or indirectly),
+> implementations MUST detect cycles and emit a back-reference tag (`0x32`)
+> instead of infinitely recursing. Cycles can occur through any chain of
+> type references: containers, struct fields, enum variants, or combinations
+> thereof.
+>
+> The back-reference tag is a single byte that indicates "this type was
+> already encoded earlier in this signature". This ensures:
+> - No stack overflow during encoding
+> - Deterministic output (same type always produces same bytes)
+> - Finite signature size for recursive types
+
 ## Method Signature Encoding
 
 > r[signature.method]


### PR DESCRIPTION
## Summary

Fixes stack overflow when encoding recursive type definitions in `encode_shape()`. This addresses issue #50 where types that reference themselves (directly or through chains of containers/fields) would cause infinite recursion.

## Changes

- **Add BACKREF tag (0x32)**: New signature tag for back-references to already-encoded types
- **Cycle detection**: Track visited shapes using `HashSet<*const Shape>` during encoding
- **Spec update**: Add `signature.recursive` rule documenting the recursive type handling behavior
- **Tests**: Add comprehensive tests for:
  - Basic recursive types (tree nodes with `Vec<Self>`)
  - Deterministic encoding (same type always produces same bytes)
  - Mutually recursive types (Parent/Child referencing each other)

## Technical Details

When encoding a shape, we now check if it's been visited before. If so, we emit the `BACKREF` tag instead of recursing into its fields. This ensures:
- No stack overflow during encoding
- Deterministic output for recursive types
- Finite signature size regardless of type recursion depth

Closes #50