### PR TITLE
Add NoopCaller and remove From<DriverCaller> impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Roam are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the implicit `From<DriverCaller> for ()` conversion. Use `NoopCaller` when you need to retain root connection liveness without exposing root RPC methods.
+
 - No entries yet.
 
 ## [7.0.0] - 2026-03-02

--- a/rust/roam-bench/benches/rpc.rs
+++ b/rust/roam-bench/benches/rpc.rs
@@ -25,7 +25,7 @@ const ZEROCOPY_PAYLOAD_SIZES: &[usize] = &[
 
 mod roam_zerocopy_bench {
     use moire::task::FutureExt;
-    use roam_core::{acceptor, initiator, memory_link_pair};
+    use roam_core::{NoopCaller, acceptor, initiator, memory_link_pair};
     use roam_shm::varslot::SizeClassConfig;
     use roam_shm::{Segment, SegmentConfig, create_test_link_pair};
     use roam_stream::StreamLink;
@@ -55,12 +55,15 @@ mod roam_zerocopy_bench {
     pub async fn setup_mem() -> ZerocopyClient {
         let (a, b) = memory_link_pair(64);
 
-        let server_task = moire::task::spawn(
+        let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+        let _server_task = moire::task::spawn(
             async move {
-                let ((), _sh) = acceptor(b)
-                    .establish::<()>(ZerocopyDispatcher::new(Handler))
+                let (_caller, _sh) = acceptor(b)
+                    .establish::<NoopCaller>(ZerocopyDispatcher::new(Handler))
                     .await
                     .expect("server handshake failed");
+                let _ = server_ready_tx.send(());
+                std::future::pending::<()>().await;
             }
             .named("server_setup"),
         );
@@ -70,7 +73,7 @@ mod roam_zerocopy_bench {
             .await
             .expect("client handshake failed");
 
-        server_task.await.expect("server setup failed");
+        server_ready_rx.await.expect("server setup failed");
 
         client
     }
@@ -116,12 +119,15 @@ mod roam_zerocopy_bench {
             .expect("create_test_link_pair");
         std::mem::forget(dir);
 
-        let server_task = moire::task::spawn(
+        let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+        let _server_task = moire::task::spawn(
             async move {
-                let ((), _sh) = acceptor(b)
-                    .establish::<()>(ZerocopyDispatcher::new(Handler))
+                let (_caller, _sh) = acceptor(b)
+                    .establish::<NoopCaller>(ZerocopyDispatcher::new(Handler))
                     .await
                     .expect("server handshake failed");
+                let _ = server_ready_tx.send(());
+                std::future::pending::<()>().await;
             }
             .named("server_setup"),
         );
@@ -131,7 +137,7 @@ mod roam_zerocopy_bench {
             .await
             .expect("client handshake failed");
 
-        server_task.await.expect("server setup failed");
+        server_ready_rx.await.expect("server setup failed");
 
         client
     }
@@ -140,14 +146,17 @@ mod roam_zerocopy_bench {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let server_task = moire::task::spawn(
+        let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+        let _server_task = moire::task::spawn(
             async move {
                 let (stream, _) = listener.accept().await.unwrap();
                 stream.set_nodelay(true).unwrap();
-                let ((), _sh) = acceptor(StreamLink::tcp(stream))
-                    .establish::<()>(ZerocopyDispatcher::new(Handler))
+                let (_caller, _sh) = acceptor(StreamLink::tcp(stream))
+                    .establish::<NoopCaller>(ZerocopyDispatcher::new(Handler))
                     .await
                     .expect("server handshake failed");
+                let _ = server_ready_tx.send(());
+                std::future::pending::<()>().await;
             }
             .named("server_setup"),
         );
@@ -160,7 +169,7 @@ mod roam_zerocopy_bench {
             .await
             .expect("client handshake failed");
 
-        server_task.await.expect("server setup failed");
+        server_ready_rx.await.expect("server setup failed");
 
         client
     }
@@ -225,7 +234,7 @@ define_zerocopy_transport_benches!(
 
 mod roam_bench {
     use moire::task::FutureExt;
-    use roam_core::{acceptor, initiator, memory_link_pair};
+    use roam_core::{NoopCaller, acceptor, initiator, memory_link_pair};
 
     #[roam::service]
     pub trait Bench {
@@ -257,12 +266,15 @@ mod roam_bench {
     pub async fn setup() -> BenchClient {
         let (a, b) = memory_link_pair(64);
 
-        let server_task = moire::task::spawn(
+        let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+        let _server_task = moire::task::spawn(
             async move {
-                let ((), _sh) = acceptor(b)
-                    .establish::<()>(BenchDispatcher::new(Handler))
+                let (_caller, _sh) = acceptor(b)
+                    .establish::<NoopCaller>(BenchDispatcher::new(Handler))
                     .await
                     .expect("server handshake failed");
+                let _ = server_ready_tx.send(());
+                std::future::pending::<()>().await;
             }
             .named("server_setup"),
         );
@@ -272,7 +284,7 @@ mod roam_bench {
             .await
             .expect("client handshake failed");
 
-        server_task.await.expect("server setup failed");
+        server_ready_rx.await.expect("server setup failed");
 
         client
     }
@@ -333,7 +345,7 @@ mod roam_shm_bench {
     use std::sync::Arc;
 
     use moire::task::FutureExt;
-    use roam_core::{acceptor, initiator};
+    use roam_core::{NoopCaller, acceptor, initiator};
     use roam_shm::varslot::SizeClassConfig;
     use roam_shm::{Segment, SegmentConfig, create_test_link_pair};
 
@@ -375,12 +387,15 @@ mod roam_shm_bench {
         // Leak the tempdir so the segment file lives for the entire benchmark run.
         std::mem::forget(dir);
 
-        let server_task = moire::task::spawn(
+        let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+        let _server_task = moire::task::spawn(
             async move {
-                let ((), _sh) = acceptor(b)
-                    .establish::<()>(BenchDispatcher::new(Handler))
+                let (_caller, _sh) = acceptor(b)
+                    .establish::<NoopCaller>(BenchDispatcher::new(Handler))
                     .await
                     .expect("server handshake failed");
+                let _ = server_ready_tx.send(());
+                std::future::pending::<()>().await;
             }
             .named("server_setup"),
         );
@@ -390,7 +405,7 @@ mod roam_shm_bench {
             .await
             .expect("client handshake failed");
 
-        server_task.await.expect("server setup failed");
+        server_ready_rx.await.expect("server setup failed");
 
         client
     }
@@ -449,7 +464,7 @@ fn roam_shm_stream(bencher: divan::Bencher, n: usize) {
 
 mod roam_tcp_bench {
     use moire::task::FutureExt;
-    use roam_core::{acceptor, initiator};
+    use roam_core::{NoopCaller, acceptor, initiator};
     use roam_stream::StreamLink;
 
     use tokio::net::TcpListener;
@@ -460,14 +475,17 @@ mod roam_tcp_bench {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let server_task = moire::task::spawn(
+        let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+        let _server_task = moire::task::spawn(
             async move {
                 let (stream, _) = listener.accept().await.unwrap();
                 stream.set_nodelay(true).unwrap();
-                let ((), _sh) = acceptor(StreamLink::tcp(stream))
-                    .establish::<()>(BenchDispatcher::new(Handler))
+                let (_caller, _sh) = acceptor(StreamLink::tcp(stream))
+                    .establish::<NoopCaller>(BenchDispatcher::new(Handler))
                     .await
                     .expect("server handshake failed");
+                let _ = server_ready_tx.send(());
+                std::future::pending::<()>().await;
             }
             .named("server_setup"),
         );
@@ -480,7 +498,7 @@ mod roam_tcp_bench {
             .await
             .expect("client handshake failed");
 
-        server_task.await.expect("server setup failed");
+        server_ready_rx.await.expect("server setup failed");
 
         client
     }

--- a/rust/roam-core/CHANGELOG.md
+++ b/rust/roam-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the implicit `From<DriverCaller> for ()` conversion and add `NoopCaller` for liveness-only root handles.
+
 ## [7.0.0-alpha.3](https://github.com/bearcove/roam/compare/roam-core-v7.0.0-alpha.2...roam-core-v7.0.0-alpha.3) - 2026-03-03
 
 ### Other

--- a/rust/roam-core/src/driver.rs
+++ b/rust/roam-core/src/driver.rs
@@ -150,10 +150,17 @@ impl ChannelSink for DriverChannelSink {
     }
 }
 
-/// Cloneable handle for making outgoing calls through a connection.
+/// Liveness-only handle for a connection root.
 ///
-impl From<DriverCaller> for () {
-    fn from(_: DriverCaller) {}
+/// Keeps the root connection alive but intentionally exposes no outbound RPC API.
+#[must_use = "Dropping NoopCaller may close the connection if it is the last caller."]
+#[derive(Clone)]
+pub struct NoopCaller(#[allow(dead_code)] DriverCaller);
+
+impl From<DriverCaller> for NoopCaller {
+    fn from(caller: DriverCaller) -> Self {
+        Self(caller)
+    }
 }
 
 #[derive(Clone)]

--- a/rust/roam-core/src/wasm_driver.rs
+++ b/rust/roam-core/src/wasm_driver.rs
@@ -107,8 +107,17 @@ impl Caller for DriverCaller {
     }
 }
 
-impl From<DriverCaller> for () {
-    fn from(_: DriverCaller) {}
+/// Liveness-only handle for a connection root.
+///
+/// Keeps the root connection alive but intentionally exposes no outbound RPC API.
+#[must_use = "Dropping NoopCaller may close the connection if it is the last caller."]
+#[derive(Clone)]
+pub struct NoopCaller(#[allow(dead_code)] DriverCaller);
+
+impl From<DriverCaller> for NoopCaller {
+    fn from(caller: DriverCaller) -> Self {
+        Self(caller)
+    }
 }
 
 /// Wasm-only driver. No channel support.

--- a/rust/roam-macros-core/src/lib.rs
+++ b/rust/roam-macros-core/src/lib.rs
@@ -509,6 +509,7 @@ fn generate_client(parsed: &ServiceTrait, roam: &TokenStream2) -> TokenStream2 {
 
     quote! {
         #[doc = #client_doc]
+        #[must_use = "Dropping this client may close the connection if it is the last caller."]
         #[derive(Clone)]
         pub struct #client_name {
             caller: #roam::ErasedCaller,

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__adder_infallible.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__adder_infallible.snap
@@ -84,6 +84,7 @@ where
     }
 }
 #[doc = "Client for the `Adder` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
 #[derive(Clone)]
 pub struct AdderClient {
     caller: ::roam::ErasedCaller,

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
@@ -163,6 +163,7 @@ where
     }
 }
 #[doc = "Client for the `WordLab` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
 #[derive(Clone)]
 pub struct WordLabClient {
     caller: ::roam::ErasedCaller,

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_cow_return.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_cow_return.snap
@@ -85,6 +85,7 @@ where
     }
 }
 #[doc = "Client for the `TextSvc` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
 #[derive(Clone)]
 pub struct TextSvcClient {
     caller: ::roam::ErasedCaller,

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return.snap
@@ -87,6 +87,7 @@ where
     }
 }
 #[doc = "Client for the `Hasher` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
 #[derive(Clone)]
 pub struct HasherClient {
     caller: ::roam::ErasedCaller,

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return_call_style.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return_call_style.snap
@@ -87,6 +87,7 @@ where
     }
 }
 #[doc = "Client for the `Hasher` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
 #[derive(Clone)]
 pub struct HasherClient {
     caller: ::roam::ErasedCaller,

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__fallible.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__fallible.snap
@@ -86,6 +86,7 @@ where
     }
 }
 #[doc = "Client for the `Calc` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
 #[derive(Clone)]
 pub struct CalcClient {
     caller: ::roam::ErasedCaller,

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__no_args.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__no_args.snap
@@ -84,6 +84,7 @@ where
     }
 }
 #[doc = "Client for the `Ping` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
 #[derive(Clone)]
 pub struct PingClient {
     caller: ::roam::ErasedCaller,

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__streaming_tx.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__streaming_tx.snap
@@ -106,6 +106,7 @@ where
     }
 }
 #[doc = "Client for the `Streamer` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
 #[derive(Clone)]
 pub struct StreamerClient {
     caller: ::roam::ErasedCaller,

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__unit_return.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__unit_return.snap
@@ -84,6 +84,7 @@ where
     }
 }
 #[doc = "Client for the `Notifier` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
 #[derive(Clone)]
 pub struct NotifierClient {
     caller: ::roam::ErasedCaller,

--- a/rust/roam/CHANGELOG.md
+++ b/rust/roam/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Remove the implicit `From<DriverCaller> for ()` conversion. Use `NoopCaller` with `establish::<NoopCaller>(...)` when you want root liveness without a root client API.


### PR DESCRIPTION
Replace implicit From<DriverCaller> for () with NoopCaller as a liveness-only root handle
Update core and wasm drivers to establish with NoopCaller and adapt benches, tests, and codegen-generated clients Add must_use notes in generated client types and update changelogs