### PR TITLE
Instrument tokio sync primitives with peeps-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "facet"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#e38260e30e02ffd3d5e67821bedfcd0750b06788"
+source = "git+https://github.com/facet-rs/facet?branch=main#910995c970b160809f678f87c5608082ec61a84d"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "facet-core"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#e38260e30e02ffd3d5e67821bedfcd0750b06788"
+source = "git+https://github.com/facet-rs/facet?branch=main#910995c970b160809f678f87c5608082ec61a84d"
 dependencies = [
  "autocfg",
  "camino",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-parse"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#e38260e30e02ffd3d5e67821bedfcd0750b06788"
+source = "git+https://github.com/facet-rs/facet?branch=main#910995c970b160809f678f87c5608082ec61a84d"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "facet-macro-types"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#e38260e30e02ffd3d5e67821bedfcd0750b06788"
+source = "git+https://github.com/facet-rs/facet?branch=main#910995c970b160809f678f87c5608082ec61a84d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "facet-macros"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#e38260e30e02ffd3d5e67821bedfcd0750b06788"
+source = "git+https://github.com/facet-rs/facet?branch=main#910995c970b160809f678f87c5608082ec61a84d"
 dependencies = [
  "facet-macros-impl",
 ]
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "facet-macros-impl"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#e38260e30e02ffd3d5e67821bedfcd0750b06788"
+source = "git+https://github.com/facet-rs/facet?branch=main#910995c970b160809f678f87c5608082ec61a84d"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "facet-path"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#e38260e30e02ffd3d5e67821bedfcd0750b06788"
+source = "git+https://github.com/facet-rs/facet?branch=main#910995c970b160809f678f87c5608082ec61a84d"
 dependencies = [
  "facet-core",
 ]
@@ -912,7 +912,7 @@ dependencies = [
 [[package]]
 name = "facet-reflect"
 version = "0.43.2"
-source = "git+https://github.com/facet-rs/facet?branch=main#e38260e30e02ffd3d5e67821bedfcd0750b06788"
+source = "git+https://github.com/facet-rs/facet?branch=main#910995c970b160809f678f87c5608082ec61a84d"
 dependencies = [
  "facet-core",
  "facet-path",
@@ -1563,7 +1563,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1807,7 +1807,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1924,9 +1924,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeps-sync"
+version = "0.1.0"
+source = "git+https://github.com/bearcove/peeps?branch=main#33e4037744253c902c2f925c640cb6020ce1dc18"
+dependencies = [
+ "peeps-types",
+ "tokio",
+]
+
+[[package]]
 name = "peeps-tasks"
 version = "0.1.0"
-source = "git+https://github.com/bearcove/peeps?branch=main#2e00454e83aacd0a4d7e96a9f623131dc63e7985"
+source = "git+https://github.com/bearcove/peeps?branch=main#33e4037744253c902c2f925c640cb6020ce1dc18"
 dependencies = [
  "backtrace",
  "facet",
@@ -1937,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "peeps-types"
 version = "0.1.0"
-source = "git+https://github.com/bearcove/peeps?branch=main#2e00454e83aacd0a4d7e96a9f623131dc63e7985"
+source = "git+https://github.com/bearcove/peeps?branch=main#33e4037744253c902c2f925c640cb6020ce1dc18"
 dependencies = [
  "facet",
  "inventory",
@@ -2058,7 +2067,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2296,6 +2305,7 @@ dependencies = [
  "facet-value",
  "futures-util",
  "http",
+ "peeps-sync",
  "reqwest",
  "roam-hash",
  "roam-schema",
@@ -2364,6 +2374,7 @@ dependencies = [
  "futures-util",
  "gloo-timers",
  "inventory",
+ "peeps-sync",
  "peeps-tasks",
  "peeps-types",
  "roam",
@@ -2387,6 +2398,7 @@ dependencies = [
  "inventory",
  "libc",
  "libproc",
+ "peeps-sync",
  "peeps-tasks",
  "peeps-types",
  "roam",
@@ -2432,6 +2444,7 @@ dependencies = [
  "facet",
  "facet-json",
  "facet-pretty",
+ "peeps-sync",
  "rand",
  "reqwest",
  "roam",
@@ -2448,6 +2461,7 @@ name = "roam-tracing"
 version = "3.0.0"
 dependencies = [
  "facet",
+ "peeps-sync",
  "roam",
  "tokio",
  "tracing",
@@ -2502,7 +2516,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2885,7 +2899,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3444,7 +3458,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ ur-taking-me-with-you = { path = "rust/ur-taking-me-with-you", version = "3.0.0"
 roam-task-local = { path = "rust/roam-task-local", version = "3.0.0" }
 peeps-tasks = { version = "0.1.0", git = "https://github.com/bearcove/peeps", branch = "main" }
 peeps-types = { version = "0.1.0", git = "https://github.com/bearcove/peeps", branch = "main" }
+peeps-sync = { version = "0.1.0", git = "https://github.com/bearcove/peeps", branch = "main" }
 
 # # Uncomment to develop peeps
 # peeps = { path = "../peeps/crates/peeps" }
@@ -68,6 +69,7 @@ peeps-types = { version = "0.1.0", git = "https://github.com/bearcove/peeps", br
 # peeps-locks = { path = "../peeps/crates/peeps-locks" }
 # peeps-roam = { path = "../peeps/crates/peeps-roam" }
 # peeps-types = { path = "../peeps/crates/peeps-types" }
+# peeps-sync = { path = "../peeps/crates/peeps-sync" }
 
 inventory = "0.3"
 

--- a/rust/roam-http-bridge/Cargo.toml
+++ b/rust/roam-http-bridge/Cargo.toml
@@ -30,6 +30,7 @@ facet-value.workspace = true
 
 axum = { version = "0.8", features = ["ws"] }
 tokio.workspace = true
+peeps-sync.workspace = true
 # Zero-cost tracing: compiles to nothing when feature is disabled
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 http = "1"

--- a/rust/roam-session/Cargo.toml
+++ b/rust/roam-session/Cargo.toml
@@ -34,6 +34,7 @@ tracing = { workspace = true, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true
 peeps-tasks.workspace = true
+peeps-sync.workspace = true
 futures-util = { version = "0.3", default-features = false, features = [
   "std",
   "async-await-macro",

--- a/rust/roam-session/src/channel.rs
+++ b/rust/roam-session/src/channel.rs
@@ -33,7 +33,7 @@ use crate::{CHANNEL_SIZE, ChannelId, DriverMessage, IncomingChannelMessage, get_
 /// let sum = fut.await?;
 /// ```
 pub fn channel<T: 'static>() -> (Tx<T>, Rx<T>) {
-    let (sender, receiver) = crate::runtime::channel(CHANNEL_SIZE);
+    let (sender, receiver) = crate::runtime::channel("roam_channel", CHANNEL_SIZE);
 
     // Check if we're in a dispatch context - if so, create bound channels
     if let Some(ctx) = get_dispatch_context() {
@@ -607,7 +607,7 @@ mod tests {
 
     #[tokio::test]
     async fn tx_drop_fallback_handles_closed_driver_channel() {
-        let (driver_tx, mut driver_rx) = crate::runtime::channel::<DriverMessage>(1);
+        let (driver_tx, mut driver_rx) = crate::runtime::channel::<DriverMessage>("test_driver", 1);
 
         driver_tx
             .try_send(DriverMessage::Data {
@@ -617,7 +617,8 @@ mod tests {
             })
             .expect("seed message should fill single-slot channel");
 
-        let (inner_tx, _inner_rx) = crate::runtime::channel::<IncomingChannelMessage>(1);
+        let (inner_tx, _inner_rx) =
+            crate::runtime::channel::<IncomingChannelMessage>("test_inner", 1);
         let mut tx: Tx<Vec<u8>> = Tx::new(4242, inner_tx);
         tx.conn_id = ConnectionId::ROOT;
         tx.sender = SenderSlot::empty();

--- a/rust/roam-session/src/forwarding.rs
+++ b/rust/roam-session/src/forwarding.rs
@@ -117,7 +117,8 @@ impl ServiceDispatcher for ForwardingDispatcher {
                         );
 
                         // Set up forwarding: upstream → downstream
-                        let (tx, mut rx) = crate::runtime::channel::<IncomingChannelMessage>(64);
+                        let (tx, mut rx) =
+                            crate::runtime::channel::<IncomingChannelMessage>("fwd_resp_chan", 64);
                         upstream.register_incoming(upstream_id, tx);
 
                         let task_tx_clone = task_tx.clone();
@@ -192,12 +193,12 @@ impl ServiceDispatcher for ForwardingDispatcher {
                 channel_map.push((downstream_id, upstream_id));
 
                 // Buffer for downstream → upstream (client sends Data)
-                let (ds_to_us_tx, ds_to_us_rx) = crate::runtime::channel(64);
+                let (ds_to_us_tx, ds_to_us_rx) = crate::runtime::channel("fwd_ds_to_us", 64);
                 registry.register_incoming(downstream_id, ds_to_us_tx);
                 ds_to_us_rxs.push(ds_to_us_rx);
 
                 // Buffer for upstream → downstream (server sends Data)
-                let (us_to_ds_tx, us_to_ds_rx) = crate::runtime::channel(64);
+                let (us_to_ds_tx, us_to_ds_rx) = crate::runtime::channel("fwd_us_to_ds", 64);
                 upstream.register_incoming(upstream_id, us_to_ds_tx);
                 us_to_ds_rxs.push(us_to_ds_rx);
             }

--- a/rust/roam-session/src/runtime/mod.rs
+++ b/rust/roam-session/src/runtime/mod.rs
@@ -23,8 +23,8 @@
 //! runtime::spawn(async { /* ... */ });
 //!
 //! // Create channels
-//! let (tx, rx) = runtime::channel(16);
-//! let (otx, orx) = runtime::oneshot();
+//! let (tx, rx) = runtime::channel("my_channel", 16);
+//! let (otx, orx) = runtime::oneshot("my_oneshot");
 //!
 //! // Timeouts and sleeping
 //! runtime::sleep(Duration::from_secs(1)).await;

--- a/rust/roam-session/src/runtime/tokio_runtime.rs
+++ b/rust/roam-session/src/runtime/tokio_runtime.rs
@@ -3,27 +3,31 @@
 use std::future::Future;
 use std::time::Duration;
 
-// Re-export tokio sync types directly
+// Re-export tokio Mutex (not wrapped by peeps-sync)
 pub use tokio::sync::Mutex;
-pub use tokio::sync::mpsc::{
-    Receiver, Sender, UnboundedReceiver, UnboundedSender, channel, error::SendError,
-    unbounded_channel,
+
+// Re-export peeps-sync channel types
+pub use peeps_sync::{
+    OneshotReceiver, OneshotSender, Receiver, Sender, UnboundedReceiver, UnboundedSender, channel,
+    oneshot_channel, unbounded_channel,
 };
-pub use tokio::sync::oneshot::{Receiver as OneshotReceiver, Sender as OneshotSender};
+
+// Re-export tokio error types (peeps-sync uses the same ones)
+pub use tokio::sync::mpsc::error::SendError;
 
 /// Create a bounded mpsc channel.
-pub fn bounded<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
-    channel(buffer)
+pub fn bounded<T>(name: impl Into<String>, buffer: usize) -> (Sender<T>, Receiver<T>) {
+    channel(name, buffer)
 }
 
 /// Create an unbounded mpsc channel.
-pub fn unbounded<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
-    unbounded_channel()
+pub fn unbounded<T>(name: impl Into<String>) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
+    unbounded_channel(name)
 }
 
 /// Create a oneshot channel.
-pub fn oneshot<T>() -> (OneshotSender<T>, OneshotReceiver<T>) {
-    tokio::sync::oneshot::channel()
+pub fn oneshot<T>(name: impl Into<String>) -> (OneshotSender<T>, OneshotReceiver<T>) {
+    oneshot_channel(name)
 }
 
 /// Handle that can be used to abort a spawned task.

--- a/rust/roam-session/src/tests.rs
+++ b/rust/roam-session/src/tests.rs
@@ -51,7 +51,7 @@ async fn tx_serializes_and_rx_deserializes() {
 
 /// Create a test registry with a dummy task channel.
 fn test_registry() -> ChannelRegistry {
-    let (task_tx, _task_rx) = crate::runtime::channel(10);
+    let (task_tx, _task_rx) = crate::runtime::channel("test", 10);
     ChannelRegistry::new(task_tx)
 }
 
@@ -59,7 +59,7 @@ fn test_registry() -> ChannelRegistry {
 #[tokio::test]
 async fn data_after_close_is_rejected() {
     let mut registry = test_registry();
-    let (tx, _rx) = crate::runtime::channel(10);
+    let (tx, _rx) = crate::runtime::channel("test", 10);
     registry.register_incoming(42, tx);
 
     // Close the channel
@@ -77,7 +77,7 @@ async fn channel_registry_routes_data_to_registered_channel() {
     let mut registry = test_registry();
 
     // Register a channel
-    let (tx, mut rx) = crate::runtime::channel(10);
+    let (tx, mut rx) = crate::runtime::channel("test", 10);
     registry.register_incoming(42, tx);
 
     // Data to registered channel should succeed
@@ -97,7 +97,7 @@ async fn channel_registry_routes_data_to_registered_channel() {
 #[tokio::test]
 async fn channel_registry_close_terminates_channel() {
     let mut registry = test_registry();
-    let (tx, mut rx) = crate::runtime::channel(10);
+    let (tx, mut rx) = crate::runtime::channel("test", 10);
     registry.register_incoming(42, tx);
 
     // Send some data
@@ -121,10 +121,10 @@ async fn channel_registry_close_terminates_channel() {
 
 #[tokio::test]
 async fn channel_registry_drop_does_not_emit_explicit_close() {
-    let (task_tx, _task_rx) = crate::runtime::channel(10);
+    let (task_tx, _task_rx) = crate::runtime::channel("test", 10);
     let mut registry = ChannelRegistry::new(task_tx);
 
-    let (tx, mut rx) = crate::runtime::channel(10);
+    let (tx, mut rx) = crate::runtime::channel("test", 10);
     registry.register_incoming(42, tx);
     drop(registry);
 

--- a/rust/roam-session/src/types.rs
+++ b/rust/roam-session/src/types.rs
@@ -520,7 +520,7 @@ impl ChannelRegistry {
             trace!(channel_id, "bind_rx_channel: registering incoming channel");
 
             // Create channel and set receiver slot
-            let (tx, rx) = crate::runtime::channel(RX_STREAM_BUFFER_SIZE);
+            let (tx, rx) = crate::runtime::channel("rx_stream_bind", RX_STREAM_BUFFER_SIZE);
 
             if let Ok(mut receiver_field) = ps.field_by_name("receiver")
                 && let Ok(slot) = receiver_field.get_mut::<ReceiverSlot>()

--- a/rust/roam-shm/Cargo.toml
+++ b/rust/roam-shm/Cargo.toml
@@ -18,6 +18,7 @@ diagnostics = ["roam-session/diagnostics"]
 
 [dependencies]
 peeps-tasks.workspace = true
+peeps-sync.workspace = true
 shm-primitives.workspace = true
 roam-frame.workspace = true
 ur-taking-me-with-you.workspace = true

--- a/rust/roam-telemetry/Cargo.toml
+++ b/rust/roam-telemetry/Cargo.toml
@@ -32,6 +32,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json"] }
 
 # Async runtime
 tokio = { workspace = true, features = ["sync", "time", "rt"] }
+peeps-sync.workspace = true
 
 # Utilities
 rand = "0.9"

--- a/rust/roam-tracing/Cargo.toml
+++ b/rust/roam-tracing/Cargo.toml
@@ -25,3 +25,4 @@ tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "s
 
 # Async runtime
 tokio = { version = "1", features = ["sync", "rt"] }
+peeps-sync.workspace = true


### PR DESCRIPTION
Replace direct tokio::sync usage with peeps_sync wrappers for
diagnostic visibility into channels and oneshot across the codebase:

- roam-session: runtime abstraction layer re-exports peeps-sync types,
  propagating to driver, connection_handle, channel, forwarding, tests
- roam-http-bridge: mpsc + oneshot for WebSocket session handling
- roam-tracing: mpsc for trace host records
- roam-telemetry: mpsc for telemetry export
- roam-shm: oneshot + mpsc for SHM driver operations
