### PR TITLE
SHM transport: decouple from roam-frame Frame type

### DIFF
--- a/rust/roam-shm/src/lib.rs
+++ b/rust/roam-shm/src/lib.rs
@@ -88,12 +88,9 @@ pub use channel::{
 pub use layout::{
     HEADER_SIZE, MAGIC, SegmentConfig, SegmentHeader, SegmentLayout, SizeClass, VERSION,
 };
-pub use msg::msg_type;
+pub use msg::{ShmMsg, msg_type};
 pub use peer::{PeerEntry, PeerId, PeerState};
 pub use var_slot_pool::{SizeClassHeader, VarFreeError, VarSlotHandle, VarSlotPool};
-
-// Re-export MsgDesc from roam-frame
-pub use roam_frame::{Frame, INLINE_PAYLOAD_LEN, INLINE_PAYLOAD_SLOT, MsgDesc, Payload};
 
 // Re-export FileCleanup from shm-primitives
 pub use shm_primitives::FileCleanup;
@@ -105,7 +102,7 @@ pub use host::{PollResult, ShmHost};
 pub use guest::ShmGuest;
 
 pub use transport::{
-    ConvertError, ShmGuestTransport, ShmHostGuestTransport, frame_to_message, message_to_frame,
+    ConvertError, ShmGuestTransport, ShmHostGuestTransport, message_to_shm_msg, shm_msg_to_message,
 };
 
 pub use spawn::{

--- a/rust/roam-shm/src/msg.rs
+++ b/rust/roam-shm/src/msg.rs
@@ -65,6 +65,37 @@ pub const fn msg_type_name(msg_type: u8) -> &'static str {
     }
 }
 
+/// Decoded SHM message — v2-native representation.
+///
+/// Carries just the fields needed for BipBuffer frame encoding:
+/// msg_type, id, method_id, and payload bytes.
+#[derive(Debug, Clone)]
+pub struct ShmMsg {
+    pub msg_type: u8,
+    pub id: u32,
+    pub method_id: u64,
+    pub payload: Vec<u8>,
+}
+
+impl ShmMsg {
+    /// Create a new ShmMsg.
+    #[inline]
+    pub fn new(msg_type: u8, id: u32, method_id: u64, payload: Vec<u8>) -> Self {
+        Self {
+            msg_type,
+            id,
+            method_id,
+            payload,
+        }
+    }
+
+    /// Get payload bytes.
+    #[inline]
+    pub fn payload_bytes(&self) -> &[u8] {
+        &self.payload
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Introduces `ShmMsg`, a simple SHM-native message struct that replaces `roam-frame`'s `Frame`/`MsgDesc`/`Payload` types throughout the `roam-shm` crate. This removes the coupling between the SHM transport layer and the frame-level inline payload machinery, yielding a net reduction of ~220 lines and a cleaner API.

## Changes

- Add `ShmMsg` struct to `roam_shm::msg` with `msg_type`, `id`, `method_id`, and `payload: Vec<u8>`
- Change `ShmGuest::send()` and `ShmHost::send()` to take `&ShmMsg` instead of owned `Frame`, eliminating clones on retry loops
- Rename `frame_to_message`/`message_to_frame` to `shm_msg_to_message`/`message_to_shm_msg`
- Remove `roam-frame` re-exports (`Frame`, `MsgDesc`, `Payload`, `INLINE_PAYLOAD_*`) from `roam-shm`'s public API
- `ShmHost::extract_payload` now returns `Vec<u8>` directly instead of `Payload` enum
- `PollResult::messages` contains `(PeerId, ShmMsg)` pairs instead of `(PeerId, Frame)`
- Update all tests (roundtrip, stress, mmap, error_scenarios, transport) to use `ShmMsg`

## Test plan

- [ ] All existing `roam-shm` tests pass (roundtrip, stress, mmap, error_scenarios, transport)
- [ ] Pre-push hooks pass (format, lint, tests)