### PR TITLE
Fix TypeScript channel flow control and credit propagation

### DIFF
--- a/rust/roam-codegen/src/targets/typescript/mod.rs
+++ b/rust/roam-codegen/src/targets/typescript/mod.rs
@@ -186,7 +186,7 @@ mod tests {
     use super::generate_service;
     use facet::Facet;
     use roam_hash::method_descriptor;
-    use roam_types::ServiceDescriptor;
+    use roam_types::{Rx, ServiceDescriptor, Tx};
 
     #[derive(Facet)]
     struct RecursiveNode {
@@ -279,6 +279,32 @@ mod tests {
         assert!(
             generated.contains("id: SessionId;"),
             "uses of transparent named newtypes must keep alias name:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn generated_typescript_preserves_channel_initial_credit() {
+        let subscribe = method_descriptor::<(Tx<u32>, Rx<u32, 32>), ()>(
+            "StreamSvc",
+            "subscribe",
+            &["output", "input"],
+            None,
+        );
+        let methods = Box::leak(vec![subscribe].into_boxed_slice());
+        let service = ServiceDescriptor {
+            service_name: "StreamSvc",
+            methods,
+            doc: None,
+        };
+
+        let generated = generate_service(&service);
+        assert!(
+            generated.contains("{ kind: 'tx', initial_credit: 16, element: { kind: 'u32' } }"),
+            "default Tx<T> credit must be emitted into the descriptor:\n{generated}"
+        );
+        assert!(
+            generated.contains("{ kind: 'rx', initial_credit: 32, element: { kind: 'u32' } }"),
+            "explicit Rx<T, N> credit must be emitted into the descriptor:\n{generated}"
         );
     }
 }

--- a/rust/roam-codegen/src/targets/typescript/schema.rs
+++ b/rust/roam-codegen/src/targets/typescript/schema.rs
@@ -52,6 +52,15 @@ fn named_shape_name(shape: &'static Shape) -> Option<&'static str> {
     }
 }
 
+fn extract_initial_credit(shape: &'static Shape) -> u32 {
+    shape
+        .const_params
+        .iter()
+        .find(|cp| cp.name == "N")
+        .map(|cp| cp.value as u32)
+        .unwrap_or(16)
+}
+
 fn generate_schema_with_field(
     shape: &'static Shape,
     field: Option<&Field>,
@@ -91,13 +100,15 @@ fn generate_schema_with_field(
         ShapeKind::Scalar(scalar) => generate_scalar_schema(scalar),
         ShapeKind::Tx { inner } => {
             format!(
-                "{{ kind: 'tx', element: {} }}",
+                "{{ kind: 'tx', initial_credit: {}, element: {} }}",
+                extract_initial_credit(shape),
                 generate_schema_with_field(inner, None, state)
             )
         }
         ShapeKind::Rx { inner } => {
             format!(
-                "{{ kind: 'rx', element: {} }}",
+                "{{ kind: 'rx', initial_credit: {}, element: {} }}",
+                extract_initial_credit(shape),
                 generate_schema_with_field(inner, None, state)
             )
         }

--- a/typescript/generated/testbed.ts
+++ b/typescript/generated/testbed.ts
@@ -791,7 +791,7 @@ export const testbed_descriptor: ServiceDescriptor = {
     {
       name: "sum",
       id: 0x855b3a25d97bfefdn,
-      args: { kind: "tuple", elements: [{ kind: "rx", element: { kind: "i32" } }] },
+      args: { kind: "tuple", elements: [{ kind: "rx", initial_credit: 16, element: { kind: "i32" } }] },
       result: {
         kind: "enum",
         variants: [{ name: "Ok", fields: { kind: "i64" } }, {
@@ -809,7 +809,10 @@ export const testbed_descriptor: ServiceDescriptor = {
     {
       name: "generate",
       id: 0x54d2273d8cdb9c38n,
-      args: { kind: "tuple", elements: [{ kind: "u32" }, { kind: "tx", element: { kind: "i32" } }] },
+      args: {
+        kind: "tuple",
+        elements: [{ kind: "u32" }, { kind: "tx", initial_credit: 16, element: { kind: "i32" } }],
+      },
       result: {
         kind: "enum",
         variants: [{ name: "Ok", fields: { kind: "struct", fields: {} } }, {
@@ -829,7 +832,11 @@ export const testbed_descriptor: ServiceDescriptor = {
       id: 0x5d9895604eb18b19n,
       args: {
         kind: "tuple",
-        elements: [{ kind: "rx", element: { kind: "string" } }, { kind: "tx", element: { kind: "string" } }],
+        elements: [{ kind: "rx", initial_credit: 16, element: { kind: "string" } }, {
+          kind: "tx",
+          initial_credit: 16,
+          element: { kind: "string" },
+        }],
       },
       result: {
         kind: "enum",

--- a/typescript/packages/roam-core/src/channeling/binding.ts
+++ b/typescript/packages/roam-core/src/channeling/binding.ts
@@ -15,6 +15,7 @@ import type { ChannelIdAllocator } from "./allocator.ts";
 import type { ChannelRegistry } from "./registry.ts";
 import { Tx } from "./tx.ts";
 import { Rx } from "./rx.ts";
+import { DEFAULT_INITIAL_CREDIT } from "./types.ts";
 import { encodeWithSchema, decodeWithSchema } from "@bearcove/roam-postcard";
 
 /**
@@ -88,6 +89,7 @@ function bindValue(
       if (!tx.isBound) {
         const channelId = allocator.next();
         const elementSchema = resolved.element;
+        const initialCredit = resolved.initial_credit ?? DEFAULT_INITIAL_CREDIT;
 
         // Just set the channel ID on Tx (for wire encoding)
         // Don't register as outgoing - client doesn't send on this channel
@@ -95,8 +97,11 @@ function bindValue(
 
         // Bind the paired Rx for receiving (this is what client reads from)
         if (tx._pair && !tx._pair.isBound) {
-          tx._pair.bind(channelId, registry, (b: Uint8Array) =>
-            decodeWithSchema(b, 0, elementSchema, schemaRegistry).value,
+          tx._pair.bind(
+            channelId,
+            registry,
+            (b: Uint8Array) => decodeWithSchema(b, 0, elementSchema, schemaRegistry).value,
+            initialCredit,
           );
         }
       }
@@ -112,14 +117,21 @@ function bindValue(
       if (!rx.isBound) {
         const channelId = allocator.next();
         const elementSchema = resolved.element;
-        rx.bind(channelId, registry, (b: Uint8Array) =>
-          decodeWithSchema(b, 0, elementSchema, schemaRegistry).value,
+        const initialCredit = resolved.initial_credit ?? DEFAULT_INITIAL_CREDIT;
+        rx.bind(
+          channelId,
+          registry,
+          (b: Uint8Array) => decodeWithSchema(b, 0, elementSchema, schemaRegistry).value,
+          initialCredit,
         );
 
         // Bind the paired Tx for sending (this is what client writes to)
         if (rx._pair && !rx._pair.isBound) {
-          rx._pair.bind(channelId, registry, (v: unknown) =>
-            encodeWithSchema(v, elementSchema, schemaRegistry),
+          rx._pair.bind(
+            channelId,
+            registry,
+            (v: unknown) => encodeWithSchema(v, elementSchema, schemaRegistry),
+            initialCredit,
           );
         }
       }

--- a/typescript/packages/roam-core/src/channeling/channel.ts
+++ b/typescript/packages/roam-core/src/channeling/channel.ts
@@ -112,10 +112,15 @@ export class ChannelReceiver<T> {
   constructor(
     private channel: Channel<T>,
     private readonly _keepaliveOwner?: object,
+    private readonly onRecv?: () => void,
   ) {}
 
-  recv(): Promise<T | null> {
-    return this.channel.recv();
+  async recv(): Promise<T | null> {
+    const value = await this.channel.recv();
+    if (value !== null) {
+      this.onRecv?.();
+    }
+    return value;
   }
 
   isClosed(): boolean {

--- a/typescript/packages/roam-core/src/channeling/index.ts
+++ b/typescript/packages/roam-core/src/channeling/index.ts
@@ -1,6 +1,6 @@
 // Channeling module exports
 
-export { type ChannelId, Role, ChannelError } from "./types.ts";
+export { type ChannelId, Role, ChannelError, DEFAULT_INITIAL_CREDIT } from "./types.ts";
 export { ChannelIdAllocator } from "./allocator.ts";
 export { createChannel, ChannelSender, ChannelReceiver, type Channel } from "./channel.ts";
 export {

--- a/typescript/packages/roam-core/src/channeling/registry.ts
+++ b/typescript/packages/roam-core/src/channeling/registry.ts
@@ -1,17 +1,144 @@
 // Channel registry for managing active channels on a connection.
 
-import { type ChannelId, ChannelError } from "./types.ts";
+import { type ChannelId, ChannelError, DEFAULT_INITIAL_CREDIT } from "./types.ts";
 import { createChannel, type Channel, ChannelReceiver } from "./channel.ts";
 
 /** Message sent on an outgoing channel. */
-export type OutgoingMessage = { kind: "data"; payload: Uint8Array } | { kind: "close" };
+export type OutgoingMessage =
+  | { kind: "data"; payload: Uint8Array }
+  | { kind: "close" }
+  | { kind: "credit"; additional: number };
 
 /** Result of polling an outgoing channel. */
 export type OutgoingPoll =
   | { kind: "data"; channelId: ChannelId; payload: Uint8Array }
   | { kind: "close"; channelId: ChannelId }
+  | { kind: "credit"; channelId: ChannelId; additional: number }
   | { kind: "pending" }
   | { kind: "done" };
+
+class AsyncQueue<T> {
+  private items: T[] = [];
+  private closed = false;
+  private recvWaiters: Array<(value: T | null) => void> = [];
+  private sendWaiters: Array<() => void> = [];
+
+  constructor(private readonly capacity: number) {}
+
+  async enqueue(value: T): Promise<boolean> {
+    while (!this.closed && this.recvWaiters.length === 0 && this.items.length >= this.capacity) {
+      await new Promise<void>((resolve) => {
+        this.sendWaiters.push(resolve);
+      });
+    }
+
+    if (this.closed) {
+      return false;
+    }
+
+    const waiter = this.recvWaiters.shift();
+    if (waiter) {
+      waiter(value);
+      return true;
+    }
+
+    this.items.push(value);
+    return true;
+  }
+
+  async dequeue(): Promise<T | null> {
+    if (this.items.length > 0) {
+      const value = this.items.shift()!;
+      this.signalSpace();
+      return value;
+    }
+
+    if (this.closed) {
+      return null;
+    }
+
+    return new Promise((resolve) => {
+      this.recvWaiters.push(resolve);
+    });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+
+    for (const waiter of this.recvWaiters) {
+      waiter(null);
+    }
+    this.recvWaiters.length = 0;
+
+    for (const waiter of this.sendWaiters) {
+      waiter();
+    }
+    this.sendWaiters.length = 0;
+  }
+
+  private signalSpace(): void {
+    const waiter = this.sendWaiters.shift();
+    waiter?.();
+  }
+}
+
+class CreditWindow {
+  private available: number;
+  private closed = false;
+  private waiters: Array<() => void> = [];
+
+  constructor(initialCredit: number) {
+    this.available = initialCredit;
+  }
+
+  async consume(): Promise<void> {
+    while (true) {
+      if (this.closed) {
+        throw ChannelError.closed();
+      }
+      if (this.available > 0) {
+        this.available -= 1;
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        this.waiters.push(resolve);
+      });
+    }
+  }
+
+  grant(additional: number): void {
+    if (this.closed || additional <= 0) {
+      return;
+    }
+    this.available += additional;
+    const waiters = this.waiters.splice(0, this.waiters.length);
+    for (const waiter of waiters) {
+      waiter();
+    }
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    const waiters = this.waiters.splice(0, this.waiters.length);
+    for (const waiter of waiters) {
+      waiter();
+    }
+  }
+}
+
+export interface OutgoingCreditController {
+  consume(): Promise<void>;
+  close(): void;
+}
+
+interface OutgoingState {
+  queue: AsyncQueue<OutgoingMessage>;
+  credit: CreditWindow;
+}
 
 /**
  * Sender handle for outgoing channel data.
@@ -21,7 +148,8 @@ export type OutgoingPoll =
 export class OutgoingSender {
   constructor(
     private _channelId: ChannelId,
-    private channel: Channel<OutgoingMessage>,
+    private state: OutgoingState,
+    private readonly notifyOutgoing?: () => void,
     private readonly _keepaliveOwner?: object,
   ) {}
 
@@ -30,14 +158,24 @@ export class OutgoingSender {
   }
 
   /** Send serialized data. */
-  sendData(data: Uint8Array): boolean {
-    return this.channel.send({ kind: "data", payload: data });
+  async sendData(data: Uint8Array): Promise<void> {
+    await this.state.credit.consume();
+    const enqueued = await this.state.queue.enqueue({ kind: "data", payload: data });
+    if (!enqueued) {
+      throw ChannelError.closed();
+    }
+    this.notifyOutgoing?.();
   }
 
   /** Send close signal. */
   sendClose(): void {
-    this.channel.send({ kind: "close" });
-    this.channel.close();
+    void this.state.queue.enqueue({ kind: "close" }).then((enqueued) => {
+      if (enqueued) {
+        this.notifyOutgoing?.();
+      }
+      this.state.queue.close();
+      this.state.credit.close();
+    });
   }
 }
 
@@ -50,13 +188,20 @@ export class OutgoingSender {
  * r[impl channeling.unknown] - Unknown channel IDs cause Goodbye.
  */
 export class ChannelRegistry {
-  constructor(private readonly keepaliveOwner?: object) {}
+  constructor(
+    private readonly keepaliveOwner?: object,
+    private readonly notifyOutgoing?: () => void,
+  ) {}
 
   /** Channels where we receive Data messages (backing Rx<T> handles). */
   private incoming = new Map<ChannelId, Channel<Uint8Array>>();
 
   /** Channels where we send Data messages (backing Tx<T> handles). */
-  private outgoing = new Map<ChannelId, Channel<OutgoingMessage>>();
+  private outgoing = new Map<ChannelId, OutgoingState>();
+
+  /** Pending GrantCredit control messages. */
+  private pendingCredits: Array<{ channelId: ChannelId; additional: number }> = [];
+  private creditWaiter: ((value: { channelId: ChannelId; additional: number }) => void) | null = null;
 
   /** Channel IDs that have been closed. */
   private closed = new Set<ChannelId>();
@@ -66,10 +211,18 @@ export class ChannelRegistry {
    *
    * r[impl channeling.allocation.caller] - Caller allocates channel IDs.
    */
-  registerIncoming(channelId: ChannelId): ChannelReceiver<Uint8Array> {
-    const channel = createChannel<Uint8Array>(64);
+  registerIncoming(
+    channelId: ChannelId,
+    initialCredit: number = DEFAULT_INITIAL_CREDIT,
+    onConsumed?: (additional: number) => void,
+  ): ChannelReceiver<Uint8Array> {
+    const channel = createChannel<Uint8Array>(initialCredit);
     this.incoming.set(channelId, channel);
-    return new ChannelReceiver(channel, this.keepaliveOwner);
+    return new ChannelReceiver(
+      channel,
+      this.keepaliveOwner,
+      () => (onConsumed ? onConsumed(1) : this.queueGrantCredit(channelId, 1)),
+    );
   }
 
   /**
@@ -77,10 +230,19 @@ export class ChannelRegistry {
    *
    * r[impl channeling.allocation.caller] - Caller allocates channel IDs.
    */
-  registerOutgoing(channelId: ChannelId): OutgoingSender {
-    const channel = createChannel<OutgoingMessage>(64);
-    this.outgoing.set(channelId, channel);
-    return new OutgoingSender(channelId, channel, this.keepaliveOwner);
+  registerOutgoing(
+    channelId: ChannelId,
+    initialCredit: number = DEFAULT_INITIAL_CREDIT,
+  ): OutgoingSender {
+    const state = this.ensureOutgoing(channelId, initialCredit);
+    return new OutgoingSender(channelId, state, this.notifyOutgoing, this.keepaliveOwner);
+  }
+
+  registerServerOutgoing(
+    channelId: ChannelId,
+    initialCredit: number = DEFAULT_INITIAL_CREDIT,
+  ): OutgoingCreditController {
+    return this.ensureOutgoing(channelId, initialCredit).credit;
   }
 
   /**
@@ -100,49 +262,98 @@ export class ChannelRegistry {
       throw ChannelError.unknown(channelId);
     }
 
-    // If send fails, the Rx<T> was dropped - that's okay
-    channel.send(payload);
+    if (!channel.send(payload)) {
+      throw ChannelError.overflow(channelId);
+    }
+  }
+
+  grantCredit(channelId: ChannelId, additional: number): void {
+    this.outgoing.get(channelId)?.credit.grant(additional);
+  }
+
+  queueGrantCredit(channelId: ChannelId, additional: number): void {
+    if (additional <= 0) {
+      return;
+    }
+
+    const credit = { channelId, additional };
+    if (this.creditWaiter) {
+      const waiter = this.creditWaiter;
+      this.creditWaiter = null;
+      waiter(credit);
+    } else {
+      this.pendingCredits.push(credit);
+    }
+    this.notifyOutgoing?.();
   }
 
   /**
    * Wait for outgoing data from any registered channel.
    */
   async waitOutgoing(): Promise<OutgoingPoll> {
-    if (this.outgoing.size === 0) {
-      return { kind: "done" };
+    while (true) {
+      const pendingCredit = this.pendingCredits.shift();
+      if (pendingCredit) {
+        return { kind: "credit", ...pendingCredit };
+      }
+
+      if (this.outgoing.size === 0) {
+        return { kind: "done" };
+      }
+
+      const promises: Promise<
+        | { source: "channel"; channelId: ChannelId; msg: OutgoingMessage | null }
+        | { source: "credit"; channelId: ChannelId; additional: number }
+      >[] = [];
+
+      for (const [channelId, state] of this.outgoing) {
+        promises.push(
+          state.queue.dequeue().then((msg) => ({
+            source: "channel" as const,
+            channelId,
+            msg,
+          })),
+        );
+      }
+
+      promises.push(
+        new Promise<{ source: "credit"; channelId: ChannelId; additional: number }>((resolve) => {
+          this.creditWaiter = (credit) => {
+            resolve({ source: "credit", ...credit });
+          };
+        }),
+      );
+
+      const result = await Promise.race(promises);
+
+      if (result.source === "credit") {
+        return { kind: "credit", channelId: result.channelId, additional: result.additional };
+      }
+
+      this.creditWaiter = null;
+
+      if (result.msg === null) {
+        this.outgoing.delete(result.channelId);
+        this.closed.add(result.channelId);
+        continue;
+      }
+
+      if (result.msg.kind === "data") {
+        return { kind: "data", channelId: result.channelId, payload: result.msg.payload };
+      }
+
+      if (result.msg.kind === "close") {
+        this.outgoing.delete(result.channelId);
+        this.closed.add(result.channelId);
+        return { kind: "close", channelId: result.channelId };
+      }
+
+      return {
+        kind: "credit",
+        channelId: result.channelId,
+        additional: result.msg.additional,
+      };
     }
-
-    // Create a race between all outgoing channels
-    const promises: Promise<{ channelId: ChannelId; msg: OutgoingMessage | null }>[] = [];
-
-    for (const [channelId, channel] of this.outgoing) {
-      promises.push(channel.recv().then((msg) => ({ channelId, msg })));
-    }
-
-    if (promises.length === 0) {
-      return { kind: "done" };
-    }
-
-    const result = await Promise.race(promises);
-
-    if (result.msg === null) {
-      // Channel closed without message - implicit close
-      this.outgoing.delete(result.channelId);
-      this.closed.add(result.channelId);
-      return { kind: "close", channelId: result.channelId };
-    }
-
-    if (result.msg.kind === "data") {
-      return { kind: "data", channelId: result.channelId, payload: result.msg.payload };
-    }
-
-    if (result.msg.kind === "close") {
-      this.outgoing.delete(result.channelId);
-      this.closed.add(result.channelId);
-      return { kind: "close", channelId: result.channelId };
-    }
-
-    return { kind: "pending" };
   }
 
   /**
@@ -155,6 +366,13 @@ export class ChannelRegistry {
     if (channel) {
       channel.close();
       this.incoming.delete(channelId);
+    }
+
+    const outgoing = this.outgoing.get(channelId);
+    if (outgoing) {
+      outgoing.credit.close();
+      outgoing.queue.close();
+      this.outgoing.delete(channelId);
     }
     this.closed.add(channelId);
   }
@@ -175,6 +393,20 @@ export class ChannelRegistry {
   }
 
   hasLiveChannels(): boolean {
-    return this.incoming.size > 0 || this.outgoing.size > 0;
+    return this.incoming.size > 0 || this.outgoing.size > 0 || this.pendingCredits.length > 0;
+  }
+
+  private ensureOutgoing(channelId: ChannelId, initialCredit: number): OutgoingState {
+    let state = this.outgoing.get(channelId);
+    if (state) {
+      return state;
+    }
+
+    state = {
+      queue: new AsyncQueue<OutgoingMessage>(64),
+      credit: new CreditWindow(initialCredit),
+    };
+    this.outgoing.set(channelId, state);
+    return state;
   }
 }

--- a/typescript/packages/roam-core/src/channeling/rx.ts
+++ b/typescript/packages/roam-core/src/channeling/rx.ts
@@ -89,13 +89,15 @@ export class Rx<T> {
     channelId: ChannelId,
     registry: ChannelRegistry,
     deserialize: (bytes: Uint8Array) => T,
+    initialCredit: number,
+    onConsumed?: (additional: number) => void,
   ): void {
     if (this._consumed) {
       throw ChannelError.alreadyConsumed("Rx");
     }
 
     this._channelId = channelId;
-    this.receiver = registry.registerIncoming(channelId);
+    this.receiver = registry.registerIncoming(channelId, initialCredit, onConsumed);
     this.deserialize = deserialize;
     this._consumed = true;
   }

--- a/typescript/packages/roam-core/src/channeling/task.ts
+++ b/typescript/packages/roam-core/src/channeling/task.ts
@@ -14,6 +14,7 @@ import { type ChannelId } from "./types.ts";
 export type TaskMessage =
   | { kind: "data"; channelId: ChannelId; payload: Uint8Array }
   | { kind: "close"; channelId: ChannelId }
+  | { kind: "grantCredit"; channelId: ChannelId; additional: number }
   | { kind: "response"; requestId: bigint; payload: Uint8Array };
 
 /**

--- a/typescript/packages/roam-core/src/channeling/tx.ts
+++ b/typescript/packages/roam-core/src/channeling/tx.ts
@@ -1,7 +1,7 @@
 // Tx channel handle - caller sends data to callee.
 
 import { type ChannelId, ChannelError } from "./types.ts";
-import { OutgoingSender, ChannelRegistry } from "./registry.ts";
+import { OutgoingSender, ChannelRegistry, type OutgoingCreditController } from "./registry.ts";
 import { type TaskSender } from "./task.ts";
 
 // Forward declaration for pair reference
@@ -16,7 +16,7 @@ import type { Rx } from "./rx.ts";
  */
 type TxSender =
   | { mode: "client"; sender: OutgoingSender }
-  | { mode: "server"; channelId: ChannelId; taskSender: TaskSender };
+  | { mode: "server"; channelId: ChannelId; taskSender: TaskSender; credit: OutgoingCreditController };
 
 /**
  * Tx channel handle - caller sends data to callee.
@@ -49,19 +49,31 @@ export class Tx<T> {
   /** Create an unbound Tx (for use with channel<T>()). */
   constructor();
   /** Create a server-side Tx with a TaskSender. */
-  constructor(channelId: ChannelId, taskSender: TaskSender, serialize: (value: T) => Uint8Array);
+  constructor(
+    channelId: ChannelId,
+    taskSender: TaskSender,
+    credit: OutgoingCreditController,
+    serialize: (value: T) => Uint8Array,
+  );
   constructor(
     channelId?: ChannelId,
     taskSender?: TaskSender,
+    credit?: OutgoingCreditController,
     serialize?: (value: T) => Uint8Array,
   ) {
-    if (channelId !== undefined && taskSender !== undefined && serialize !== undefined) {
+    if (
+      channelId !== undefined &&
+      taskSender !== undefined &&
+      credit !== undefined &&
+      serialize !== undefined
+    ) {
       // Server-side constructor
       this._channelId = channelId;
       this.sender = {
         mode: "server",
         channelId: channelId,
         taskSender: taskSender,
+        credit,
       };
       this.serialize = serialize;
       this._consumed = true; // Server-side Tx is immediately bound
@@ -97,13 +109,18 @@ export class Tx<T> {
    * @param registry - The channel registry to register with
    * @param serialize - Function to serialize values
    */
-  bind(channelId: ChannelId, registry: ChannelRegistry, serialize: (value: T) => Uint8Array): void {
+  bind(
+    channelId: ChannelId,
+    registry: ChannelRegistry,
+    serialize: (value: T) => Uint8Array,
+    initialCredit: number,
+  ): void {
     if (this._consumed) {
       throw ChannelError.alreadyConsumed("Tx");
     }
 
     this._channelId = channelId;
-    const outgoing = registry.registerOutgoing(channelId);
+    const outgoing = registry.registerOutgoing(channelId, initialCredit);
     this.sender = { mode: "client", sender: outgoing };
     this.serialize = serialize;
     this._consumed = true;
@@ -150,11 +167,10 @@ export class Tx<T> {
     }
 
     if (this.sender.mode === "client") {
-      if (!this.sender.sender.sendData(bytes)) {
-        throw ChannelError.closed();
-      }
+      await this.sender.sender.sendData(bytes);
     } else {
       // Server-side: send directly via task channel
+      await this.sender.credit.consume();
       this.sender.taskSender({
         kind: "data",
         channelId: this.sender.channelId,
@@ -180,6 +196,7 @@ export class Tx<T> {
     if (this.sender.mode === "client") {
       this.sender.sender.sendClose();
     } else {
+      this.sender.credit.close();
       // Server-side: send Close via task channel
       this.sender.taskSender({
         kind: "close",
@@ -206,7 +223,14 @@ export class Tx<T> {
 export function createServerTx<T>(
   channelId: ChannelId,
   taskSender: TaskSender,
+  registry: ChannelRegistry,
+  initialCredit: number,
   serialize: (value: T) => Uint8Array,
 ): Tx<T> {
-  return new Tx(channelId, taskSender, serialize);
+  return new Tx(
+    channelId,
+    taskSender,
+    registry.registerServerOutgoing(channelId, initialCredit),
+    serialize,
+  );
 }

--- a/typescript/packages/roam-core/src/channeling/types.ts
+++ b/typescript/packages/roam-core/src/channeling/types.ts
@@ -3,6 +3,9 @@
 /** Channel ID type (matches wire format). */
 export type ChannelId = bigint;
 
+/** Default per-channel initial credit when the const generic `N` is omitted. */
+export const DEFAULT_INITIAL_CREDIT = 16;
+
 /** Connection role - determines channel ID parity. */
 export const Role = {
   /** Initiator (client) uses odd channel IDs (1, 3, 5, ...). */
@@ -19,6 +22,7 @@ export class ChannelError extends Error {
       | "unknown"
       | "dataAfterClose"
       | "closed"
+      | "overflow"
       | "serialize"
       | "deserialize"
       | "notBound"
@@ -39,6 +43,10 @@ export class ChannelError extends Error {
 
   static closed(): ChannelError {
     return new ChannelError("closed", "channel closed");
+  }
+
+  static overflow(channelId: ChannelId): ChannelError {
+    return new ChannelError("overflow", `incoming channel buffer overflow on channel ${channelId}`);
   }
 
   static serialize(cause: unknown): ChannelError {

--- a/typescript/packages/roam-core/src/connection.channeling.test.ts
+++ b/typescript/packages/roam-core/src/connection.channeling.test.ts
@@ -5,6 +5,7 @@ import {
   encodeMessage,
   helloYourself,
   messageData,
+  messageCredit,
   messageHelloYourself,
   messageResponse,
   messageClose,
@@ -12,12 +13,21 @@ import {
   type Message,
 } from "@bearcove/roam-wire";
 
-import { bindChannels, channel, type Schema } from "./channeling/index.ts";
+import {
+  bindChannels,
+  channel,
+  ChannelIdAllocator,
+  ChannelRegistry,
+  Role,
+  type Schema,
+} from "./channeling/index.ts";
+import { DEFAULT_INITIAL_CREDIT } from "./channeling/types.ts";
 import { defaultHello, helloExchangeInitiator } from "./connection.ts";
 import type { MessageTransport } from "./transport.ts";
 
 class ScriptedTransport implements MessageTransport {
   lastDecoded: Uint8Array = new Uint8Array(0);
+  sent: Message[] = [];
 
   private queue: Uint8Array[] = [];
   private waitingResolve: ((payload: Uint8Array | null) => void) | null = null;
@@ -26,6 +36,7 @@ class ScriptedTransport implements MessageTransport {
   async send(payload: Uint8Array): Promise<void> {
     this.lastDecoded = payload;
     const msg = decodeMessage(payload).value as Message;
+    this.sent.push(msg);
 
     if (msg.payload.tag === "Hello") {
       const hy = helloYourself(parityEven(), 64);
@@ -98,7 +109,91 @@ function settleWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   });
 }
 
+async function waitForGrantCredit(
+  transport: ScriptedTransport,
+  channelId: bigint,
+  timeoutMs: number,
+): Promise<Message> {
+  return settleWithin(
+    (async () => {
+      while (true) {
+        let grant: Message | undefined;
+        for (let i = transport.sent.length - 1; i >= 0; i--) {
+          const msg = transport.sent[i];
+          if (
+            msg.payload.tag === "ChannelMessage" &&
+            msg.payload.value.id === channelId &&
+            msg.payload.value.body.tag === "GrantCredit"
+          ) {
+            grant = msg;
+            break;
+          }
+        }
+        if (grant) {
+          return grant;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    })(),
+    timeoutMs,
+  );
+}
+
 describe("channeling connection liveness", () => {
+  it("binds incoming buffers to the channel initial credit instead of the transport default", () => {
+    const registry = new ChannelRegistry();
+    const allocator = new ChannelIdAllocator(Role.Initiator);
+    const [outputTx] = channel<number>();
+    const [channelId] = bindChannels(
+      [
+        {
+          kind: "tx",
+          initial_credit: DEFAULT_INITIAL_CREDIT,
+          element: { kind: "u32" },
+        } satisfies Schema,
+      ],
+      [outputTx],
+      allocator,
+      registry,
+    );
+
+    for (let i = 0; i < DEFAULT_INITIAL_CREDIT; i++) {
+      expect(() =>
+        registry.routeData(channelId, encodeWithSchema(i, { kind: "u32" })),
+      ).not.toThrow();
+    }
+
+    expect(() =>
+      registry.routeData(channelId, encodeWithSchema(999, { kind: "u32" })),
+    ).toThrow(/overflow/);
+  });
+
+  it("applies GrantCredit to blocked outgoing tx handles", async () => {
+    const registry = new ChannelRegistry();
+    const allocator = new ChannelIdAllocator(Role.Initiator);
+    const [, inputRx] = channel<number>();
+    const [inputTx] = [inputRx._pair!];
+    const [channelId] = bindChannels(
+      [
+        {
+          kind: "rx",
+          initial_credit: 1,
+          element: { kind: "u32" },
+        } satisfies Schema,
+      ],
+      [inputRx],
+      allocator,
+      registry,
+    );
+
+    await inputTx.send(1);
+    const secondSend = inputTx.send(2);
+    await expect(settleWithin(secondSend, 50)).rejects.toThrow(/did not settle/);
+
+    registry.grantCredit(channelId, 1);
+    await expect(settleWithin(secondSend, 500)).resolves.toBeUndefined();
+  });
+
   it("keeps servicing bound stream rx handles after the initial response", async () => {
     const transport = new ScriptedTransport();
     const conn = await helloExchangeInitiator(transport, defaultHello());
@@ -120,5 +215,35 @@ describe("channeling connection liveness", () => {
 
     transport.enqueue(encodeMessage(messageClose(channelIds[0])));
     await expect(settleWithin(updatesRx.recv(), 500)).resolves.toBeNull();
+  });
+
+  it("sends GrantCredit after the caller consumes a streamed item", async () => {
+    const transport = new ScriptedTransport();
+    const conn = await helloExchangeInitiator(transport, defaultHello());
+
+    const [updatesTx, updatesRx] = channel<number>();
+    const channelIds = bindChannels(
+      [
+        {
+          kind: "tx",
+          initial_credit: DEFAULT_INITIAL_CREDIT,
+          element: { kind: "u32" },
+        } satisfies Schema,
+      ],
+      [updatesTx],
+      conn.getChannelAllocator(),
+      conn.getChannelRegistry(),
+    );
+
+    await conn.call(1n, new Uint8Array([1]), 200, channelIds);
+
+    transport.enqueue(
+      encodeMessage(messageData(channelIds[0], encodeWithSchema(123, { kind: "u32" }))),
+    );
+    await expect(settleWithin(updatesRx.recv(), 500)).resolves.toBe(123);
+
+    await expect(
+      waitForGrantCredit(transport, channelIds[0], 500),
+    ).resolves.toMatchObject(messageCredit(channelIds[0], 1));
   });
 });

--- a/typescript/packages/roam-core/src/connection.ts
+++ b/typescript/packages/roam-core/src/connection.ts
@@ -27,6 +27,7 @@ import {
   messageReject,
   messageData,
   messageClose,
+  messageCredit,
   encodeMessage,
   decodeMessage,
 } from "@bearcove/roam-wire";
@@ -34,6 +35,7 @@ import {
   ChannelRegistry,
   ChannelIdAllocator,
   ChannelError,
+  DEFAULT_INITIAL_CREDIT,
   Role,
   Tx,
   Rx,
@@ -231,6 +233,7 @@ export class Connection<T extends MessageTransport = MessageTransport> {
   >();
   private messagePumpRunning = false;
   private messagePumpPromise: Promise<void> | null = null;
+  private messagePumpWakeupResolve: (() => void) | null = null;
   private keepalive: KeepaliveConfig | null;
 
   /**
@@ -252,7 +255,7 @@ export class Connection<T extends MessageTransport = MessageTransport> {
     this._negotiated = negotiated;
     this.ourHello = ourHello;
     this.channelAllocator = new ChannelIdAllocator(role);
-    this.channelRegistry = new ChannelRegistry(this);
+    this.channelRegistry = new ChannelRegistry(this, () => this.wakeMessagePump());
     this._acceptConnections = acceptConnections;
     this.keepalive = keepalive;
   }
@@ -342,7 +345,18 @@ export class Connection<T extends MessageTransport = MessageTransport> {
         await this.io.send(encodeMessage(messageData(poll.channelId, poll.payload)));
       } else if (poll.kind === "close") {
         await this.io.send(encodeMessage(messageClose(poll.channelId)));
+      } else if (poll.kind === "credit") {
+        await this.io.send(encodeMessage(messageCredit(poll.channelId, poll.additional)));
       }
+    }
+  }
+
+  private wakeMessagePump(): void {
+    this.startMessagePump();
+    const resolve = this.messagePumpWakeupResolve;
+    if (resolve) {
+      this.messagePumpWakeupResolve = null;
+      resolve();
     }
   }
 
@@ -441,18 +455,50 @@ export class Connection<T extends MessageTransport = MessageTransport> {
 
     this.messagePumpPromise = (async () => {
       const keepaliveRuntime = this.makeKeepaliveRuntime();
+      let pendingRecv: Promise<
+        { kind: "message"; payload: Uint8Array | null } | { kind: "error"; error: unknown }
+      > | null = null;
       try {
         while (this.pendingRequests.size > 0 || this.channelRegistry.hasLiveChannels()) {
           if (!(await this.handleKeepaliveTick(keepaliveRuntime))) {
             return;
           }
-          const data = await this.io.recvTimeout(100); // Short timeout to check for new requests
+
+          await this.flushOutgoing();
+
+          if (!pendingRecv) {
+            pendingRecv = this.io
+              .recvTimeout(100)
+              .then((payload) => ({ kind: "message" as const, payload }))
+              .catch((error) => ({ kind: "error" as const, error }));
+          }
+
+          const wakeupPromise = new Promise<void>((resolve) => {
+            this.messagePumpWakeupResolve = resolve;
+          });
+
+          const raceResult = await Promise.race([
+            pendingRecv.then((result) => ({ source: "recv" as const, result })),
+            wakeupPromise.then(() => ({ source: "wakeup" as const })),
+          ]);
+
+          if (raceResult.source === "wakeup") {
+            continue;
+          }
+
+          pendingRecv = null;
+          const recvResult = raceResult.result;
+
+          if (recvResult.kind === "error") {
+            throw recvResult.error;
+          }
+
+          const data = recvResult.payload;
           if (!data) {
             if (this.io.isClosed()) {
               this.failPendingRequests(ConnectionError.closed());
               return;
             }
-            // No message received, but keep running if there are pending requests
             continue;
           }
 
@@ -485,8 +531,12 @@ export class Connection<T extends MessageTransport = MessageTransport> {
                 msg.payload.value.id,
                 msg.payload.value.body.value.item,
               );
-            } catch {
-              // Ignore channel errors - connection still valid
+            } catch (e) {
+              if (e instanceof ChannelError && e.kind === "overflow") {
+                this.io.close();
+                this.failPendingRequests(ConnectionError.closed());
+                return;
+              }
             }
             continue;
           }
@@ -499,7 +549,12 @@ export class Connection<T extends MessageTransport = MessageTransport> {
           }
 
           if (msgTag(msg) === "ChannelMessage" && msg.payload.value.body.tag === "GrantCredit") {
-            // Flow control, currently ignored
+            if (this.channelRegistry.contains(msg.payload.value.id)) {
+              this.channelRegistry.grantCredit(
+                msg.payload.value.id,
+                msg.payload.value.body.value.additional,
+              );
+            }
             continue;
           }
 
@@ -523,6 +578,7 @@ export class Connection<T extends MessageTransport = MessageTransport> {
       } finally {
         this.messagePumpRunning = false;
         this.messagePumpPromise = null;
+        this.messagePumpWakeupResolve = null;
       }
     })();
   }
@@ -638,6 +694,9 @@ export class Connection<T extends MessageTransport = MessageTransport> {
             break;
           case "close":
             await this.io.send(encodeMessage(messageClose(msg.channelId)));
+            break;
+          case "grantCredit":
+            await this.io.send(encodeMessage(messageCredit(msg.channelId, msg.additional)));
             break;
           case "response":
             await this.io.send(encodeMessage(messageResponse(msg.requestId, msg.payload)));
@@ -870,12 +929,26 @@ export class Connection<T extends MessageTransport = MessageTransport> {
           const argSchema = method.args.elements[i];
           if (argSchema.kind === "tx") {
             const channelId = requestChannels[channelIdx++];
-            return createServerTx(channelId, taskSender, (v: unknown) =>
-              encodeWithSchema(v, argSchema.element, descriptor.schema_registry),
+            return createServerTx(
+              channelId,
+              taskSender,
+              this.channelRegistry,
+              argSchema.initial_credit ?? DEFAULT_INITIAL_CREDIT,
+              (v: unknown) => encodeWithSchema(v, argSchema.element, descriptor.schema_registry),
             );
           } else if (argSchema.kind === "rx") {
             const channelId = requestChannels[channelIdx++];
-            const receiver = this.channelRegistry.registerIncoming(channelId);
+            const receiver = this.channelRegistry.registerIncoming(
+              channelId,
+              argSchema.initial_credit ?? DEFAULT_INITIAL_CREDIT,
+              (additional) => {
+                taskSender({
+                  kind: "grantCredit",
+                  channelId,
+                  additional,
+                });
+              },
+            );
             return createServerRx(channelId, receiver, (b: Uint8Array) =>
               decodeWithSchema(b, 0, argSchema.element, descriptor.schema_registry).value,
             );
@@ -916,6 +989,12 @@ export class Connection<T extends MessageTransport = MessageTransport> {
                 context: "data after close",
               });
             }
+            if (e.kind === "overflow") {
+              throw ConnectionError.protocol({
+                ruleId: "rpc.flow-control.credit.exhaustion",
+                context: "incoming channel buffer overflow",
+              });
+            }
           }
           throw e;
         }
@@ -931,6 +1010,11 @@ export class Connection<T extends MessageTransport = MessageTransport> {
 
       if (body.tag === "Close" || body.tag === "Reset") {
         this.channelRegistry.close(channelId);
+        return undefined;
+      }
+
+      if (body.tag === "GrantCredit") {
+        this.channelRegistry.grantCredit(channelId, body.value.additional);
       }
       return undefined;
     }
@@ -1074,6 +1158,9 @@ export class Connection<T extends MessageTransport = MessageTransport> {
             // r[impl channeling.data-after-close] - Data after Close is error.
             throw await this.goodbye("channeling.data-after-close");
           }
+          if (e.kind === "overflow") {
+            throw await this.goodbye("rpc.flow-control.credit.exhaustion");
+          }
         }
         throw e;
       }
@@ -1119,11 +1206,10 @@ export class Connection<T extends MessageTransport = MessageTransport> {
         throw await this.goodbye("rpc.channel.allocation");
       }
 
-      // TODO: Implement flow control.
-      // For now, validate channel exists but ignore credit.
       if (!this.channelRegistry.contains(channelId)) {
         throw await this.goodbye("channeling.unknown");
       }
+      this.channelRegistry.grantCredit(channelId, msg.payload.value.body.value.additional);
       return;
     }
 

--- a/typescript/packages/roam-postcard/src/schema.ts
+++ b/typescript/packages/roam-postcard/src/schema.ts
@@ -147,12 +147,14 @@ export interface RefSchema {
 export interface TxSchema {
   kind: "tx";
   element: Schema;
+  initial_credit?: number;
 }
 
 /** Schema for Rx<T> - data flowing from callee to caller. */
 export interface RxSchema {
   kind: "rx";
   element: Schema;
+  initial_credit?: number;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
This fixes the TypeScript side of channel flow control and preserves per-channel initial credit in generated TypeScript descriptors.

The concrete failure mode behind the reported stall was a plain `Tx<T>`/`Rx<T>` using the Rust default initial credit of 16, combined with the TypeScript runtime ignoring `GrantCredit` and silently dropping or stalling channel traffic.

## Changes
- preserve `initial_credit` for `Tx<T, N>` and `Rx<T, N>` in TypeScript schema/codegen and regenerate `typescript/generated/testbed.ts`
- implement channel credit accounting in the TypeScript runtime for both caller and server-side channel senders
- send `GrantCredit` when TypeScript `Rx` handles consume items, and apply incoming `GrantCredit` instead of ignoring it
- fail loudly on incoming channel overflow instead of silently dropping payloads
- add targeted TypeScript and Rust regression coverage for the 16-credit case and unblock-on-grant behavior

## Testing
- `cargo nextest run -p roam-codegen generated_typescript_preserves_channel_initial_credit`
- `pnpm --filter @bearcove/roam-postcard test -- schema_codec.test.ts`
- `pnpm --filter @bearcove/roam-core check`
- `pnpm --filter @bearcove/roam-core test -- connection.channeling.test.ts`