### PR TITLE
Fix/otlp skip none fields

### DIFF
--- a/rust/roam-telemetry/src/otlp.rs
+++ b/rust/roam-telemetry/src/otlp.rs
@@ -130,14 +130,14 @@ impl KeyValue {
 
 /// Attribute value (only one field should be set).
 #[derive(Debug, Clone, Facet)]
-#[facet(rename_all = "camelCase")]
+#[facet(rename_all = "camelCase", skip_all_unless_truthy)]
 pub struct AnyValue {
-    #[facet(default, skip_serializing_if = Option::is_none)]
+    #[facet(default)]
     pub string_value: Option<String>,
     /// OTLP uses string for int64 to avoid JS precision loss.
-    #[facet(default, skip_serializing_if = Option::is_none)]
+    #[facet(default)]
     pub int_value: Option<String>,
-    #[facet(default, skip_serializing_if = Option::is_none)]
+    #[facet(default)]
     pub bool_value: Option<bool>,
 }
 


### PR DESCRIPTION
Hello!

I was unable to export any traces to Jaeger or Tempo until I made these changes. It's very possible I have something misconfigured if this is not the correct solution but I was getting errors that the OTLP spec expects null values to be not included in the JSON. 