### PR TITLE
codegen(ts): emit type aliases for transparent newtypes

### DIFF
--- a/rust/roam-codegen/src/targets/typescript/mod.rs
+++ b/rust/roam-codegen/src/targets/typescript/mod.rs
@@ -193,6 +193,16 @@ mod tests {
         next: Option<Box<RecursiveNode>>,
     }
 
+    #[derive(Facet)]
+    #[repr(transparent)]
+    #[facet(transparent)]
+    struct SessionId(pub String);
+
+    #[derive(Facet)]
+    struct SessionSummary {
+        id: SessionId,
+    }
+
     #[test]
     fn generated_typescript_contains_no_postcard_primitive_usage() {
         let echo = method_descriptor::<(String,), String>("TestSvc", "echo", &["message"], None);
@@ -243,6 +253,32 @@ mod tests {
         assert!(
             generated.contains("{ kind: 'ref', name: 'RecursiveNode' }"),
             "recursive references must emit ref schemas:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn generated_typescript_emits_alias_for_transparent_newtype() {
+        let summarize = method_descriptor::<(SessionId,), SessionSummary>(
+            "SessionSvc",
+            "summarize",
+            &["id"],
+            None,
+        );
+        let methods = Box::leak(vec![summarize].into_boxed_slice());
+        let service = ServiceDescriptor {
+            service_name: "SessionSvc",
+            methods,
+            doc: None,
+        };
+
+        let generated = generate_service(&service);
+        assert!(
+            generated.contains("export type SessionId = string;"),
+            "transparent named newtypes must emit a type alias:\n{generated}"
+        );
+        assert!(
+            generated.contains("id: SessionId;"),
+            "uses of transparent named newtypes must keep alias name:\n{generated}"
         );
     }
 }

--- a/rust/roam-codegen/src/targets/typescript/types.rs
+++ b/rust/roam-codegen/src/targets/typescript/types.rs
@@ -13,6 +13,25 @@ use roam_types::{
     classify_variant, is_bytes,
 };
 
+fn transparent_named_alias(shape: &'static Shape) -> Option<(&'static str, &'static Shape)> {
+    if !shape.is_transparent() {
+        return None;
+    }
+    let name = extract_type_name(shape.type_identifier)?;
+    let inner = shape.inner?;
+    Some((name, inner))
+}
+
+fn extract_type_name(type_identifier: &'static str) -> Option<&'static str> {
+    if type_identifier.is_empty()
+        || type_identifier.starts_with('(')
+        || type_identifier.starts_with('[')
+    {
+        return None;
+    }
+    Some(type_identifier)
+}
+
 /// Generate TypeScript field access expression.
 /// Uses bracket notation for numeric field names (tuple fields), dot notation otherwise.
 pub fn ts_field_access(expr: &str, field_name: &str) -> String {
@@ -38,6 +57,15 @@ pub fn collect_named_types(service: &ServiceDescriptor) -> Vec<(String, &'static
         seen: &mut HashSet<String>,
         types: &mut Vec<(String, &'static Shape)>,
     ) {
+        if let Some((name, inner)) = transparent_named_alias(shape) {
+            if !seen.contains(name) {
+                seen.insert(name.to_string());
+                visit(inner, seen, types);
+                types.push((name.to_string(), shape));
+            }
+            return;
+        }
+
         match classify_shape(shape) {
             ShapeKind::Struct(StructInfo {
                 name: Some(name),
@@ -119,6 +147,14 @@ pub fn generate_named_types(named_types: &[(String, &'static Shape)]) -> String 
     out.push_str("// Named type definitions\n");
 
     for (name, shape) in named_types {
+        if let Some((_, inner)) = transparent_named_alias(shape) {
+            out.push_str(&format!(
+                "export type {name} = {};\n\n",
+                ts_type_base_named(inner)
+            ));
+            continue;
+        }
+
         match classify_shape(shape) {
             ShapeKind::Struct(StructInfo { fields, .. }) => {
                 out.push_str(&format!("export interface {} {{\n", name));
@@ -167,6 +203,10 @@ pub fn generate_named_types(named_types: &[(String, &'static Shape)]) -> String 
 /// Convert Shape to TypeScript type string, using named types when available.
 /// This handles container types recursively, using named types at every level.
 pub fn ts_type_base_named(shape: &'static Shape) -> String {
+    if let Some((name, _)) = transparent_named_alias(shape) {
+        return name.to_string();
+    }
+
     match classify_shape(shape) {
         // Named types - use the name directly
         ShapeKind::Struct(StructInfo {


### PR DESCRIPTION
## Summary
Fix TypeScript codegen so transparent named newtypes are preserved as named aliases instead of being inlined to their inner scalar type.

## Changes
- detect transparent named wrappers during TypeScript type collection
- emit `export type Alias = Inner` for transparent named wrappers
- preserve alias names at usage sites (`SessionId` instead of `string`)
- add a regression test that verifies alias emission and alias usage

## Test Plan
- cargo fmt --all -- --check
- cargo check -p roam-codegen
- cargo nextest run -p roam-codegen

Closes #213
