### PR TITLE
Fix Swift request finalization races

### DIFF
--- a/swift/roam-runtime/Sources/RoamRuntime/Driver.swift
+++ b/swift/roam-runtime/Sources/RoamRuntime/Driver.swift
@@ -341,9 +341,7 @@ private final class LockedQueue<T>: @unchecked Sendable {
 
 /// Actor that holds mutable driver state to avoid NSLock in async contexts.
 private actor DriverState {
-    // Temporary kill-switch: keep the implementation in-tree but disabled
-    // while we debug the primary state-machine bug.
-    private let retainFinalizedRequests = false
+    private let retainFinalizedRequests = true
 
     private struct FinalizedRequest: Sendable {
         let reason: String
@@ -373,8 +371,12 @@ private actor DriverState {
         return true
     }
 
-    func removePendingResponse(_ requestId: UInt64) -> PendingCall? {
-        pendingResponses.removeValue(forKey: requestId)
+    func claimPendingResponse(_ requestId: UInt64, reason: String) -> PendingCall? {
+        guard let pending = pendingResponses.removeValue(forKey: requestId) else {
+            return nil
+        }
+        markFinalizedRequest(requestId, reason: reason)
+        return pending
     }
 
     func markFinalizedRequest(_ requestId: UInt64, reason: String) {
@@ -454,12 +456,15 @@ private actor DriverState {
         )
     }
 
-    func failAllPending() -> [UInt64: PendingCall] {
+    func claimAllPendingResponses(reason: String) -> [UInt64: PendingCall] {
         isClosed = true
         let responses = pendingResponses
         pendingResponses.removeAll()
         inFlightRequests.removeAll()
         inFlightResponseContext.removeAll()
+        for requestId in responses.keys {
+            markFinalizedRequest(requestId, reason: reason)
+        }
         return responses
     }
 
@@ -800,12 +805,15 @@ public final class Driver: @unchecked Sendable {
                     ))
                 return
             } catch {
-                let pending = await state.removePendingResponse(requestId)
+                let pending = await state.claimPendingResponse(
+                    requestId,
+                    reason: "transport-send-failed"
+                )
                 pending?.timeoutTask?.cancel()
                 warnLog(
                     "transport send failed for request_id \(requestId): \(String(describing: error))"
                 )
-                responseTx(.failure(.transportError(String(describing: error))))
+                pending?.responseTx(.failure(.transportError(String(describing: error))))
                 await failAllPending()
                 eventContinuation.finish()
                 return
@@ -827,10 +835,12 @@ public final class Driver: @unchecked Sendable {
                 } catch {
                     return
                 }
-                guard let pending = await capturedState.removePendingResponse(requestId) else {
+                guard let pending = await capturedState.claimPendingResponse(
+                    requestId,
+                    reason: "timeout"
+                ) else {
                     return
                 }
-                await capturedState.markFinalizedRequest(requestId, reason: "timeout")
                 pending.timeoutTask?.cancel()
                 warnLog("request timed out request_id=\(requestId) timeout_s=\(timeout)")
                 pending.responseTx(.failure(.timeout))
@@ -863,7 +873,10 @@ public final class Driver: @unchecked Sendable {
             } catch TransportError.wouldBlock {
                 return
             } catch {
-                let pending = await state.removePendingResponse(call.requestId)
+                let pending = await state.claimPendingResponse(
+                    call.requestId,
+                    reason: "transport-send-failed"
+                )
                 pending?.timeoutTask?.cancel()
                 pending?.responseTx(.failure(.transportError(String(describing: error))))
                 pendingCalls.removeFirst()
@@ -888,10 +901,12 @@ public final class Driver: @unchecked Sendable {
                 } catch {
                     return
                 }
-                guard let pending = await capturedState.removePendingResponse(requestId) else {
+                guard let pending = await capturedState.claimPendingResponse(
+                    requestId,
+                    reason: "timeout"
+                ) else {
                     return
                 }
-                await capturedState.markFinalizedRequest(requestId, reason: "timeout")
                 pending.timeoutTask?.cancel()
                 warnLog("request timed out request_id=\(requestId) timeout_s=\(timeout)")
                 pending.responseTx(.failure(.timeout))
@@ -983,7 +998,8 @@ public final class Driver: @unchecked Sendable {
                 )
             case .response(let response):
                 let payload = response.ret.bytes
-                guard let pending = await state.removePendingResponse(request.id) else {
+                guard let pending = await state.claimPendingResponse(request.id, reason: "response")
+                else {
                     if let finalized = await state.takeFinalizedRequest(request.id) {
                         warnLog(
                             "dropping late response for finalized request_id \(request.id) "
@@ -1212,7 +1228,7 @@ public final class Driver: @unchecked Sendable {
         // instead of hanging forever.
         await handle.closeRequestSemaphore()
 
-        let responses = await state.failAllPending()
+        let responses = await state.claimAllPendingResponses(reason: "connection-closed")
 
         for (_, pending) in responses {
             pending.timeoutTask?.cancel()

--- a/swift/roam-runtime/Tests/RoamRuntimeTests/ConnectionFailureTests.swift
+++ b/swift/roam-runtime/Tests/RoamRuntimeTests/ConnectionFailureTests.swift
@@ -587,7 +587,7 @@ struct ConnectionFailureTests {
         #expect(protocolReason == "call.lifecycle.unknown-request-id")
     }
 
-    @Test func lateResponseAfterTimeoutTriggersProtocolViolation() async throws {
+    @Test func lateResponseAfterTimeoutIsIgnoredAndConnectionStaysUsable() async throws {
         let transport = ScriptedTransport()
         let (handle, driver) = try await establishInitiator(
             transport: transport,
@@ -620,19 +620,97 @@ struct ConnectionFailureTests {
             )
         )
 
-        do {
-            try await driverTask.value
-            Issue.record("expected protocol violation")
-        } catch {
-            #expect(isProtocolViolation(error, rule: "call.lifecycle.unknown-request-id"))
+        let followupCall = Task {
+            try await handle.callRaw(methodId: 99, payload: [9], timeout: 1.0)
+        }
+        guard let followupRequestId = await awaitRequestId(transport, index: 1) else {
+            Issue.record("expected follow-up request to be sent")
+            return
         }
 
-        do {
-            _ = try await handle.callRaw(methodId: 99, payload: [9], timeout: 2.0)
-            Issue.record("expected connection closed")
-        } catch {
-            #expect(isConnectionClosed(error))
+        await transport.enqueueMessage(
+            .response(
+                connId: 0,
+                requestId: followupRequestId,
+                metadata: [],
+                channels: [],
+                payload: [0xBB]
+            )
+        )
+
+        let followupResponse = try await awaitTaskResult(followupCall, timeoutMs: 1_000)
+        #expect(followupResponse == [0xBB])
+        #expect(await awaitProtocolReason(transport, timeoutMs: 100) == nil)
+
+        try? await transport.close()
+        _ = try? await driverTask.value
+    }
+
+    @Test func duplicateResponseAfterSuccessIsIgnored() async throws {
+        let transport = ScriptedTransport()
+        let (handle, driver) = try await establishInitiator(
+            transport: transport,
+            dispatcher: NoopDispatcher()
+        )
+        let driverTask = Task {
+            try await driver.run()
         }
+
+        let firstCall = Task {
+            try await handle.callRaw(methodId: 7, payload: [7], timeout: 1.0)
+        }
+        guard let firstRequestId = await awaitRequestId(transport, index: 0) else {
+            Issue.record("expected first request to be sent")
+            return
+        }
+
+        await transport.enqueueMessage(
+            .response(
+                connId: 0,
+                requestId: firstRequestId,
+                metadata: [],
+                channels: [],
+                payload: [0x01]
+            )
+        )
+
+        let firstResponse = try await awaitTaskResult(firstCall, timeoutMs: 1_000)
+        #expect(firstResponse == [0x01])
+
+        await transport.enqueueMessage(
+            .response(
+                connId: 0,
+                requestId: firstRequestId,
+                metadata: [],
+                channels: [],
+                payload: [0x02]
+            )
+        )
+
+        let secondCall = Task {
+            try await handle.callRaw(methodId: 8, payload: [8], timeout: 1.0)
+        }
+        guard let secondRequestId = await awaitRequestId(transport, index: 1) else {
+            Issue.record("expected second request to be sent")
+            return
+        }
+
+        await transport.enqueueMessage(
+            .response(
+                connId: 0,
+                requestId: secondRequestId,
+                metadata: [],
+                channels: [],
+                payload: [0x03]
+            )
+        )
+
+        let secondResponse = try await awaitTaskResult(secondCall, timeoutMs: 1_000)
+        #expect(secondResponse == [0x03])
+        #expect(await awaitProtocolReason(transport, timeoutMs: 100) == nil)
+
+        try? await transport.close()
+        _ = try? await driverTask.value
     }
 
     @Test func protocolViolationFromIncomingMessageFailsPendingCalls() async throws {


### PR DESCRIPTION
## Summary
This fixes the Swift driver so each outgoing request has exactly one terminal owner inside driver state.

Pending calls are now claimed through a single state transition before any callback fires, which prevents teardown, timeout, transport-send failure, and response-arrival races from finalizing the same request more than once.

## Changes
- centralize pending-request claiming in `DriverState` instead of letting multiple paths remove and complete requests independently
- retain finalized request IDs long enough to drop late duplicate or timed-out responses instead of treating them as protocol violations
- update Swift connection-failure regression tests to prove late responses are ignored and the connection remains usable

## Testing
- `cargo build --release -p roam-shm-ffi`
- `cd swift/roam-runtime && swift test --filter ConnectionFailureTests`
- `cd swift/roam-runtime && swift test --filter ShmDriverRaceTests`

Closes #220
