### PR TITLE
Trim redundant TypeScript schema and wire tests

### DIFF
--- a/typescript/packages/roam-core/src/channeling/schema.test.ts
+++ b/typescript/packages/roam-core/src/channeling/schema.test.ts
@@ -1,79 +1,84 @@
-// Tests to verify schema types are correctly re-exported from roam-postcard
-
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+import type { EnumSchema, Schema, SchemaRegistry, StructSchema } from "./schema.ts";
 import {
-  type Schema,
-  type EnumSchema,
-  type StructSchema,
-  type TupleSchema,
-  type RefSchema,
-  type SchemaRegistry,
   findVariantByDiscriminant,
   findVariantByName,
   getVariantDiscriminant,
-  getVariantFieldSchemas,
   getVariantFieldNames,
+  getVariantFieldSchemas,
   isNewtypeVariant,
   isRefSchema,
   resolveSchema,
 } from "./schema.ts";
 
-describe("Schema re-exports", () => {
-  it("exports EnumSchema type correctly", () => {
-    const schema: EnumSchema = {
-      kind: "enum",
-      variants: [
-        { name: "A", fields: null },
-        { name: "B", discriminant: 5, fields: { kind: "string" } },
-      ],
-    };
-    expect(schema.kind).toBe("enum");
-    expect(schema.variants).toHaveLength(2);
+const PayloadSchema: StructSchema = {
+  kind: "struct",
+  fields: {
+    message: { kind: "string" },
+    next: { kind: "option", inner: { kind: "ref", name: "Payload" } },
+  },
+};
+
+const EventSchema: EnumSchema = {
+  kind: "enum",
+  variants: [
+    {
+      name: "Started",
+      fields: { kind: "ref", name: "Payload" },
+    },
+    {
+      name: "Progress",
+      discriminant: 7,
+      fields: {
+        current: { kind: "u32" },
+        total: { kind: "u32" },
+      },
+    },
+    {
+      name: "Chunk",
+      fields: [{ kind: "bytes" }, { kind: "u32" }],
+    },
+  ],
+};
+
+const registry: SchemaRegistry = new Map<string, Schema>([
+  ["Payload", PayloadSchema],
+  ["Event", EventSchema],
+]);
+
+describe("channeling schema compatibility", () => {
+  it("resolves the top-level ref without eagerly resolving nested refs", () => {
+    const resolved = resolveSchema({ kind: "ref", name: "Payload" }, registry);
+
+    expect(resolved).toBe(PayloadSchema);
+    expect((resolved as StructSchema).fields.next).toEqual({
+      kind: "option",
+      inner: { kind: "ref", name: "Payload" },
+    });
   });
 
-  it("exports TupleSchema type correctly", () => {
-    const schema: TupleSchema = {
-      kind: "tuple",
-      elements: [{ kind: "string" }, { kind: "u32" }],
-    };
-    expect(schema.kind).toBe("tuple");
-    expect(schema.elements).toHaveLength(2);
+  it("provides enum metadata used by the channel binder for named variants", () => {
+    const progress = findVariantByName(EventSchema, "Progress");
+
+    expect(progress).toBeDefined();
+    expect(isNewtypeVariant(progress!)).toBe(false);
+    expect(getVariantFieldNames(progress!)).toEqual(["current", "total"]);
+    expect(getVariantFieldSchemas(progress!)).toEqual([{ kind: "u32" }, { kind: "u32" }]);
   });
 
-  it("exports RefSchema type correctly", () => {
-    const schema: RefSchema = {
-      kind: "ref",
-      name: "MyType",
-    };
-    expect(schema.kind).toBe("ref");
-    expect(schema.name).toBe("MyType");
+  it("recognizes newtype variants and sparse discriminants", () => {
+    const started = findVariantByDiscriminant(EventSchema, 0);
+    const progress = findVariantByDiscriminant(EventSchema, 7);
+
+    expect(started?.name).toBe("Started");
+    expect(progress?.name).toBe("Progress");
+    expect(isNewtypeVariant(started!)).toBe(true);
+    expect(getVariantDiscriminant(EventSchema, progress!)).toBe(7);
+    expect(getVariantFieldSchemas(started!)).toEqual([{ kind: "ref", name: "Payload" }]);
   });
 
-  it("exports helper functions", () => {
-    // Just verify the functions are exported and callable
-    expect(typeof findVariantByDiscriminant).toBe("function");
-    expect(typeof findVariantByName).toBe("function");
-    expect(typeof getVariantDiscriminant).toBe("function");
-    expect(typeof getVariantFieldSchemas).toBe("function");
-    expect(typeof getVariantFieldNames).toBe("function");
-    expect(typeof isNewtypeVariant).toBe("function");
-    expect(typeof isRefSchema).toBe("function");
-    expect(typeof resolveSchema).toBe("function");
-  });
-
-  it("isRefSchema works on re-exported function", () => {
-    expect(isRefSchema({ kind: "ref", name: "Test" })).toBe(true);
-    expect(isRefSchema({ kind: "string" })).toBe(false);
-  });
-
-  it("resolveSchema works with registry", () => {
-    const pointSchema: StructSchema = {
-      kind: "struct",
-      fields: { x: { kind: "i32" }, y: { kind: "i32" } },
-    };
-    const registry: SchemaRegistry = new Map<string, Schema>([["Point", pointSchema as Schema]]);
-
-    const resolved = resolveSchema({ kind: "ref", name: "Point" }, registry);
-    expect(resolved).toBe(pointSchema);
+  it("exposes ref detection for runtime schema walking", () => {
+    expect(isRefSchema({ kind: "ref", name: "Payload" })).toBe(true);
+    expect(isRefSchema(PayloadSchema)).toBe(false);
   });
 });

--- a/typescript/packages/roam-wire/src/wire.test.ts
+++ b/typescript/packages/roam-wire/src/wire.test.ts
@@ -1,115 +1,83 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  type Message,
-  MessageDiscriminant,
-  MetadataValueDiscriminant,
-  HelloDiscriminant,
   MetadataFlags,
-  parityOdd,
-  parityEven,
   connectionSettings,
   helloV7,
   helloYourself,
-  metadataString,
   metadataBytes,
-  metadataU64,
   metadataEntry,
-  messageHello,
-  messagePing,
-  messagePong,
-  messageGoodbye,
-  messageRequest,
-  messageResponse,
-  messageCancel,
-  messageData,
+  metadataString,
   messageClose,
-  messageReset,
   messageCredit,
+  messageData,
+  messageHello,
+  messageRequest,
+  parityEven,
+  parityOdd,
 } from "./types.ts";
-import { HelloSchema, RequestBodySchema, MessageSchema } from "./schemas.ts";
-import {
-  encodeMessage,
-  decodeMessage,
-} from "./codec.ts";
+import { decodeMessage, encodeMessage } from "./codec.ts";
+import { HelloSchema, MessageSchema, RequestBodySchema } from "./schemas.ts";
 import { encodeU32 } from "@bearcove/roam-postcard";
 
-describe("wire discriminants", () => {
-  it("has correct v7 message discriminants", () => {
-    expect(MessageDiscriminant.Hello).toBe(0);
-    expect(MessageDiscriminant.HelloYourself).toBe(1);
-    expect(MessageDiscriminant.ProtocolError).toBe(2);
-    expect(MessageDiscriminant.ConnectionOpen).toBe(3);
-    expect(MessageDiscriminant.ConnectionAccept).toBe(4);
-    expect(MessageDiscriminant.ConnectionReject).toBe(5);
-    expect(MessageDiscriminant.ConnectionClose).toBe(6);
-    expect(MessageDiscriminant.RequestMessage).toBe(7);
-    expect(MessageDiscriminant.ChannelMessage).toBe(8);
-    expect(MessageDiscriminant.Ping).toBe(9);
-    expect(MessageDiscriminant.Pong).toBe(10);
-  });
-
-  it("has correct metadata and hello discriminants", () => {
-    expect(MetadataValueDiscriminant.String).toBe(0);
-    expect(MetadataValueDiscriminant.Bytes).toBe(1);
-    expect(MetadataValueDiscriminant.U64).toBe(2);
-    expect(HelloDiscriminant.V7).toBe(7);
-  });
-});
-
-describe("factory helpers", () => {
-  it("builds hello and hello-yourself", () => {
+describe("wire helpers", () => {
+  it("builds handshake helpers with expected defaults", () => {
     const hello = helloV7(parityOdd(), 64);
-    expect(hello.version).toBe(7);
-    expect(hello.connection_settings).toEqual(connectionSettings(parityOdd(), 64));
+    const yourself = helloYourself(parityEven(), 32);
 
-    const hy = helloYourself(parityEven(), 32);
-    expect(hy.connection_settings).toEqual(connectionSettings(parityEven(), 32));
+    expect(hello).toEqual({
+      version: 7,
+      connection_settings: connectionSettings(parityOdd(), 64),
+      metadata: [],
+    });
+    expect(yourself).toEqual({
+      connection_settings: connectionSettings(parityEven(), 32),
+      metadata: [],
+    });
   });
 
-  it("builds nested request/channel/control messages", () => {
-    const meta = [metadataEntry("k", metadataString("v"), MetadataFlags.NONE)];
-
-    const request = messageRequest(11n, 42n, new Uint8Array([1, 2]), meta, [3n], 2n);
-    expect(request.connection_id).toBe(2n);
-    expect(request.payload.tag).toBe("RequestMessage");
-
-    const response = messageResponse(11n, new Uint8Array([9]), meta, [7n], 2n);
-    expect(response.payload.tag).toBe("RequestMessage");
-
-    const cancel = messageCancel(11n, 2n, meta);
-    expect(cancel.payload.tag).toBe("RequestMessage");
-
-    const data = messageData(5n, new Uint8Array([8, 7]), 2n);
-    const close = messageClose(5n, 2n, meta);
-    const reset = messageReset(5n, 2n, meta);
+  it("builds nested request and channel helpers with the expected tags", () => {
+    const metadata = [metadataEntry("trace-id", metadataString("abc123"), MetadataFlags.NONE)];
+    const request = messageRequest(11n, 42n, new Uint8Array([1, 2]), metadata, [3n], 2n);
+    const item = messageData(5n, new Uint8Array([8, 7]), 2n);
+    const close = messageClose(5n, 2n, metadata);
     const credit = messageCredit(5n, 1024, 2n);
-    expect(data.payload.tag).toBe("ChannelMessage");
+
+    expect(request.payload).toMatchObject({
+      tag: "RequestMessage",
+      value: { id: 11n, body: { tag: "Call" } },
+    });
+    expect(item.payload).toMatchObject({
+      tag: "ChannelMessage",
+      value: { id: 5n, body: { tag: "Item" } },
+    });
     expect(close.payload.tag).toBe("ChannelMessage");
-    expect(reset.payload.tag).toBe("ChannelMessage");
     expect(credit.payload.tag).toBe("ChannelMessage");
 
-    const hello = messageHello(helloV7(parityOdd(), 64, meta));
-    const ping = messagePing(123n);
-    const pong = messagePong(123n);
-    const goodbye = messageGoodbye(2n, meta);
-    expect(hello.payload.tag).toBe("Hello");
-    expect(ping.payload.tag).toBe("Ping");
-    expect(pong.payload.tag).toBe("Pong");
-    expect(goodbye.payload.tag).toBe("ConnectionClose");
+    if (close.payload.tag !== "ChannelMessage" || credit.payload.tag !== "ChannelMessage") {
+      throw new Error("expected channel messages");
+    }
+
+    expect(close.payload.value.body.tag).toBe("Close");
+    expect(credit.payload.value.body.tag).toBe("GrantCredit");
   });
 });
 
-describe("schema-driven codec", () => {
-  it("roundtrips message with nested request body", () => {
+describe("wire codec", () => {
+  it("roundtrips arbitrary request payloads and consumes the full buffer", () => {
     const metadata = [
       metadataEntry("trace-id", metadataString("abc123"), MetadataFlags.NONE),
-      metadataEntry("auth", metadataBytes(new Uint8Array([0xde, 0xad, 0xbe, 0xef])), 3n),
-      metadataEntry("attempt", metadataU64(2n), MetadataFlags.NONE),
+      metadataEntry(
+        "payload",
+        metadataBytes(new Uint8Array([0xde, 0xad, 0xbe, 0xef])),
+        MetadataFlags.SENSITIVE,
+      ),
     ];
-
-    const args = encodeU32(0x1234_5678);
-    const message = messageRequest(11n, 0xE5A1_D6B2_C390_F001n, args, metadata, [3n, 5n], 2n);
+    const message = messageRequest(99n, 0xE5A1_D6B2_C390_F001n, encodeU32(0x1234_5678), metadata, [
+      3n,
+      5n,
+      8n,
+    ], 2n);
 
     const encoded = encodeMessage(message);
     const decoded = decodeMessage(encoded);
@@ -117,41 +85,27 @@ describe("schema-driven codec", () => {
     expect(decoded.next).toBe(encoded.length);
     expect(decoded.value).toEqual(message);
   });
-
-  it("roundtrips multiple messages individually", () => {
-    const messages: Message[] = [
-      messageHello(helloV7(parityOdd(), 64)),
-      messagePing(7n),
-      messagePong(7n),
-      messageGoodbye(2n, []),
-      messageData(3n, new Uint8Array([0x4d]), 2n),
-    ];
-
-    for (const message of messages) {
-      const encoded = encodeMessage(message);
-      const decoded = decodeMessage(encoded);
-      expect(decoded.next).toBe(encoded.length);
-      expect(decoded.value).toEqual(message);
-    }
-  });
 });
 
 describe("generated wire schemas", () => {
-  it("has v7 hello schema as struct", () => {
-    expect(HelloSchema.kind).toBe("struct");
-  });
-
   it("marks opaque payload bytes as trailing", () => {
     const requestBody = RequestBodySchema as any;
     const call = requestBody.variants.find((v: any) => v.name === "Call");
-    const response = requestBody.variants.find((v: any) => v.name === "Response");
     const channelBody = (MessageSchema as any).fields.payload.variants.find(
       (v: any) => v.name === "ChannelMessage",
     ).fields.fields.body;
     const item = channelBody.variants.find((v: any) => v.name === "Item");
 
+    expect(HelloSchema.kind).toBe("struct");
     expect(call.fields.fields.args).toEqual({ kind: "bytes", trailing: true });
-    expect(response.fields.fields.ret).toEqual({ kind: "bytes", trailing: true });
     expect(item.fields.fields.item).toEqual({ kind: "bytes", trailing: true });
+  });
+
+  it("encodes handshake messages with the generated schema", () => {
+    const encoded = encodeMessage(messageHello(helloV7(parityOdd(), 16)));
+    const decoded = decodeMessage(encoded);
+
+    expect(decoded.next).toBe(encoded.length);
+    expect(decoded.value.payload.tag).toBe("Hello");
   });
 });


### PR DESCRIPTION
## Summary
This trims redundant TypeScript test coverage in the v7 packages and keeps the remaining tests focused on runtime behavior instead of export smoke checks.

It also closes two stale cleanup issues: Playwright `test-results` are already ignored on current `main`, and the v7 Rust send path already sizes outbound buffers from a scatter plan before allocation.

## Changes
- replace `roam-core` channeling schema smoke tests with behavioral assertions around deferred ref resolution and enum metadata used by the runtime
- reduce `roam-wire` overlap with the Rust-backed golden-vector suite, keeping helper semantics, one arbitrary roundtrip invariant, and generated-schema trailing-bytes checks
- verify `#125` against current v7 conduit send paths, which call `facet_postcard::peek_to_scatter_plan(...)` and then `alloc(plan.total_size())` before writing
- verify `#161` is already resolved on `main` by existing ignore rules for `typescript/**/test-results/`

## Testing
- `pnpm --filter @bearcove/roam-core test -- src/channeling/schema.test.ts`
- `pnpm --filter @bearcove/roam-core run check`
- `pnpm --filter @bearcove/roam-wire test -- src/wire.test.ts src/golden.test.ts`
- `pnpm --filter @bearcove/roam-wire run check`

Closes #159
Closes #160
Closes #161
Closes #125
