### PR TITLE
Add roam-telemetry crate and pre/post middleware support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "roam-telemetry"
+version = "0.6.0"
+dependencies = [
+ "facet",
+ "facet-json",
+ "facet-pretty",
+ "rand",
+ "reqwest",
+ "roam-session",
+ "roam-wire",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "roam-tracing"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "rust/roam-schema",
     "rust/roam-shm",
     "rust/roam-tracing",
+    "rust/roam-telemetry",
     "rust/roam-codegen",
     "rust/roam-macros",
     "rust/roam-macros-parse",

--- a/rust/roam-session/src/middleware.rs
+++ b/rust/roam-session/src/middleware.rs
@@ -1,43 +1,47 @@
-//! Middleware for intercepting requests after deserialization but before the handler.
+//! Middleware for intercepting requests before and after the handler.
 //!
-//! Middleware can:
-//! - Inspect deserialized args via [`SendPeek`] (reflection-based, no type knowledge needed)
-//! - Reject requests (e.g., authentication failure)
-//! - Add values to `Context::extensions` for handlers to retrieve
-//! - Log, trace, or meter requests
+//! Middleware has two phases:
+//! - **pre**: Runs after deserialization, before the handler. Can reject requests.
+//! - **post**: Runs after the handler completes. Observes the outcome (success or error).
+//!
+//! This pattern enables proper observability (e.g., OpenTelemetry):
+//! - `pre()` starts a tracing span, stores it in `ctx.extensions`
+//! - `post()` retrieves the span, records the outcome, and ends it
 //!
 //! # Example
 //!
 //! ```ignore
-//! use roam_session::{Middleware, Context, Rejection, SendPeek};
+//! use roam_session::{Middleware, Context, Rejection, SendPeek, MethodOutcome};
 //! use std::pin::Pin;
 //! use std::future::Future;
 //!
-//! struct AuthMiddleware { /* ... */ }
+//! struct TracingMiddleware { /* ... */ }
 //!
-//! impl Middleware for AuthMiddleware {
-//!     fn intercept<'a>(
+//! impl Middleware for TracingMiddleware {
+//!     fn pre<'a>(
 //!         &'a self,
 //!         ctx: &'a mut Context,
-//!         args: SendPeek<'a>,
+//!         _args: SendPeek<'a>,
 //!     ) -> Pin<Box<dyn Future<Output = Result<(), Rejection>> + Send + 'a>> {
 //!         Box::pin(async move {
-//!             // Check for auth token in metadata
-//!             let token = ctx.metadata.iter()
-//!                 .find(|(k, _)| k == "auth-token")
-//!                 .map(|(_, v)| v.as_string());
-//!
-//!             let Some(token) = token else {
-//!                 return Err(Rejection::unauthenticated("missing auth-token"));
-//!             };
-//!
-//!             // Can also inspect args via reflection using args.peek()
-//!             // e.g., args.peek().get("user_id") to check authorization
-//!
-//!             // Store validated info in extensions for handler access
-//!             ctx.extensions.insert(AuthenticatedUser { token: token.to_string() });
-//!
+//!             // Start a span and store it in extensions
+//!             let span = Span::start(ctx.method_id());
+//!             ctx.extensions.insert(span);
 //!             Ok(())
+//!         })
+//!     }
+//!
+//!     fn post<'a>(
+//!         &'a self,
+//!         ctx: &'a Context,
+//!         outcome: MethodOutcome<'a>,
+//!     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+//!         Box::pin(async move {
+//!             // Get the span we stored in pre()
+//!             if let Some(span) = ctx.extensions.get::<Span>() {
+//!                 span.set_status(outcome.is_ok());
+//!                 span.end();
+//!             }
 //!         })
 //!     }
 //! }
@@ -50,6 +54,48 @@ use std::sync::Arc;
 use facet::Peek;
 
 use crate::Context;
+
+/// The outcome of a method call, used by post-middleware.
+///
+/// Represents the three possible outcomes:
+/// - `Ok`: Handler returned successfully
+/// - `Err`: Handler returned an error
+/// - `Rejected`: Pre-middleware rejected the request (handler never ran)
+#[derive(Clone, Copy)]
+pub enum MethodOutcome<'mem> {
+    /// Handler returned Ok(value)
+    Ok(SendPeek<'mem>),
+    /// Handler returned Err(error)
+    Err(SendPeek<'mem>),
+    /// Pre-middleware rejected the request (handler never ran)
+    Rejected,
+}
+
+impl MethodOutcome<'_> {
+    /// Returns true if this is an Ok outcome.
+    pub fn is_ok(&self) -> bool {
+        matches!(self, MethodOutcome::Ok(_))
+    }
+
+    /// Returns true if this is an Err outcome (not including Rejected).
+    pub fn is_err(&self) -> bool {
+        matches!(self, MethodOutcome::Err(_))
+    }
+
+    /// Returns true if the request was rejected by pre-middleware.
+    pub fn is_rejected(&self) -> bool {
+        matches!(self, MethodOutcome::Rejected)
+    }
+
+    /// Get the inner SendPeek if the handler ran (Ok or Err).
+    /// Returns None if the request was rejected before the handler ran.
+    pub fn peek(&self) -> Option<SendPeek<'_>> {
+        match self {
+            MethodOutcome::Ok(p) | MethodOutcome::Err(p) => Some(*p),
+            MethodOutcome::Rejected => None,
+        }
+    }
+}
 
 /// A Send-safe wrapper around [`Peek`].
 ///
@@ -166,21 +212,33 @@ impl Rejection {
     }
 }
 
-/// Middleware that can intercept requests after deserialization.
+/// Middleware that can intercept requests before and after the handler.
 ///
-/// Middleware sees:
-/// - Request context (metadata, extensions, conn_id, method_id)
-/// - Deserialized args via [`SendPeek`] (reflection-based inspection)
+/// ## Pre-middleware
 ///
-/// Middleware can:
+/// `pre()` runs after deserialization but before the handler. It can:
 /// - Reject the request by returning `Err(Rejection)`
-/// - Continue by returning `Ok(())`
-/// - Add values to `ctx.extensions` for handlers
+/// - Add values to `ctx.extensions` for the handler and post-middleware
+/// - Inspect args via reflection
 ///
-/// Middleware is async to support operations like database lookups for
-/// token validation.
+/// ## Post-middleware
+///
+/// `post()` runs after the handler completes (or is skipped due to rejection).
+/// It can:
+/// - Observe the method outcome (success or error)
+/// - Retrieve values from extensions (e.g., to end a tracing span)
+/// - Record metrics, logs, etc.
+///
+/// ## Execution order
+///
+/// For middleware stack [A, B, C]:
+/// - Pre runs first-to-last: A.pre() → B.pre() → C.pre() → handler
+/// - Post runs last-to-first: C.post() → B.post() → A.post()
+///
+/// This mirrors standard "wrap" semantics: the first middleware added is the
+/// outermost wrapper.
 pub trait Middleware: Send + Sync {
-    /// Intercept a request after deserialization but before the handler runs.
+    /// Run before the handler.
     ///
     /// # Arguments
     ///
@@ -188,12 +246,29 @@ pub trait Middleware: Send + Sync {
     /// - `args`: SendPeek view of deserialized args (inspect via reflection)
     ///
     /// Return `Ok(())` to continue to the handler.
-    /// Return `Err(rejection)` to reject the request.
-    fn intercept<'a>(
+    /// Return `Err(rejection)` to reject the request. Note: `post()` will still
+    /// be called even if `pre()` rejects, so you can clean up resources.
+    fn pre<'a>(
         &'a self,
         ctx: &'a mut Context,
         args: SendPeek<'a>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Rejection>> + Send + 'a>>;
+
+    /// Run after the handler (or after rejection).
+    ///
+    /// # Arguments
+    ///
+    /// - `ctx`: Request context (note: immutable, can only read extensions)
+    /// - `outcome`: The method outcome - either Ok(result) or Err(error)
+    ///
+    /// The default implementation does nothing.
+    fn post<'a>(
+        &'a self,
+        _ctx: &'a Context,
+        _outcome: MethodOutcome<'a>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
 }
 
 /// Middleware that does nothing (passes all requests through).
@@ -203,7 +278,7 @@ pub trait Middleware: Send + Sync {
 pub struct NoopMiddleware;
 
 impl Middleware for NoopMiddleware {
-    fn intercept<'a>(
+    fn pre<'a>(
         &'a self,
         _ctx: &'a mut Context,
         _args: SendPeek<'a>,
@@ -247,30 +322,46 @@ impl Default for MiddlewareStack {
 }
 
 impl Middleware for MiddlewareStack {
-    fn intercept<'a>(
+    fn pre<'a>(
         &'a self,
         ctx: &'a mut Context,
         args: SendPeek<'a>,
     ) -> Pin<Box<dyn Future<Output = Result<(), Rejection>> + Send + 'a>> {
         Box::pin(async move {
+            // Pre runs first-to-last
             for layer in &self.layers {
-                layer.intercept(ctx, args).await?;
+                layer.pre(ctx, args).await?;
             }
             Ok(())
+        })
+    }
+
+    fn post<'a>(
+        &'a self,
+        ctx: &'a Context,
+        outcome: MethodOutcome<'a>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            // Post runs last-to-first (reverse order)
+            for layer in self.layers.iter().rev() {
+                layer.post(ctx, outcome).await;
+            }
         })
     }
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)] // Tests need unsafe to create SendPeek
 mod tests {
     use super::*;
+    use facet::Facet;
 
     struct TestMiddleware {
         should_reject: bool,
     }
 
     impl Middleware for TestMiddleware {
-        fn intercept<'a>(
+        fn pre<'a>(
             &'a self,
             ctx: &'a mut Context,
             _args: SendPeek<'a>,
@@ -297,5 +388,176 @@ mod tests {
             });
 
         assert_eq!(stack.layers.len(), 2);
+    }
+
+    // Test that middleware can actually inspect arguments via reflection
+    #[test]
+    fn test_middleware_inspects_args() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        // A simple argument type
+        #[derive(Facet)]
+        struct TestArgs {
+            user_id: u64,
+            message: String,
+        }
+
+        static INSPECTED: AtomicBool = AtomicBool::new(false);
+        static FOUND_USER_ID: AtomicBool = AtomicBool::new(false);
+
+        struct InspectingMiddleware;
+
+        impl Middleware for InspectingMiddleware {
+            fn pre<'a>(
+                &'a self,
+                _ctx: &'a mut Context,
+                args: SendPeek<'a>,
+            ) -> Pin<Box<dyn Future<Output = Result<(), Rejection>> + Send + 'a>> {
+                Box::pin(async move {
+                    INSPECTED.store(true, Ordering::SeqCst);
+
+                    // Use Peek to inspect the args structure
+                    let peek = args.peek();
+
+                    // Try to access as a struct and get the user_id field
+                    if let Ok(ps) = peek.into_struct()
+                        && let Ok(field) = ps.field_by_name("user_id")
+                        && let Ok(&uid) = field.get::<u64>()
+                        && uid == 12345
+                    {
+                        FOUND_USER_ID.store(true, Ordering::SeqCst);
+                    }
+
+                    Ok(())
+                })
+            }
+        }
+
+        // Create test args
+        let args = TestArgs {
+            user_id: 12345,
+            message: "hello".to_string(),
+        };
+
+        // Create a SendPeek from the args
+        let peek = Peek::new(&args);
+        // SAFETY: TestArgs is Send, we own it, it won't be mutated
+        let send_peek = unsafe { SendPeek::new(peek) };
+
+        // Create a context (method_id doesn't matter for this test)
+        let mut ctx = Context::new(
+            roam_wire::ConnectionId::new(1),
+            roam_wire::RequestId::new(1),
+            roam_wire::MethodId::new(0),
+            roam_wire::Metadata::default(),
+            vec![],
+        );
+
+        // Run the middleware synchronously (for test purposes)
+        let mw = InspectingMiddleware;
+        let future = mw.pre(&mut ctx, send_peek);
+
+        // Use a simple blocking executor for the test
+        futures_util::pin_mut!(future);
+        let waker = futures_util::task::noop_waker();
+        let mut cx = std::task::Context::from_waker(&waker);
+        loop {
+            match future.as_mut().poll(&mut cx) {
+                std::task::Poll::Ready(result) => {
+                    assert!(result.is_ok());
+                    break;
+                }
+                std::task::Poll::Pending => continue,
+            }
+        }
+
+        assert!(
+            INSPECTED.load(Ordering::SeqCst),
+            "middleware was not called"
+        );
+        assert!(
+            FOUND_USER_ID.load(Ordering::SeqCst),
+            "middleware did not find user_id=12345"
+        );
+    }
+
+    // Test that post-middleware can observe the outcome
+    #[test]
+    fn test_post_middleware_observes_outcome() {
+        use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+        static POST_CALLED: AtomicBool = AtomicBool::new(false);
+        static OUTCOME_TYPE: AtomicU8 = AtomicU8::new(0); // 0=none, 1=ok, 2=err, 3=rejected
+
+        struct ObservingMiddleware;
+
+        impl Middleware for ObservingMiddleware {
+            fn pre<'a>(
+                &'a self,
+                _ctx: &'a mut Context,
+                _args: SendPeek<'a>,
+            ) -> Pin<Box<dyn Future<Output = Result<(), Rejection>> + Send + 'a>> {
+                Box::pin(async { Ok(()) })
+            }
+
+            fn post<'a>(
+                &'a self,
+                _ctx: &'a Context,
+                outcome: MethodOutcome<'a>,
+            ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+                Box::pin(async move {
+                    POST_CALLED.store(true, Ordering::SeqCst);
+                    match outcome {
+                        MethodOutcome::Ok(_) => OUTCOME_TYPE.store(1, Ordering::SeqCst),
+                        MethodOutcome::Err(_) => OUTCOME_TYPE.store(2, Ordering::SeqCst),
+                        MethodOutcome::Rejected => OUTCOME_TYPE.store(3, Ordering::SeqCst),
+                    }
+                })
+            }
+        }
+
+        let ctx = Context::new(
+            roam_wire::ConnectionId::new(1),
+            roam_wire::RequestId::new(1),
+            roam_wire::MethodId::new(0),
+            roam_wire::Metadata::default(),
+            vec![],
+        );
+
+        let mw = ObservingMiddleware;
+
+        // Test with Ok outcome
+        let result_value = 42u64;
+        let peek = Peek::new(&result_value);
+        let send_peek = unsafe { SendPeek::new(peek) };
+        let outcome = MethodOutcome::Ok(send_peek);
+
+        let future = mw.post(&ctx, outcome);
+        futures_util::pin_mut!(future);
+        let waker = futures_util::task::noop_waker();
+        let mut cx = std::task::Context::from_waker(&waker);
+        loop {
+            match future.as_mut().poll(&mut cx) {
+                std::task::Poll::Ready(()) => break,
+                std::task::Poll::Pending => continue,
+            }
+        }
+
+        assert!(POST_CALLED.load(Ordering::SeqCst));
+        assert_eq!(OUTCOME_TYPE.load(Ordering::SeqCst), 1); // Ok
+
+        // Test with Rejected outcome
+        POST_CALLED.store(false, Ordering::SeqCst);
+        let future = mw.post(&ctx, MethodOutcome::Rejected);
+        futures_util::pin_mut!(future);
+        loop {
+            match future.as_mut().poll(&mut cx) {
+                std::task::Poll::Ready(()) => break,
+                std::task::Poll::Pending => continue,
+            }
+        }
+
+        assert!(POST_CALLED.load(Ordering::SeqCst));
+        assert_eq!(OUTCOME_TYPE.load(Ordering::SeqCst), 3); // Rejected
     }
 }

--- a/rust/roam-telemetry/Cargo.toml
+++ b/rust/roam-telemetry/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "roam-telemetry"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Lightweight OTLP telemetry for roam RPC"
+
+[package.metadata]
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[dependencies]
+# Roam
+roam-session = { workspace = true }
+roam-wire = { workspace = true }
+
+# Facet for JSON serialization and pretty printing
+facet = { workspace = true }
+facet-json = { workspace = true }
+facet-pretty = { workspace = true }
+
+# HTTP client
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+
+# Async runtime
+tokio = { workspace = true, features = ["sync", "time", "rt"] }
+
+# Utilities
+rand = "0.9"
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/rust/roam-telemetry/README.md.in
+++ b/rust/roam-telemetry/README.md.in
@@ -1,0 +1,114 @@
+# roam-telemetry
+
+[![crates.io](https://img.shields.io/crates/v/roam-telemetry.svg)](https://crates.io/crates/roam-telemetry)
+[![documentation](https://docs.rs/roam-telemetry/badge.svg)](https://docs.rs/roam-telemetry)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/roam-telemetry.svg)](./LICENSE)
+
+Lightweight OTLP telemetry for roam RPC.
+
+This crate provides OpenTelemetry-compatible tracing without the heavy `opentelemetry` crate dependency. It sends traces directly to an OTLP HTTP endpoint (like Grafana Tempo) using reqwest and facet-json.
+
+## Features
+
+- **Lightweight** - No opentelemetry dependency, just reqwest + facet-json
+- **OTLP JSON export** - Sends traces to Tempo/Jaeger/any OTLP collector via HTTP
+- **W3C Trace Context** - Extracts/injects `traceparent` for distributed tracing
+- **Batching** - Collects spans and exports in configurable batches
+- **Pre/post middleware** - Uses roam's middleware system to capture request lifecycle
+
+## Usage
+
+```rust
+use roam_telemetry::{TelemetryMiddleware, OtlpExporter};
+
+// Create exporter pointing to your collector
+let exporter = OtlpExporter::new(
+    "http://tempo:4318/v1/traces",
+    "my-service"
+);
+
+// Add to your service dispatcher
+let dispatcher = MyServiceDispatcher::new(handler)
+    .with_middleware(TelemetryMiddleware::new(exporter));
+```
+
+## Trace Context Propagation
+
+### Automatic (Recommended)
+
+Use `TracingCaller` for automatic trace propagation on outgoing calls:
+
+```rust
+use roam_telemetry::{TracingCaller, OtlpExporter};
+
+let exporter = OtlpExporter::new("http://tempo:4318/v1/traces", "my-service");
+
+// Wrap your connection handle with TracingCaller
+let caller = TracingCaller::new(connection_handle, exporter.clone());
+let client = DownstreamServiceClient::new(caller);
+
+// Calls automatically:
+// - Create CLIENT spans
+// - Inject traceparent into metadata
+// - Record success/failure
+client.some_method(args).await?;
+```
+
+When used together with `TelemetryMiddleware` on the server side, traces automatically propagate across service boundaries.
+
+### Manual
+
+For fine-grained control, access the pending span from context extensions:
+
+```rust
+use roam_telemetry::PendingSpan;
+
+async fn my_handler(ctx: &Context, ...) -> Result<...> {
+    if let Some(span) = ctx.extensions.get::<PendingSpan>() {
+        let traceparent = span.traceparent();
+        // Manually add to outgoing call metadata
+        downstream_client
+            .call()
+            .with_metadata(vec![
+                ("traceparent".into(), MetadataValue::String(traceparent))
+            ])
+            .await?;
+    }
+    // ...
+}
+```
+
+## Configuration
+
+```rust
+use roam_telemetry::{OtlpExporter, ExporterConfig, KeyValue};
+use std::time::Duration;
+
+let exporter = OtlpExporter::with_config(ExporterConfig {
+    endpoint: "http://tempo:4318/v1/traces".to_string(),
+    service_name: "my-service".to_string(),
+    resource_attributes: vec![
+        KeyValue::string("deployment.environment", "production"),
+        KeyValue::string("service.version", "1.0.0"),
+    ],
+    max_batch_size: 512,
+    max_batch_delay: Duration::from_secs(5),
+    timeout: Duration::from_secs(10),
+});
+```
+
+## Span Attributes
+
+Each span includes:
+
+- `rpc.system` = "roam"
+- `rpc.method` = method name (e.g., "MyService.my_method")
+- `rpc.request_id` = request ID
+- `network.peer.connection_id` = connection ID
+- `rpc.metadata.*` = request metadata (first 10 entries)
+- `rpc.success` = true/false
+- `rpc.error_type` = "user_error" or "rejected" (on failure)
+
+## License
+
+MIT OR Apache-2.0

--- a/rust/roam-telemetry/arborium-header.html
+++ b/rust/roam-telemetry/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@2/dist/arborium.iife.js"></script>

--- a/rust/roam-telemetry/src/client.rs
+++ b/rust/roam-telemetry/src/client.rs
@@ -1,0 +1,255 @@
+//! Client-side telemetry for outgoing RPC calls.
+//!
+//! Provides a `TracingCaller` wrapper that:
+//! - Creates CLIENT spans for outgoing calls
+//! - Injects `traceparent` into request metadata for distributed tracing
+//! - Records call success/failure in the span
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use facet::Facet;
+use roam_session::{Caller, ResponseData, TransportError};
+use roam_wire::MetadataValue;
+
+use crate::exporter::OtlpExporter;
+use crate::otlp::{KeyValue, Span, SpanKind, Status, generate_span_id, generate_trace_id};
+
+/// The current trace information for context propagation.
+///
+/// This is stored in `Context::extensions` by `TelemetryMiddleware`, and
+/// read from `CURRENT_EXTENSIONS` task-local by `TracingCaller`.
+#[derive(Debug, Clone)]
+pub struct CurrentTrace {
+    /// The trace ID (32 hex chars).
+    pub trace_id: String,
+    /// The current span ID (16 hex chars) - becomes parent of child spans.
+    pub span_id: String,
+    /// Trace flags.
+    pub flags: u8,
+}
+
+impl CurrentTrace {
+    /// Format as a traceparent header value.
+    pub fn traceparent(&self) -> String {
+        format!("00-{}-{}-{:02x}", self.trace_id, self.span_id, self.flags)
+    }
+}
+
+/// A `Caller` wrapper that adds distributed tracing to outgoing calls.
+///
+/// For each call:
+/// 1. Creates a CLIENT span
+/// 2. Injects `traceparent` into metadata (propagating the current trace)
+/// 3. Makes the call
+/// 4. Records success/failure and exports the span
+///
+/// # Trace Propagation
+///
+/// If a [`CurrentTrace`] is found in the task-local `CURRENT_EXTENSIONS`
+/// (set by the generated dispatch code), the span will be a child of that trace.
+/// Otherwise, a new trace is started.
+///
+/// The server-side `TelemetryMiddleware` inserts `CurrentTrace` into context
+/// extensions, and the generated dispatch code makes extensions available via
+/// the `CURRENT_EXTENSIONS` task-local. This allows nested calls to be part
+/// of the same trace.
+///
+/// # Example
+///
+/// ```ignore
+/// use roam_telemetry::{TracingCaller, OtlpExporter};
+///
+/// let exporter = OtlpExporter::new("http://tempo:4318/v1/traces", "my-service");
+/// let caller = TracingCaller::new(connection_handle, exporter);
+/// let client = MyServiceClient::new(caller);
+///
+/// // Calls will now create spans and propagate trace context
+/// client.some_method(args).await?;
+/// ```
+#[derive(Clone)]
+pub struct TracingCaller<C> {
+    inner: C,
+    exporter: OtlpExporter,
+}
+
+impl<C> TracingCaller<C> {
+    /// Create a new tracing caller wrapping the given caller.
+    pub fn new(inner: C, exporter: OtlpExporter) -> Self {
+        Self { inner, exporter }
+    }
+
+    /// Get the inner caller.
+    pub fn inner(&self) -> &C {
+        &self.inner
+    }
+}
+
+impl<C: Caller> Caller for TracingCaller<C> {
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn call_with_metadata<T: Facet<'static> + Send>(
+        &self,
+        method_id: u64,
+        args: &mut T,
+        mut metadata: roam_wire::Metadata,
+    ) -> Result<ResponseData, TransportError> {
+        // Get trace context from CURRENT_EXTENSIONS (set by generated dispatch code)
+        // or create a new trace if not in a request context
+        let (trace_id, parent_span_id) = roam_session::CURRENT_EXTENSIONS
+            .try_with(|ext| {
+                ext.get::<CurrentTrace>()
+                    .map(|tc| (tc.trace_id.clone(), Some(tc.span_id.clone())))
+            })
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| (generate_trace_id(), None));
+
+        let span_id = generate_span_id();
+        let flags: u8 = 0x01; // sampled
+
+        // Inject traceparent into metadata
+        let traceparent = format!("00-{}-{}-{:02x}", trace_id, span_id, flags);
+        metadata.push((
+            "traceparent".to_string(),
+            MetadataValue::String(traceparent),
+        ));
+
+        let start_time_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+
+        // Get method name for span (best effort)
+        let method_name = roam_session::diagnostic::get_method_name(method_id)
+            .unwrap_or("unknown")
+            .to_string();
+
+        // Make the actual call
+        let result = self
+            .inner
+            .call_with_metadata(method_id, args, metadata)
+            .await;
+
+        let end_time_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+
+        // Build span attributes
+        let mut attributes = vec![
+            KeyValue::string("rpc.system", "roam"),
+            KeyValue::string("rpc.method", &method_name),
+            KeyValue::string("rpc.service", self.exporter.service_name()),
+        ];
+
+        let status = match &result {
+            Ok(_) => {
+                attributes.push(KeyValue::bool("rpc.success", true));
+                Status::ok()
+            }
+            Err(e) => {
+                attributes.push(KeyValue::bool("rpc.success", false));
+                attributes.push(KeyValue::string("rpc.error", format!("{:?}", e)));
+                Status::error(format!("{:?}", e))
+            }
+        };
+
+        // Export the span
+        let span = Span {
+            trace_id,
+            span_id,
+            parent_span_id,
+            name: method_name,
+            kind: SpanKind::Client.as_u32(),
+            start_time_unix_nano: start_time_ns.to_string(),
+            end_time_unix_nano: end_time_ns.to_string(),
+            attributes,
+            status,
+        };
+        self.exporter.send(span);
+
+        result
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    async fn call_with_metadata<T: Facet<'static> + Send>(
+        &self,
+        method_id: u64,
+        args: &mut T,
+        mut metadata: roam_wire::Metadata,
+    ) -> Result<ResponseData, TransportError> {
+        // WASM version - uses same CURRENT_EXTENSIONS task-local
+        let (trace_id, parent_span_id) = roam_session::CURRENT_EXTENSIONS
+            .try_with(|ext| {
+                ext.get::<CurrentTrace>()
+                    .map(|tc| (tc.trace_id.clone(), Some(tc.span_id.clone())))
+            })
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| (generate_trace_id(), None));
+
+        let span_id = generate_span_id();
+        let flags: u8 = 0x01;
+
+        let traceparent = format!("00-{}-{}-{:02x}", trace_id, span_id, flags);
+        metadata.push((
+            "traceparent".to_string(),
+            MetadataValue::String(traceparent),
+        ));
+
+        let start_time_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+
+        let method_name = roam_session::diagnostic::get_method_name(method_id)
+            .unwrap_or("unknown")
+            .to_string();
+
+        let result = self
+            .inner
+            .call_with_metadata(method_id, args, metadata)
+            .await;
+
+        let end_time_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+
+        let mut attributes = vec![
+            KeyValue::string("rpc.system", "roam"),
+            KeyValue::string("rpc.method", &method_name),
+            KeyValue::string("rpc.service", self.exporter.service_name()),
+        ];
+
+        let status = match &result {
+            Ok(_) => {
+                attributes.push(KeyValue::bool("rpc.success", true));
+                Status::ok()
+            }
+            Err(e) => {
+                attributes.push(KeyValue::bool("rpc.success", false));
+                attributes.push(KeyValue::string("rpc.error", format!("{:?}", e)));
+                Status::error(format!("{:?}", e))
+            }
+        };
+
+        let span = Span {
+            trace_id,
+            span_id,
+            parent_span_id,
+            name: method_name,
+            kind: SpanKind::Client.as_u32(),
+            start_time_unix_nano: start_time_ns.to_string(),
+            end_time_unix_nano: end_time_ns.to_string(),
+            attributes,
+            status,
+        };
+        self.exporter.send(span);
+
+        result
+    }
+
+    fn bind_response_streams<T: Facet<'static>>(&self, response: &mut T, channels: &[u64]) {
+        self.inner.bind_response_streams(response, channels)
+    }
+}

--- a/rust/roam-telemetry/src/exporter.rs
+++ b/rust/roam-telemetry/src/exporter.rs
@@ -1,0 +1,192 @@
+//! OTLP HTTP exporter using reqwest.
+//!
+//! Batches spans and sends them to an OTLP HTTP endpoint.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use crate::otlp::{
+    ExportTraceServiceRequest, InstrumentationScope, KeyValue, Resource, ResourceSpans, ScopeSpans,
+    Span,
+};
+
+/// Configuration for the OTLP exporter.
+#[derive(Debug, Clone)]
+pub struct ExporterConfig {
+    /// OTLP HTTP endpoint (e.g., "http://tempo:4318/v1/traces").
+    pub endpoint: String,
+    /// Service name for resource attributes.
+    pub service_name: String,
+    /// Additional resource attributes.
+    pub resource_attributes: Vec<KeyValue>,
+    /// Maximum batch size before sending.
+    pub max_batch_size: usize,
+    /// Maximum time to wait before sending a batch.
+    pub max_batch_delay: Duration,
+    /// HTTP timeout for export requests.
+    pub timeout: Duration,
+}
+
+impl Default for ExporterConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: "http://localhost:4318/v1/traces".to_string(),
+            service_name: "unknown".to_string(),
+            resource_attributes: Vec::new(),
+            max_batch_size: 512,
+            max_batch_delay: Duration::from_secs(5),
+            timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+/// OTLP HTTP exporter.
+///
+/// Collects spans via an async channel and batches them for export.
+/// The exporter runs a background task that:
+/// - Collects spans until batch is full or timeout expires
+/// - Serializes batch to JSON using facet-json
+/// - POSTs to the OTLP endpoint
+#[derive(Clone)]
+pub struct OtlpExporter {
+    tx: mpsc::Sender<Span>,
+    config: Arc<ExporterConfig>,
+}
+
+impl OtlpExporter {
+    /// Create a new exporter with the given endpoint and service name.
+    ///
+    /// This starts a background task that batches and exports spans.
+    /// The task runs until the exporter is dropped.
+    pub fn new(endpoint: impl Into<String>, service_name: impl Into<String>) -> Self {
+        Self::with_config(ExporterConfig {
+            endpoint: endpoint.into(),
+            service_name: service_name.into(),
+            ..Default::default()
+        })
+    }
+
+    /// Create a new exporter with full configuration.
+    pub fn with_config(config: ExporterConfig) -> Self {
+        let (tx, rx) = mpsc::channel(4096);
+        let config = Arc::new(config);
+
+        // Spawn the background export task
+        let config_clone = config.clone();
+        tokio::spawn(async move {
+            export_loop(rx, config_clone).await;
+        });
+
+        Self { tx, config }
+    }
+
+    /// Queue a span for export.
+    ///
+    /// This is non-blocking. If the channel is full, the span is dropped.
+    pub fn send(&self, span: Span) {
+        // Use try_send to avoid blocking - if buffer is full, drop the span
+        let _ = self.tx.try_send(span);
+    }
+
+    /// Get the service name.
+    pub fn service_name(&self) -> &str {
+        &self.config.service_name
+    }
+}
+
+async fn export_loop(mut rx: mpsc::Receiver<Span>, config: Arc<ExporterConfig>) {
+    let client = reqwest::Client::builder()
+        .timeout(config.timeout)
+        .build()
+        .expect("failed to create HTTP client");
+
+    let mut batch = Vec::with_capacity(config.max_batch_size);
+    let mut interval = tokio::time::interval(config.max_batch_delay);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            // Receive spans
+            span = rx.recv() => {
+                match span {
+                    Some(span) => {
+                        batch.push(span);
+                        if batch.len() >= config.max_batch_size {
+                            export_batch(&client, &config, &mut batch).await;
+                        }
+                    }
+                    None => {
+                        // Channel closed, export remaining and exit
+                        if !batch.is_empty() {
+                            export_batch(&client, &config, &mut batch).await;
+                        }
+                        break;
+                    }
+                }
+            }
+            // Periodic flush
+            _ = interval.tick() => {
+                if !batch.is_empty() {
+                    export_batch(&client, &config, &mut batch).await;
+                }
+            }
+        }
+    }
+}
+
+async fn export_batch(client: &reqwest::Client, config: &ExporterConfig, batch: &mut Vec<Span>) {
+    if batch.is_empty() {
+        return;
+    }
+
+    // Build resource attributes
+    let mut attributes = vec![KeyValue::string("service.name", &config.service_name)];
+    attributes.extend(config.resource_attributes.iter().cloned());
+
+    // Build the export request
+    let request = ExportTraceServiceRequest {
+        resource_spans: vec![ResourceSpans {
+            resource: Resource { attributes },
+            scope_spans: vec![ScopeSpans {
+                scope: InstrumentationScope {
+                    name: "roam-telemetry".to_string(),
+                    version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                },
+                spans: std::mem::take(batch),
+            }],
+        }],
+    };
+
+    // Serialize to JSON
+    let json = match facet_json::to_string(&request) {
+        Ok(json) => json,
+        Err(e) => {
+            tracing::warn!("failed to serialize spans: {}", e);
+            return;
+        }
+    };
+
+    // Send to endpoint
+    match client
+        .post(&config.endpoint)
+        .header("Content-Type", "application/json")
+        .body(json)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if !response.status().is_success() {
+                tracing::warn!(
+                    "OTLP export failed: {} {}",
+                    response.status(),
+                    response.text().await.unwrap_or_default()
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!("OTLP export error: {}", e);
+        }
+    }
+}

--- a/rust/roam-telemetry/src/lib.rs
+++ b/rust/roam-telemetry/src/lib.rs
@@ -1,0 +1,31 @@
+//! Lightweight OTLP telemetry for roam RPC.
+//!
+//! This crate provides OpenTelemetry-compatible tracing without the heavy
+//! `opentelemetry` crate dependency. It sends traces directly to an OTLP
+//! HTTP endpoint (like Grafana Tempo) using reqwest and facet-json.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use roam_telemetry::{TelemetryMiddleware, OtlpExporter};
+//!
+//! // Create exporter pointing to Tempo
+//! let exporter = OtlpExporter::new("http://tempo:4318/v1/traces", "my-service");
+//!
+//! // Create middleware
+//! let telemetry = TelemetryMiddleware::new(exporter);
+//!
+//! // Add to dispatcher
+//! let dispatcher = MyServiceDispatcher::new(handler)
+//!     .with_middleware(telemetry);
+//! ```
+
+mod client;
+mod exporter;
+mod middleware;
+mod otlp;
+
+pub use client::{CurrentTrace, TracingCaller};
+pub use exporter::{ExporterConfig, OtlpExporter};
+pub use middleware::{PendingSpan, TelemetryMiddleware};
+pub use otlp::{KeyValue, Span, SpanKind, StatusCode, TraceContext};

--- a/rust/roam-telemetry/src/middleware.rs
+++ b/rust/roam-telemetry/src/middleware.rs
@@ -1,0 +1,217 @@
+//! Telemetry middleware for roam RPC.
+//!
+//! Creates spans for incoming RPC requests with W3C Trace Context propagation.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use facet_pretty::PrettyPrinter;
+use roam_session::{Context, MethodOutcome, Middleware, Rejection, SendPeek};
+
+use crate::client::CurrentTrace;
+use crate::exporter::OtlpExporter;
+use crate::otlp::{
+    KeyValue, Span, SpanKind, Status, TraceContext, generate_span_id, generate_trace_id,
+};
+
+/// A span that's been started but not yet finished.
+///
+/// Stored in `ctx.extensions` during request processing.
+#[derive(Debug, Clone)]
+pub struct PendingSpan {
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: Option<String>,
+    pub name: String,
+    pub start_time_ns: u64,
+    pub attributes: Vec<KeyValue>,
+}
+
+impl PendingSpan {
+    /// Start a new span, extracting trace context from metadata if present.
+    pub fn start(ctx: &Context) -> Self {
+        let name = ctx.method_name().unwrap_or("unknown").to_string();
+
+        // Try to extract trace context from metadata
+        let trace_ctx = ctx
+            .metadata()
+            .iter()
+            .find(|(k, _)| k == TraceContext::TRACEPARENT_KEY)
+            .and_then(|(_, v)| match v {
+                roam_wire::MetadataValue::String(s) => TraceContext::parse(s),
+                _ => None,
+            });
+
+        let (trace_id, parent_span_id) = match trace_ctx {
+            Some(tc) => (tc.trace_id, Some(tc.parent_span_id)),
+            None => (generate_trace_id(), None),
+        };
+
+        let span_id = generate_span_id();
+
+        let start_time_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+
+        // Add standard attributes
+        let mut attributes = vec![
+            KeyValue::string("rpc.system", "roam"),
+            KeyValue::string("rpc.method", &name),
+            KeyValue::int("rpc.request_id", ctx.request_id().raw() as i64),
+            KeyValue::int("network.peer.connection_id", ctx.conn_id().raw() as i64),
+        ];
+
+        // Add metadata as attributes (limited to avoid bloat)
+        for (key, value) in ctx.metadata().iter().take(10) {
+            if key != TraceContext::TRACEPARENT_KEY {
+                let value_str = match value {
+                    roam_wire::MetadataValue::String(s) => s.clone(),
+                    roam_wire::MetadataValue::Bytes(b) => format!("<{} bytes>", b.len()),
+                    roam_wire::MetadataValue::U64(n) => n.to_string(),
+                };
+                attributes.push(KeyValue::string(format!("rpc.metadata.{}", key), value_str));
+            }
+        }
+
+        Self {
+            trace_id,
+            span_id,
+            parent_span_id,
+            name,
+            start_time_ns,
+            attributes,
+        }
+    }
+
+    /// Finish the span and convert to an OTLP Span.
+    pub fn finish(mut self, outcome: &MethodOutcome<'_>) -> Span {
+        let end_time_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+
+        let status = match outcome {
+            MethodOutcome::Ok(_) => {
+                self.attributes.push(KeyValue::bool("rpc.success", true));
+                Status::ok()
+            }
+            MethodOutcome::Err(_) => {
+                self.attributes.push(KeyValue::bool("rpc.success", false));
+                self.attributes
+                    .push(KeyValue::string("rpc.error_type", "user_error"));
+                Status::error("user error")
+            }
+            MethodOutcome::Rejected => {
+                self.attributes.push(KeyValue::bool("rpc.success", false));
+                self.attributes
+                    .push(KeyValue::string("rpc.error_type", "rejected"));
+                Status::error("rejected by middleware")
+            }
+        };
+
+        Span {
+            trace_id: self.trace_id,
+            span_id: self.span_id,
+            parent_span_id: self.parent_span_id,
+            name: self.name,
+            kind: SpanKind::Server.as_u32(),
+            start_time_unix_nano: self.start_time_ns.to_string(),
+            end_time_unix_nano: end_time_ns.to_string(),
+            attributes: self.attributes,
+            status,
+        }
+    }
+
+    /// Get the traceparent header value for propagating to downstream calls.
+    ///
+    /// Use this when making outgoing RPC calls to propagate the trace.
+    pub fn traceparent(&self) -> String {
+        format!("00-{}-{}-01", self.trace_id, self.span_id)
+    }
+}
+
+/// Telemetry middleware that creates spans for RPC requests.
+///
+/// # Trace Context Propagation
+///
+/// If the incoming request has a `traceparent` metadata key, the middleware
+/// extracts the trace ID and creates a child span. Otherwise, it starts a
+/// new trace.
+///
+/// The [`PendingSpan`] is stored in `ctx.extensions` and can be used to
+/// propagate context to downstream calls via `pending_span.traceparent()`.
+///
+/// # Example
+///
+/// ```ignore
+/// use roam_telemetry::{TelemetryMiddleware, OtlpExporter};
+///
+/// let exporter = OtlpExporter::new(
+///     "http://tempo:4318/v1/traces",
+///     "my-service"
+/// );
+/// let telemetry = TelemetryMiddleware::new(exporter);
+///
+/// let dispatcher = MyServiceDispatcher::new(handler)
+///     .with_middleware(telemetry);
+/// ```
+#[derive(Clone)]
+pub struct TelemetryMiddleware {
+    exporter: OtlpExporter,
+}
+
+impl TelemetryMiddleware {
+    /// Create a new telemetry middleware with the given exporter.
+    pub fn new(exporter: OtlpExporter) -> Self {
+        Self { exporter }
+    }
+}
+
+impl Middleware for TelemetryMiddleware {
+    fn pre<'a>(
+        &'a self,
+        ctx: &'a mut Context,
+        args: SendPeek<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Rejection>> + Send + 'a>> {
+        Box::pin(async move {
+            // Start a span and store it in extensions
+            let mut span = PendingSpan::start(ctx);
+
+            // Capture args as a pretty-printed string (truncated for span attribute limits)
+            let args_str = PrettyPrinter::new()
+                .with_colors(facet_pretty::ColorMode::Never)
+                .with_max_content_len(256)
+                .format_peek(args.peek());
+            span.attributes.push(KeyValue::string("rpc.args", args_str));
+
+            // Also insert CurrentTrace so that TracingCaller can propagate
+            // the trace context to downstream calls
+            let current_trace = CurrentTrace {
+                trace_id: span.trace_id.clone(),
+                span_id: span.span_id.clone(),
+                flags: 0x01, // sampled
+            };
+            ctx.extensions.insert(current_trace);
+
+            ctx.extensions.insert(span);
+            Ok(())
+        })
+    }
+
+    fn post<'a>(
+        &'a self,
+        ctx: &'a Context,
+        outcome: MethodOutcome<'a>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        let exporter = self.exporter.clone();
+        Box::pin(async move {
+            // Get the pending span and finish it
+            if let Some(pending) = ctx.extensions.get::<PendingSpan>() {
+                let span = pending.clone().finish(&outcome);
+                exporter.send(span);
+            }
+        })
+    }
+}

--- a/rust/roam-telemetry/src/otlp.rs
+++ b/rust/roam-telemetry/src/otlp.rs
@@ -1,0 +1,346 @@
+//! OTLP JSON types for trace export.
+//!
+//! These match the OpenTelemetry Protocol JSON format:
+//! <https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding>
+
+use facet::Facet;
+
+/// Root request for exporting traces.
+#[derive(Debug, Clone, Facet)]
+#[facet(rename_all = "camelCase")]
+pub struct ExportTraceServiceRequest {
+    pub resource_spans: Vec<ResourceSpans>,
+}
+
+/// Spans grouped by resource (service).
+#[derive(Debug, Clone, Facet)]
+#[facet(rename_all = "camelCase")]
+pub struct ResourceSpans {
+    pub resource: Resource,
+    pub scope_spans: Vec<ScopeSpans>,
+}
+
+/// Resource attributes (service.name, etc).
+#[derive(Debug, Clone, Facet)]
+pub struct Resource {
+    pub attributes: Vec<KeyValue>,
+}
+
+/// Spans grouped by instrumentation scope.
+#[derive(Debug, Clone, Facet)]
+#[facet(rename_all = "camelCase")]
+pub struct ScopeSpans {
+    pub scope: InstrumentationScope,
+    pub spans: Vec<Span>,
+}
+
+/// Instrumentation scope (library name/version).
+#[derive(Debug, Clone, Facet)]
+pub struct InstrumentationScope {
+    pub name: String,
+    #[facet(default)]
+    pub version: Option<String>,
+}
+
+/// A single span.
+#[derive(Debug, Clone, Facet)]
+#[facet(rename_all = "camelCase")]
+pub struct Span {
+    /// 16-byte trace ID as hex string (32 chars).
+    pub trace_id: String,
+    /// 8-byte span ID as hex string (16 chars).
+    pub span_id: String,
+    /// Parent span ID (if any).
+    #[facet(default)]
+    pub parent_span_id: Option<String>,
+    /// Span name (e.g., "Testbed.echo").
+    pub name: String,
+    /// Span kind (CLIENT, SERVER, etc).
+    pub kind: u32,
+    /// Start time in nanoseconds since Unix epoch.
+    pub start_time_unix_nano: String,
+    /// End time in nanoseconds since Unix epoch.
+    pub end_time_unix_nano: String,
+    /// Span attributes.
+    #[facet(default)]
+    pub attributes: Vec<KeyValue>,
+    /// Span status.
+    pub status: Status,
+}
+
+/// Span kind values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum SpanKind {
+    Unspecified = 0,
+    Internal = 1,
+    Server = 2,
+    Client = 3,
+    Producer = 4,
+    Consumer = 5,
+}
+
+impl SpanKind {
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+/// Key-value attribute.
+#[derive(Debug, Clone, Facet)]
+pub struct KeyValue {
+    pub key: String,
+    pub value: AnyValue,
+}
+
+impl KeyValue {
+    pub fn string(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: AnyValue {
+                string_value: Some(value.into()),
+                int_value: None,
+                bool_value: None,
+            },
+        }
+    }
+
+    pub fn int(key: impl Into<String>, value: i64) -> Self {
+        Self {
+            key: key.into(),
+            value: AnyValue {
+                string_value: None,
+                int_value: Some(value.to_string()),
+                bool_value: None,
+            },
+        }
+    }
+
+    pub fn bool(key: impl Into<String>, value: bool) -> Self {
+        Self {
+            key: key.into(),
+            value: AnyValue {
+                string_value: None,
+                int_value: None,
+                bool_value: Some(value),
+            },
+        }
+    }
+}
+
+/// Attribute value (only one field should be set).
+#[derive(Debug, Clone, Facet)]
+#[facet(rename_all = "camelCase")]
+pub struct AnyValue {
+    #[facet(default)]
+    pub string_value: Option<String>,
+    /// OTLP uses string for int64 to avoid JS precision loss.
+    #[facet(default)]
+    pub int_value: Option<String>,
+    #[facet(default)]
+    pub bool_value: Option<bool>,
+}
+
+/// Span status.
+#[derive(Debug, Clone, Facet)]
+pub struct Status {
+    /// Status code.
+    pub code: u32,
+    /// Optional message (usually for errors).
+    #[facet(default)]
+    pub message: Option<String>,
+}
+
+/// Status code values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum StatusCode {
+    Unset = 0,
+    Ok = 1,
+    Error = 2,
+}
+
+impl StatusCode {
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+impl Status {
+    pub fn ok() -> Self {
+        Self {
+            code: StatusCode::Ok.as_u32(),
+            message: None,
+        }
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            code: StatusCode::Error.as_u32(),
+            message: Some(message.into()),
+        }
+    }
+
+    pub fn unset() -> Self {
+        Self {
+            code: StatusCode::Unset.as_u32(),
+            message: None,
+        }
+    }
+}
+
+// ============================================================================
+// W3C Trace Context
+// ============================================================================
+
+/// W3C Trace Context extracted from or injected into metadata.
+///
+/// Format: `traceparent: 00-{trace_id}-{parent_span_id}-{flags}`
+/// - version: 2 hex chars (always "00")
+/// - trace_id: 32 hex chars (16 bytes)
+/// - parent_span_id: 16 hex chars (8 bytes)
+/// - flags: 2 hex chars (01 = sampled)
+#[derive(Debug, Clone)]
+pub struct TraceContext {
+    /// 16-byte trace ID as 32 hex chars.
+    pub trace_id: String,
+    /// 8-byte parent span ID as 16 hex chars.
+    pub parent_span_id: String,
+    /// Trace flags (01 = sampled).
+    pub flags: u8,
+}
+
+impl TraceContext {
+    /// The metadata key for W3C traceparent.
+    pub const TRACEPARENT_KEY: &'static str = "traceparent";
+
+    /// Parse from a traceparent header value.
+    ///
+    /// Format: `00-{trace_id}-{span_id}-{flags}`
+    pub fn parse(traceparent: &str) -> Option<Self> {
+        let parts: Vec<&str> = traceparent.split('-').collect();
+        if parts.len() != 4 {
+            return None;
+        }
+
+        let version = parts[0];
+        let trace_id = parts[1];
+        let parent_span_id = parts[2];
+        let flags_str = parts[3];
+
+        // Version must be "00"
+        if version != "00" {
+            return None;
+        }
+
+        // Validate lengths
+        if trace_id.len() != 32 || parent_span_id.len() != 16 || flags_str.len() != 2 {
+            return None;
+        }
+
+        // Validate hex
+        if !trace_id.chars().all(|c| c.is_ascii_hexdigit())
+            || !parent_span_id.chars().all(|c| c.is_ascii_hexdigit())
+            || !flags_str.chars().all(|c| c.is_ascii_hexdigit())
+        {
+            return None;
+        }
+
+        let flags = u8::from_str_radix(flags_str, 16).ok()?;
+
+        Some(Self {
+            trace_id: trace_id.to_lowercase(),
+            parent_span_id: parent_span_id.to_lowercase(),
+            flags,
+        })
+    }
+
+    /// Format as a traceparent header value.
+    pub fn to_traceparent(&self, span_id: &str) -> String {
+        format!("00-{}-{}-{:02x}", self.trace_id, span_id, self.flags)
+    }
+
+    /// Create a new trace context with a fresh trace ID.
+    pub fn new_root() -> Self {
+        Self {
+            trace_id: generate_trace_id(),
+            parent_span_id: String::new(), // No parent for root
+            flags: 0x01,                   // Sampled
+        }
+    }
+
+    /// Is this trace sampled?
+    pub fn is_sampled(&self) -> bool {
+        self.flags & 0x01 != 0
+    }
+}
+
+/// Generate a random 16-byte trace ID as 32 hex chars.
+pub fn generate_trace_id() -> String {
+    let bytes: [u8; 16] = rand::random();
+    hex_encode(&bytes)
+}
+
+/// Generate a random 8-byte span ID as 16 hex chars.
+pub fn generate_span_id() -> String {
+    let bytes: [u8; 8] = rand::random();
+    hex_encode(&bytes)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_traceparent() {
+        let tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        let ctx = TraceContext::parse(tp).unwrap();
+        assert_eq!(ctx.trace_id, "0af7651916cd43dd8448eb211c80319c");
+        assert_eq!(ctx.parent_span_id, "b7ad6b7169203331");
+        assert_eq!(ctx.flags, 0x01);
+        assert!(ctx.is_sampled());
+    }
+
+    #[test]
+    fn test_parse_traceparent_not_sampled() {
+        let tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00";
+        let ctx = TraceContext::parse(tp).unwrap();
+        assert!(!ctx.is_sampled());
+    }
+
+    #[test]
+    fn test_parse_invalid() {
+        assert!(TraceContext::parse("invalid").is_none());
+        assert!(TraceContext::parse("01-abc-def-00").is_none()); // wrong version
+        assert!(TraceContext::parse("00-short-span-00").is_none()); // wrong length
+    }
+
+    #[test]
+    fn test_to_traceparent() {
+        let ctx = TraceContext {
+            trace_id: "0af7651916cd43dd8448eb211c80319c".to_string(),
+            parent_span_id: "b7ad6b7169203331".to_string(),
+            flags: 0x01,
+        };
+        let span_id = "00f067aa0ba902b7";
+        assert_eq!(
+            ctx.to_traceparent(span_id),
+            "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01"
+        );
+    }
+
+    #[test]
+    fn test_generate_ids() {
+        let trace_id = generate_trace_id();
+        assert_eq!(trace_id.len(), 32);
+        assert!(trace_id.chars().all(|c| c.is_ascii_hexdigit()));
+
+        let span_id = generate_span_id();
+        assert_eq!(span_id.len(), 16);
+        assert!(span_id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}


### PR DESCRIPTION
- Add roam-telemetry: lightweight OTLP telemetry without opentelemetry dep
  - OtlpExporter with batching for Grafana Tempo/Jaeger
  - W3C Trace Context (traceparent) parsing and propagation
  - TelemetryMiddleware for server-side span creation
  - TracingCaller for client-side trace propagation

- Update middleware system to support pre/post pattern:
  - Middleware::pre() runs before handler, can reject requests
  - Middleware::post() runs after handler, observes outcome
  - MethodOutcome enum: Ok, Err, Rejected for observability

- Add CURRENT_EXTENSIONS task-local for trace propagation:
  - Generated dispatch code scopes extensions around handler
  - TracingCaller reads CurrentTrace from task-local
  - Enables multi-hop tracing (A → B → C) without coupling

- Make Extensions cloneable with Arc-based storage:
  - Use Arc<dyn Any + Send + Sync> instead of Box
  - Derive Clone (cheap - just clones Arc pointers)
  - Remove get_mut/get_or_insert* (not needed, don't work with Arc)