### PR TITLE
Fix channel stream liveness across caller drops

### DIFF
--- a/rust/roam-core/src/driver.rs
+++ b/rust/roam-core/src/driver.rs
@@ -9,10 +9,10 @@ use tokio::sync::Semaphore;
 
 use moire::task::FutureExt as _;
 use roam_types::{
-    Caller, ChannelBinder, ChannelBody, ChannelClose, ChannelId, ChannelItem, ChannelMessage,
-    ChannelSink, CreditSink, Handler, IdAllocator, IncomingChannelMessage, MaybeSend, Payload,
-    ReplySink, RequestBody, RequestCall, RequestId, RequestMessage, RequestResponse, RoamError,
-    SelfRef, TxError,
+    Caller, ChannelBinder, ChannelBody, ChannelClose, ChannelId, ChannelItem,
+    ChannelLivenessHandle, ChannelMessage, ChannelSink, CreditSink, Handler, IdAllocator,
+    IncomingChannelMessage, MaybeSend, Payload, ReplySink, RequestBody, RequestCall, RequestId,
+    RequestMessage, RequestResponse, RoamError, SelfRef, TxError,
 };
 
 use crate::session::{ConnectionHandle, ConnectionMessage, ConnectionSender, DropControlRequest};
@@ -168,6 +168,7 @@ struct DriverChannelBinder {
     sender: ConnectionSender,
     shared: Arc<DriverShared>,
     local_control_tx: mpsc::UnboundedSender<DriverLocalControl>,
+    drop_guard: Option<Arc<CallerDropGuard>>,
 }
 
 impl DriverChannelBinder {
@@ -254,6 +255,12 @@ impl ChannelBinder for DriverChannelBinder {
         channel_id: ChannelId,
     ) -> tokio::sync::mpsc::Receiver<IncomingChannelMessage> {
         self.register_rx_channel(channel_id)
+    }
+
+    fn channel_liveness(&self) -> Option<ChannelLivenessHandle> {
+        self.drop_guard
+            .as_ref()
+            .map(|guard| guard.clone() as ChannelLivenessHandle)
     }
 }
 
@@ -370,6 +377,12 @@ impl ChannelBinder for DriverCaller {
         channel_id: ChannelId,
     ) -> tokio::sync::mpsc::Receiver<IncomingChannelMessage> {
         self.register_rx_channel(channel_id)
+    }
+
+    fn channel_liveness(&self) -> Option<ChannelLivenessHandle> {
+        self._drop_guard
+            .as_ref()
+            .map(|guard| guard.clone() as ChannelLivenessHandle)
     }
 }
 
@@ -492,8 +505,14 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
     // r[impl rpc.caller.liveness.last-drop-closes-connection]
     // r[impl rpc.caller.liveness.root-internal-close]
     // r[impl rpc.caller.liveness.root-teardown-condition]
-    pub fn caller(&self) -> DriverCaller {
-        let drop_guard = if let Some(seed) = &self.drop_control_seed {
+    fn existing_drop_guard(&self) -> Option<Arc<CallerDropGuard>> {
+        self.drop_guard.lock().as_ref().and_then(Weak::upgrade)
+    }
+
+    fn connection_drop_guard(&self) -> Option<Arc<CallerDropGuard>> {
+        let drop_guard = if let Some(existing) = self.existing_drop_guard() {
+            Some(existing)
+        } else if let Some(seed) = &self.drop_control_seed {
             let mut guard = self.drop_guard.lock();
             if let Some(existing) = guard.as_ref().and_then(Weak::upgrade) {
                 Some(existing)
@@ -508,6 +527,11 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
         } else {
             None
         };
+        drop_guard
+    }
+
+    pub fn caller(&self) -> DriverCaller {
+        let drop_guard = self.connection_drop_guard();
         DriverCaller {
             sender: self.sender.clone(),
             shared: Arc::clone(&self.shared),
@@ -521,6 +545,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
             sender: self.sender.clone(),
             shared: Arc::clone(&self.shared),
             local_control_tx: self.local_control_tx.clone(),
+            drop_guard: self.existing_drop_guard(),
         }
     }
 

--- a/rust/roam-core/src/tests/driver_tests.rs
+++ b/rust/roam-core/src/tests/driver_tests.rs
@@ -1,3 +1,4 @@
+use facet::Facet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -7,7 +8,7 @@ use roam_types::{
     ChannelMessage, ChannelSink, Conduit, ConduitRx, ConnectionSettings, Handler,
     IncomingChannelMessage, Message, MessageFamily, MessagePayload, Metadata, MethodId, Parity,
     Payload, ReplySink, RequestBody, RequestCall, RequestCancel, RequestMessage, RequestResponse,
-    RoamError, SelfRef,
+    RoamError, RpcPlan, SelfRef, Tx, bind_channels_caller_args, channel,
 };
 
 use crate::session::{
@@ -128,6 +129,11 @@ impl Handler<DriverReplySink> for BlockingHandler {
         // Block forever — only cancellation (abort) will stop this
         std::future::pending::<()>().await;
     }
+}
+
+#[derive(Facet)]
+struct SubscribeArgs {
+    updates: Tx<u32, 16>,
 }
 
 // r[verify rpc.caller.liveness.refcounted]
@@ -299,6 +305,106 @@ async fn dropping_root_caller_waits_for_virtual_connections_before_session_shutd
 
     drop(vconn_caller);
     drop(server_caller_guard);
+
+    tokio::time::timeout(std::time::Duration::from_millis(500), client_session)
+        .await
+        .expect("timed out waiting for client session to exit")
+        .expect("client session task failed");
+}
+
+// r[verify rpc.channel.binding.caller-args.tx]
+#[tokio::test]
+async fn dropping_root_caller_keeps_session_alive_while_bound_stream_rx_exists() {
+    let (client_conduit, server_conduit) = message_conduit_pair();
+
+    let (client_session_tx, client_session_rx) =
+        tokio::sync::oneshot::channel::<moire::task::JoinHandle<()>>();
+
+    let server_task = moire::task::spawn(
+        async move {
+            let (server_caller, _sh) = acceptor(server_conduit)
+                .establish::<DriverCaller>(())
+                .await
+                .expect("server handshake failed");
+            server_caller
+        }
+        .named("server_setup"),
+    );
+
+    let (root_caller, _sh) = initiator(client_conduit)
+        .spawn_fn(move |fut| {
+            let handle = moire::task::spawn(fut.named("client_session"));
+            let _ = client_session_tx.send(handle);
+        })
+        .establish::<DriverCaller>(())
+        .await
+        .expect("client handshake failed");
+
+    let server_caller = server_task.await.expect("server setup failed");
+    let client_session = client_session_rx.await.expect("client session handle sent");
+
+    let (updates_tx, mut updates_rx) = channel::<u32>();
+    let mut args = SubscribeArgs {
+        updates: updates_tx,
+    };
+    let channel_ids = unsafe {
+        bind_channels_caller_args(
+            (&mut args as *mut SubscribeArgs).cast::<u8>(),
+            RpcPlan::for_type::<SubscribeArgs>(),
+            &root_caller,
+        )
+    };
+    assert_eq!(channel_ids.as_slice(), &[ChannelId(1)]);
+    drop(args);
+    drop(root_caller);
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !client_session.is_finished(),
+        "session should remain alive while a bound stream handle still exists"
+    );
+
+    let value = 123_u32;
+    server_caller
+        .connection_sender()
+        .send(ConnectionMessage::Channel(ChannelMessage {
+            id: channel_ids[0],
+            body: ChannelBody::Item(ChannelItem {
+                item: Payload::outgoing(&value),
+            }),
+        }))
+        .await
+        .expect("send channel item");
+
+    let received = updates_rx
+        .recv()
+        .await
+        .expect("stream should remain usable")
+        .expect("channel should yield one item");
+    assert_eq!(*received, 123);
+
+    server_caller
+        .connection_sender()
+        .send(ConnectionMessage::Channel(ChannelMessage {
+            id: channel_ids[0],
+            body: ChannelBody::Close(ChannelClose {
+                metadata: Default::default(),
+            }),
+        }))
+        .await
+        .expect("send channel close");
+
+    assert!(
+        updates_rx
+            .recv()
+            .await
+            .expect("close should be delivered")
+            .is_none(),
+        "stream should end after explicit close"
+    );
+
+    drop(updates_rx);
+    drop(server_caller);
 
     tokio::time::timeout(std::time::Duration::from_millis(500), client_session)
         .await

--- a/rust/roam-types/src/channel.rs
+++ b/rust/roam-types/src/channel.rs
@@ -20,8 +20,30 @@ use crate::{ChannelClose, ChannelItem, ChannelReset, Metadata, Payload, SelfRef}
 /// The binding stored in a channel core — either a sink or a receiver, never both.
 #[cfg(not(target_arch = "wasm32"))]
 pub enum ChannelBinding {
-    Sink(Arc<dyn ChannelSink>),
-    Receiver(mpsc::Receiver<IncomingChannelMessage>),
+    Sink(BoundChannelSink),
+    Receiver(BoundChannelReceiver),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub trait ChannelLiveness: Send + Sync + 'static {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send + Sync + 'static> ChannelLiveness for T {}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type ChannelLivenessHandle = Arc<dyn ChannelLiveness>;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone)]
+pub struct BoundChannelSink {
+    pub sink: Arc<dyn ChannelSink>,
+    pub liveness: Option<ChannelLivenessHandle>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub struct BoundChannelReceiver {
+    pub receiver: mpsc::Receiver<IncomingChannelMessage>,
+    pub liveness: Option<ChannelLivenessHandle>,
 }
 
 // r[impl rpc.channel.pair]
@@ -55,17 +77,17 @@ impl ChannelCore {
     pub fn get_sink(&self) -> Option<Arc<dyn ChannelSink>> {
         let guard = self.binding.lock().expect("channel core mutex poisoned");
         match guard.as_ref() {
-            Some(ChannelBinding::Sink(sink)) => Some(sink.clone()),
+            Some(ChannelBinding::Sink(bound)) => Some(bound.sink.clone()),
             _ => None,
         }
     }
 
     /// Take the receiver out of the core (for Rx on first recv).
     /// Returns None if no receiver has been set or if it was already taken.
-    pub fn take_receiver(&self) -> Option<mpsc::Receiver<IncomingChannelMessage>> {
+    pub fn take_receiver(&self) -> Option<BoundChannelReceiver> {
         let mut guard = self.binding.lock().expect("channel core mutex poisoned");
         match guard.take() {
-            Some(ChannelBinding::Receiver(rx)) => Some(rx),
+            Some(ChannelBinding::Receiver(bound)) => Some(bound),
             other => {
                 // Put it back if it wasn't a receiver
                 *guard = other;
@@ -222,6 +244,23 @@ impl SinkSlot {
     }
 }
 
+/// Opaque liveness retention slot for bound channel handles.
+#[derive(Facet)]
+#[facet(opaque)]
+pub(crate) struct LivenessSlot {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) inner: Option<ChannelLivenessHandle>,
+}
+
+impl LivenessSlot {
+    pub(crate) fn empty() -> Self {
+        Self {
+            #[cfg(not(target_arch = "wasm32"))]
+            inner: None,
+        }
+    }
+}
+
 /// Receiver-side runtime slot.
 #[derive(Facet)]
 #[facet(opaque)]
@@ -253,6 +292,7 @@ impl ReceiverSlot {
 pub struct Tx<T, const N: usize = 16> {
     pub(crate) sink: SinkSlot,
     pub(crate) core: CoreSlot,
+    pub(crate) liveness: LivenessSlot,
     #[cfg(not(target_arch = "wasm32"))]
     #[facet(opaque)]
     closed: AtomicBool,
@@ -266,6 +306,7 @@ impl<T, const N: usize> Tx<T, N> {
         Self {
             sink: SinkSlot::empty(),
             core: CoreSlot::empty(),
+            liveness: LivenessSlot::empty(),
             #[cfg(not(target_arch = "wasm32"))]
             closed: AtomicBool::new(false),
             _marker: PhantomData,
@@ -278,6 +319,7 @@ impl<T, const N: usize> Tx<T, N> {
         Self {
             sink: SinkSlot::empty(),
             core: CoreSlot { inner: Some(core) },
+            liveness: LivenessSlot::empty(),
             closed: AtomicBool::new(false),
             _marker: PhantomData,
         }
@@ -348,7 +390,18 @@ impl<T, const N: usize> Tx<T, N> {
     #[doc(hidden)]
     #[cfg(not(target_arch = "wasm32"))]
     pub fn bind(&mut self, sink: Arc<dyn ChannelSink>) {
+        self.bind_with_liveness(sink, None);
+    }
+
+    #[doc(hidden)]
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn bind_with_liveness(
+        &mut self,
+        sink: Arc<dyn ChannelSink>,
+        liveness: Option<ChannelLivenessHandle>,
+    ) {
         self.sink.inner = Some(sink);
+        self.liveness.inner = liveness;
     }
 }
 
@@ -423,6 +476,7 @@ impl std::error::Error for TxError {}
 pub struct Rx<T, const N: usize = 16> {
     pub(crate) receiver: ReceiverSlot,
     pub(crate) core: CoreSlot,
+    pub(crate) liveness: LivenessSlot,
     #[facet(opaque)]
     _marker: PhantomData<T>,
 }
@@ -433,6 +487,7 @@ impl<T, const N: usize> Rx<T, N> {
         Self {
             receiver: ReceiverSlot::empty(),
             core: CoreSlot::empty(),
+            liveness: LivenessSlot::empty(),
             _marker: PhantomData,
         }
     }
@@ -443,6 +498,7 @@ impl<T, const N: usize> Rx<T, N> {
         Self {
             receiver: ReceiverSlot::empty(),
             core: CoreSlot { inner: Some(core) },
+            liveness: LivenessSlot::empty(),
             _marker: PhantomData,
         }
     }
@@ -476,9 +532,10 @@ impl<T, const N: usize> Rx<T, N> {
         // On first call, take receiver from shared core into local slot
         if self.receiver.inner.is_none()
             && let Some(core) = &self.core.inner
-            && let Some(rx) = core.take_receiver()
+            && let Some(bound) = core.take_receiver()
         {
-            self.receiver.inner = Some(rx);
+            self.receiver.inner = Some(bound.receiver);
+            self.liveness.inner = bound.liveness;
         }
 
         let receiver = self.receiver.inner.as_mut().ok_or(RxError::Unbound)?;
@@ -501,7 +558,18 @@ impl<T, const N: usize> Rx<T, N> {
     #[doc(hidden)]
     #[cfg(not(target_arch = "wasm32"))]
     pub fn bind(&mut self, receiver: mpsc::Receiver<IncomingChannelMessage>) {
+        self.bind_with_liveness(receiver, None);
+    }
+
+    #[doc(hidden)]
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn bind_with_liveness(
+        &mut self,
+        receiver: mpsc::Receiver<IncomingChannelMessage>,
+        liveness: Option<ChannelLivenessHandle>,
+    ) {
         self.receiver.inner = Some(receiver);
+        self.liveness.inner = liveness;
     }
 }
 
@@ -639,7 +707,10 @@ mod tests {
 
         let (tx, _rx) = channel::<u32>();
         let core = tx.core.inner.as_ref().expect("paired tx should have core");
-        core.set_binding(ChannelBinding::Sink(sink));
+        core.set_binding(ChannelBinding::Sink(BoundChannelSink {
+            sink,
+            liveness: None,
+        }));
         drop(tx);
 
         assert_eq!(sink_impl.close_on_drop_calls.load(Ordering::Acquire), 1);

--- a/rust/roam-types/src/channel_binding.rs
+++ b/rust/roam-types/src/channel_binding.rs
@@ -16,7 +16,8 @@ use tokio::sync::mpsc;
 
 use crate::ChannelId;
 use crate::channel::{
-    ChannelBinding, ChannelSink, CoreSlot, IncomingChannelMessage, ReceiverSlot, SinkSlot,
+    BoundChannelReceiver, BoundChannelSink, ChannelBinding, ChannelLivenessHandle, ChannelSink,
+    CoreSlot, IncomingChannelMessage, ReceiverSlot, SinkSlot,
 };
 use crate::rpc_plan::{ChannelKind, RpcPlan};
 
@@ -43,6 +44,12 @@ pub trait ChannelBinder: Send + Sync {
     ///
     /// The channel ID comes from `Request.channels`.
     fn register_rx(&self, channel_id: ChannelId) -> mpsc::Receiver<IncomingChannelMessage>;
+
+    /// Optional opaque handle that keeps the underlying session/connection alive
+    /// for the lifetime of any bound channel handle.
+    fn channel_liveness(&self) -> Option<ChannelLivenessHandle> {
+        None
+    }
 }
 
 // r[impl rpc.channel.binding.caller-args]
@@ -79,12 +86,13 @@ pub unsafe fn bind_channels_caller_args(
                 ChannelKind::Rx => {
                     let (channel_id, sink) = binder.create_tx(loc.initial_credit);
                     channel_ids.push(channel_id);
+                    let liveness = binder.channel_liveness();
                     if let Ok(mut ps) = channel_poke.into_struct()
                         && let Ok(mut core_field) = ps.field_by_name("core")
                         && let Ok(slot) = core_field.get_mut::<CoreSlot>()
                         && let Some(core) = &slot.inner
                     {
-                        core.set_binding(ChannelBinding::Sink(sink));
+                        core.set_binding(ChannelBinding::Sink(BoundChannelSink { sink, liveness }));
                     }
                 }
                 // r[impl rpc.channel.binding.caller-args.tx]
@@ -94,12 +102,16 @@ pub unsafe fn bind_channels_caller_args(
                 ChannelKind::Tx => {
                     let (channel_id, receiver) = binder.create_rx();
                     channel_ids.push(channel_id);
+                    let liveness = binder.channel_liveness();
                     if let Ok(mut ps) = channel_poke.into_struct()
                         && let Ok(mut core_field) = ps.field_by_name("core")
                         && let Ok(slot) = core_field.get_mut::<CoreSlot>()
                         && let Some(core) = &slot.inner
                     {
-                        core.set_binding(ChannelBinding::Receiver(receiver));
+                        core.set_binding(ChannelBinding::Receiver(BoundChannelReceiver {
+                            receiver,
+                            liveness,
+                        }));
                     }
                 }
             },
@@ -151,22 +163,38 @@ pub unsafe fn bind_channels_callee_args(
                     // Tx in args: handler sends. Bind a sink directly.
                     ChannelKind::Tx => {
                         let sink = binder.bind_tx(channel_id, loc.initial_credit);
-                        if let Ok(mut ps) = channel_poke.into_struct()
-                            && let Ok(mut sink_field) = ps.field_by_name("sink")
-                            && let Ok(slot) = sink_field.get_mut::<SinkSlot>()
-                        {
-                            slot.inner = Some(sink);
+                        let liveness = binder.channel_liveness();
+                        if let Ok(mut ps) = channel_poke.into_struct() {
+                            if let Ok(mut sink_field) = ps.field_by_name("sink")
+                                && let Ok(slot) = sink_field.get_mut::<SinkSlot>()
+                            {
+                                slot.inner = Some(sink);
+                            }
+                            if let Ok(mut liveness_field) = ps.field_by_name("liveness")
+                                && let Ok(slot) =
+                                    liveness_field.get_mut::<crate::channel::LivenessSlot>()
+                            {
+                                slot.inner = liveness;
+                            }
                         }
                     }
                     // r[impl rpc.channel.binding.callee-args.rx]
                     // Rx in args: handler receives. Register and bind a receiver directly.
                     ChannelKind::Rx => {
                         let receiver = binder.register_rx(channel_id);
-                        if let Ok(mut ps) = channel_poke.into_struct()
-                            && let Ok(mut receiver_field) = ps.field_by_name("receiver")
-                            && let Ok(slot) = receiver_field.get_mut::<ReceiverSlot>()
-                        {
-                            slot.inner = Some(receiver);
+                        let liveness = binder.channel_liveness();
+                        if let Ok(mut ps) = channel_poke.into_struct() {
+                            if let Ok(mut receiver_field) = ps.field_by_name("receiver")
+                                && let Ok(slot) = receiver_field.get_mut::<ReceiverSlot>()
+                            {
+                                slot.inner = Some(receiver);
+                            }
+                            if let Ok(mut liveness_field) = ps.field_by_name("liveness")
+                                && let Ok(slot) =
+                                    liveness_field.get_mut::<crate::channel::LivenessSlot>()
+                            {
+                                slot.inner = liveness;
+                            }
                         }
                     }
                 }

--- a/typescript/packages/roam-core/src/channeling/channel.ts
+++ b/typescript/packages/roam-core/src/channeling/channel.ts
@@ -91,7 +91,10 @@ export function createChannel<T>(capacity = 64): Channel<T> {
  * Sender end of a channel (for Push).
  */
 export class ChannelSender<T> {
-  constructor(private channel: Channel<T>) {}
+  constructor(
+    private channel: Channel<T>,
+    private readonly _keepaliveOwner?: object,
+  ) {}
 
   send(value: T): boolean {
     return this.channel.send(value);
@@ -106,7 +109,10 @@ export class ChannelSender<T> {
  * Receiver end of a channel (for Pull).
  */
 export class ChannelReceiver<T> {
-  constructor(private channel: Channel<T>) {}
+  constructor(
+    private channel: Channel<T>,
+    private readonly _keepaliveOwner?: object,
+  ) {}
 
   recv(): Promise<T | null> {
     return this.channel.recv();

--- a/typescript/packages/roam-core/src/channeling/registry.ts
+++ b/typescript/packages/roam-core/src/channeling/registry.ts
@@ -22,6 +22,7 @@ export class OutgoingSender {
   constructor(
     private _channelId: ChannelId,
     private channel: Channel<OutgoingMessage>,
+    private readonly _keepaliveOwner?: object,
   ) {}
 
   get channelId(): ChannelId {
@@ -49,6 +50,8 @@ export class OutgoingSender {
  * r[impl channeling.unknown] - Unknown channel IDs cause Goodbye.
  */
 export class ChannelRegistry {
+  constructor(private readonly keepaliveOwner?: object) {}
+
   /** Channels where we receive Data messages (backing Rx<T> handles). */
   private incoming = new Map<ChannelId, Channel<Uint8Array>>();
 
@@ -66,7 +69,7 @@ export class ChannelRegistry {
   registerIncoming(channelId: ChannelId): ChannelReceiver<Uint8Array> {
     const channel = createChannel<Uint8Array>(64);
     this.incoming.set(channelId, channel);
-    return new ChannelReceiver(channel);
+    return new ChannelReceiver(channel, this.keepaliveOwner);
   }
 
   /**
@@ -77,7 +80,7 @@ export class ChannelRegistry {
   registerOutgoing(channelId: ChannelId): OutgoingSender {
     const channel = createChannel<OutgoingMessage>(64);
     this.outgoing.set(channelId, channel);
-    return new OutgoingSender(channelId, channel);
+    return new OutgoingSender(channelId, channel, this.keepaliveOwner);
   }
 
   /**
@@ -169,5 +172,9 @@ export class ChannelRegistry {
   /** Get the number of active outgoing channels. */
   get outgoingCount(): number {
     return this.outgoing.size;
+  }
+
+  hasLiveChannels(): boolean {
+    return this.incoming.size > 0 || this.outgoing.size > 0;
   }
 }

--- a/typescript/packages/roam-core/src/connection.channeling.test.ts
+++ b/typescript/packages/roam-core/src/connection.channeling.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { encodeWithSchema } from "@bearcove/roam-postcard";
+import {
+  decodeMessage,
+  encodeMessage,
+  helloYourself,
+  messageData,
+  messageHelloYourself,
+  messageResponse,
+  messageClose,
+  parityEven,
+  type Message,
+} from "@bearcove/roam-wire";
+
+import { bindChannels, channel, type Schema } from "./channeling/index.ts";
+import { defaultHello, helloExchangeInitiator } from "./connection.ts";
+import type { MessageTransport } from "./transport.ts";
+
+class ScriptedTransport implements MessageTransport {
+  lastDecoded: Uint8Array = new Uint8Array(0);
+
+  private queue: Uint8Array[] = [];
+  private waitingResolve: ((payload: Uint8Array | null) => void) | null = null;
+  private closed = false;
+
+  async send(payload: Uint8Array): Promise<void> {
+    this.lastDecoded = payload;
+    const msg = decodeMessage(payload).value as Message;
+
+    if (msg.payload.tag === "Hello") {
+      const hy = helloYourself(parityEven(), 64);
+      this.enqueue(encodeMessage(messageHelloYourself(hy)));
+      return;
+    }
+
+    if (msg.payload.tag === "RequestMessage" && msg.payload.value.body.tag === "Call") {
+      this.enqueue(encodeMessage(messageResponse(msg.payload.value.id, new Uint8Array([0x2a]))));
+    }
+  }
+
+  async recvTimeout(timeoutMs: number): Promise<Uint8Array | null> {
+    if (this.queue.length > 0) {
+      return this.queue.shift()!;
+    }
+    if (this.closed) {
+      return null;
+    }
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.waitingResolve = null;
+        resolve(null);
+      }, timeoutMs);
+      this.waitingResolve = (payload) => {
+        clearTimeout(timer);
+        resolve(payload);
+      };
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.waitingResolve) {
+      this.waitingResolve(null);
+      this.waitingResolve = null;
+    }
+  }
+
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  enqueue(payload: Uint8Array): void {
+    if (this.waitingResolve) {
+      const resolve = this.waitingResolve;
+      this.waitingResolve = null;
+      resolve(payload);
+      return;
+    }
+    this.queue.push(payload);
+  }
+}
+
+function settleWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`promise did not settle within ${timeoutMs}ms`));
+    }, timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+describe("channeling connection liveness", () => {
+  it("keeps servicing bound stream rx handles after the initial response", async () => {
+    const transport = new ScriptedTransport();
+    const conn = await helloExchangeInitiator(transport, defaultHello());
+
+    const [updatesTx, updatesRx] = channel<number>();
+    const channelIds = bindChannels(
+      [{ kind: "tx", element: { kind: "u32" } } satisfies Schema],
+      [updatesTx],
+      conn.getChannelAllocator(),
+      conn.getChannelRegistry(),
+    );
+
+    await conn.call(1n, new Uint8Array([1]), 200, channelIds);
+
+    transport.enqueue(
+      encodeMessage(messageData(channelIds[0], encodeWithSchema(123, { kind: "u32" }))),
+    );
+    await expect(settleWithin(updatesRx.recv(), 500)).resolves.toBe(123);
+
+    transport.enqueue(encodeMessage(messageClose(channelIds[0])));
+    await expect(settleWithin(updatesRx.recv(), 500)).resolves.toBeNull();
+  });
+});

--- a/typescript/packages/roam-core/src/connection.ts
+++ b/typescript/packages/roam-core/src/connection.ts
@@ -252,7 +252,7 @@ export class Connection<T extends MessageTransport = MessageTransport> {
     this._negotiated = negotiated;
     this.ourHello = ourHello;
     this.channelAllocator = new ChannelIdAllocator(role);
-    this.channelRegistry = new ChannelRegistry();
+    this.channelRegistry = new ChannelRegistry(this);
     this._acceptConnections = acceptConnections;
     this.keepalive = keepalive;
   }
@@ -442,7 +442,7 @@ export class Connection<T extends MessageTransport = MessageTransport> {
     this.messagePumpPromise = (async () => {
       const keepaliveRuntime = this.makeKeepaliveRuntime();
       try {
-        while (this.pendingRequests.size > 0) {
+        while (this.pendingRequests.size > 0 || this.channelRegistry.hasLiveChannels()) {
           if (!(await this.handleKeepaliveTick(keepaliveRuntime))) {
             return;
           }


### PR DESCRIPTION
## Summary
Keep channel-streaming RPC handles alive across caller drops in both the Rust and TypeScript runtimes.
The Rust runtime now lets bound Tx/Rx handles retain connection liveness without inventing ad-hoc stream workarounds, and the TypeScript runtime now keeps pumping channel traffic after the initial RPC response while live channels remain.

## Changes
- Add opaque channel-liveness retention to Rust channel bindings and seed it from real caller-owned connection guards.
- Add Rust regressions for root-caller drop with active stream handles and preserve explicit virtual-connection close behavior.
- Make the TypeScript channel registry retain the parent connection and keep the client message pump alive while channels are active.
- Add a TypeScript regression test covering post-response stream delivery on a bound Rx handle.

## Testing
- cargo nextest run -p roam-core
- cargo nextest run -p roam-types
- npm test

Fixes #210
