### PR TITLE
Fix TypeScript enum decoding for named kind fields

### DIFF
--- a/rust/roam-codegen/src/targets/typescript/mod.rs
+++ b/rust/roam-codegen/src/targets/typescript/mod.rs
@@ -183,6 +183,8 @@ fn generate_request_response_types(
 
 #[cfg(test)]
 mod tests {
+    #![allow(dead_code)]
+
     use super::generate_service;
     use facet::Facet;
     use roam_hash::method_descriptor;
@@ -201,6 +203,89 @@ mod tests {
     #[derive(Facet)]
     struct SessionSummary {
         id: SessionId,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    enum ToolCallKind {
+        Read,
+        Execute,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    enum ToolCallStatus {
+        Running,
+        Success,
+        Failure,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    enum PermissionResolution {
+        Approved,
+        Denied,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    enum ContentBlock {
+        Text {
+            text: String,
+        },
+        ToolCall {
+            id: String,
+            title: String,
+            kind: Option<ToolCallKind>,
+            status: ToolCallStatus,
+        },
+        Permission {
+            id: String,
+            title: String,
+            kind: Option<ToolCallKind>,
+            resolution: Option<PermissionResolution>,
+        },
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    enum BlockPatch {
+        TextAppend {
+            text: String,
+        },
+        ToolCallUpdate {
+            id: String,
+            kind: Option<ToolCallKind>,
+            status: ToolCallStatus,
+        },
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    enum SessionEvent {
+        BlockAppend {
+            block_id: String,
+            role: String,
+            block: ContentBlock,
+        },
+        BlockPatch {
+            block_id: String,
+            role: String,
+            patch: BlockPatch,
+        },
+    }
+
+    #[derive(Facet)]
+    struct SessionEventEnvelope {
+        seq: u64,
+        event: SessionEvent,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    enum SubscribeMessage {
+        Event(SessionEventEnvelope),
+        ReplayComplete,
     }
 
     #[test]
@@ -305,6 +390,38 @@ mod tests {
         assert!(
             generated.contains("{ kind: 'rx', initial_credit: 32, element: { kind: 'u32' } }"),
             "explicit Rx<T, N> credit must be emitted into the descriptor:\n{generated}"
+        );
+    }
+
+    #[test]
+    fn generated_typescript_keeps_struct_variants_with_kind_fields_named() {
+        let subscribe =
+            method_descriptor::<(), SubscribeMessage>("ShipSvc", "subscribe", &[], None);
+        let methods = Box::leak(vec![subscribe].into_boxed_slice());
+        let service = ServiceDescriptor {
+            service_name: "ShipSvc",
+            methods,
+            doc: None,
+        };
+
+        let generated = generate_service(&service);
+        assert!(
+            generated.contains(
+                "name: 'ToolCall', fields: { 'id': { kind: 'string' }, 'title': { kind: 'string' }, 'kind': { kind: 'option', inner: { kind: 'ref', name: 'ToolCallKind' } }, 'status': { kind: 'ref', name: 'ToolCallStatus' } }"
+            ),
+            "struct variants with a field named `kind` must stay named-field variants:\n{generated}"
+        );
+        assert!(
+            generated.contains(
+                "name: 'Permission', fields: { 'id': { kind: 'string' }, 'title': { kind: 'string' }, 'kind': { kind: 'option', inner: { kind: 'ref', name: 'ToolCallKind' } }, 'resolution': { kind: 'option', inner: { kind: 'ref', name: 'PermissionResolution' } } }"
+            ),
+            "similar struct variants must keep their named `kind` field:\n{generated}"
+        );
+        assert!(
+            generated.contains(
+                "name: 'ToolCallUpdate', fields: { 'id': { kind: 'string' }, 'kind': { kind: 'option', inner: { kind: 'ref', name: 'ToolCallKind' } }, 'status': { kind: 'ref', name: 'ToolCallStatus' } }"
+            ),
+            "patch variants with a field named `kind` must also stay named-field variants:\n{generated}"
         );
     }
 }

--- a/typescript/packages/roam-postcard/src/schema.test.ts
+++ b/typescript/packages/roam-postcard/src/schema.test.ts
@@ -59,6 +59,27 @@ const MessageSchema: EnumSchema = {
   ],
 };
 
+const ShipLikeBlockSchema: EnumSchema = {
+  kind: "enum",
+  variants: [
+    {
+      name: "ToolCall",
+      fields: {
+        id: { kind: "string" },
+        kind: { kind: "option", inner: { kind: "ref", name: "MetadataValue" } },
+        status: { kind: "u8" },
+      },
+    },
+    {
+      name: "Permission",
+      fields: {
+        kind: { kind: "option", inner: { kind: "ref", name: "MetadataValue" } },
+        resolution: { kind: "bool" },
+      },
+    },
+  ],
+};
+
 const HelloSchema: EnumSchema = {
   kind: "enum",
   variants: [
@@ -229,6 +250,16 @@ describe("getVariantFieldSchemas", () => {
     expect(schemas[0]).toEqual({ kind: "u32" });
     expect(schemas[1]).toEqual({ kind: "u32" });
   });
+
+  it("treats a named-field variant with a `kind` field as a struct", () => {
+    const variant = ShipLikeBlockSchema.variants[0];
+    const schemas = getVariantFieldSchemas(variant);
+    expect(schemas).toEqual([
+      { kind: "string" },
+      { kind: "option", inner: { kind: "ref", name: "MetadataValue" } },
+      { kind: "u8" },
+    ]);
+  });
 });
 
 describe("getVariantFieldNames", () => {
@@ -258,6 +289,16 @@ describe("getVariantFieldNames", () => {
     const names = getVariantFieldNames(variant);
     expect(names).toEqual(["reason"]);
   });
+
+  it("returns field names for a struct variant whose fields include `kind`", () => {
+    const variant = ShipLikeBlockSchema.variants[0];
+    expect(getVariantFieldNames(variant)).toEqual(["id", "kind", "status"]);
+  });
+
+  it("returns field names when `kind` is the first and only semantic discriminator field", () => {
+    const variant = ShipLikeBlockSchema.variants[1];
+    expect(getVariantFieldNames(variant)).toEqual(["kind", "resolution"]);
+  });
 });
 
 describe("isNewtypeVariant", () => {
@@ -284,6 +325,11 @@ describe("isNewtypeVariant", () => {
   it("returns false for struct variant", () => {
     const variant = HelloSchema.variants[0]; // V1 { ... }
     expect(isNewtypeVariant(variant)).toBe(false);
+  });
+
+  it("returns false for struct variants whose named fields include `kind`", () => {
+    expect(isNewtypeVariant(ShipLikeBlockSchema.variants[0])).toBe(false);
+    expect(isNewtypeVariant(ShipLikeBlockSchema.variants[1])).toBe(false);
   });
 });
 

--- a/typescript/packages/roam-postcard/src/schema.ts
+++ b/typescript/packages/roam-postcard/src/schema.ts
@@ -261,20 +261,7 @@ export function getVariantDiscriminant(schema: EnumSchema, variant: EnumVariant)
  * @returns Array of field schemas in encoding order
  */
 export function getVariantFieldSchemas(variant: EnumVariant): Schema[] {
-  if (variant.fields === null || variant.fields === undefined) {
-    // Unit variant
-    return [];
-  }
-  if ("kind" in variant.fields) {
-    // Newtype variant - single schema
-    return [variant.fields as Schema];
-  }
-  if (Array.isArray(variant.fields)) {
-    // Tuple variant
-    return variant.fields;
-  }
-  // Struct variant - return schemas in key order
-  return Object.values(variant.fields);
+  return classifyVariantFields(variant).schemas;
 }
 
 /**
@@ -284,20 +271,7 @@ export function getVariantFieldSchemas(variant: EnumVariant): Schema[] {
  * @returns Array of field names, or null if not a struct variant
  */
 export function getVariantFieldNames(variant: EnumVariant): string[] | null {
-  if (variant.fields === null || variant.fields === undefined) {
-    // Unit variant
-    return null;
-  }
-  if ("kind" in variant.fields) {
-    // Newtype variant - no field names
-    return null;
-  }
-  if (Array.isArray(variant.fields)) {
-    // Tuple variant - no field names
-    return null;
-  }
-  // Struct variant - return keys in order
-  return Object.keys(variant.fields);
+  return classifyVariantFields(variant).names;
 }
 
 /**
@@ -307,7 +281,37 @@ export function getVariantFieldNames(variant: EnumVariant): string[] | null {
  * @returns True if this is a newtype variant
  */
 export function isNewtypeVariant(variant: EnumVariant): boolean {
-  return variant.fields !== null && variant.fields !== undefined && "kind" in variant.fields;
+  return classifyVariantFields(variant).kind === "newtype";
+}
+
+type VariantFieldInfo =
+  | { kind: "unit"; schemas: []; names: null }
+  | { kind: "newtype"; schemas: [Schema]; names: null }
+  | { kind: "tuple"; schemas: Schema[]; names: null }
+  | { kind: "struct"; schemas: Schema[]; names: string[] };
+
+function classifyVariantFields(variant: EnumVariant): VariantFieldInfo {
+  const fields = variant.fields;
+  if (fields === null || fields === undefined) {
+    return { kind: "unit", schemas: [], names: null };
+  }
+  if (Array.isArray(fields)) {
+    return { kind: "tuple", schemas: fields, names: null };
+  }
+  if (isSchemaNode(fields)) {
+    return { kind: "newtype", schemas: [fields], names: null };
+  }
+
+  const names = Object.keys(fields);
+  return {
+    kind: "struct",
+    schemas: names.map((name) => fields[name]),
+    names,
+  };
+}
+
+function isSchemaNode(fields: Schema | Record<string, Schema>): fields is Schema {
+  return typeof (fields as { kind?: unknown }).kind === "string";
 }
 
 /**

--- a/typescript/packages/roam-postcard/src/schema_codec.test.ts
+++ b/typescript/packages/roam-postcard/src/schema_codec.test.ts
@@ -72,6 +72,112 @@ const MetadataEntrySchema: TupleSchema = {
   elements: [{ kind: "string" }, { kind: "ref", name: "MetadataValue" }],
 };
 
+const ShipToolCallKindSchema: EnumSchema = {
+  kind: "enum",
+  variants: [
+    { name: "Read", fields: null },
+    { name: "Execute", fields: null },
+  ],
+};
+
+const ShipToolCallStatusSchema: EnumSchema = {
+  kind: "enum",
+  variants: [
+    { name: "Running", fields: null },
+    { name: "Success", fields: null },
+    { name: "Failure", fields: null },
+  ],
+};
+
+const ShipPermissionResolutionSchema: EnumSchema = {
+  kind: "enum",
+  variants: [
+    { name: "Approved", fields: null },
+    { name: "Denied", fields: null },
+  ],
+};
+
+const ShipContentBlockSchema: EnumSchema = {
+  kind: "enum",
+  variants: [
+    { name: "Text", fields: { text: { kind: "string" } } },
+    {
+      name: "ToolCall",
+      fields: {
+        id: { kind: "string" },
+        title: { kind: "string" },
+        kind: { kind: "option", inner: { kind: "ref", name: "ShipToolCallKind" } },
+        status: { kind: "ref", name: "ShipToolCallStatus" },
+      },
+    },
+    {
+      name: "Permission",
+      fields: {
+        id: { kind: "string" },
+        title: { kind: "string" },
+        kind: { kind: "option", inner: { kind: "ref", name: "ShipToolCallKind" } },
+        resolution: {
+          kind: "option",
+          inner: { kind: "ref", name: "ShipPermissionResolution" },
+        },
+      },
+    },
+  ],
+};
+
+const ShipBlockPatchSchema: EnumSchema = {
+  kind: "enum",
+  variants: [
+    { name: "TextAppend", fields: { text: { kind: "string" } } },
+    {
+      name: "ToolCallUpdate",
+      fields: {
+        id: { kind: "string" },
+        kind: { kind: "option", inner: { kind: "ref", name: "ShipToolCallKind" } },
+        status: { kind: "ref", name: "ShipToolCallStatus" },
+      },
+    },
+  ],
+};
+
+const ShipSessionEventSchema: EnumSchema = {
+  kind: "enum",
+  variants: [
+    {
+      name: "BlockAppend",
+      fields: {
+        block_id: { kind: "string" },
+        role: { kind: "string" },
+        block: { kind: "ref", name: "ShipContentBlock" },
+      },
+    },
+    {
+      name: "BlockPatch",
+      fields: {
+        block_id: { kind: "string" },
+        role: { kind: "string" },
+        patch: { kind: "ref", name: "ShipBlockPatch" },
+      },
+    },
+  ],
+};
+
+const ShipSessionEventEnvelopeSchema: StructSchema = {
+  kind: "struct",
+  fields: {
+    seq: { kind: "u64" },
+    event: { kind: "ref", name: "ShipSessionEvent" },
+  },
+};
+
+const ShipSubscribeMessageSchema: EnumSchema = {
+  kind: "enum",
+  variants: [
+    { name: "Event", fields: { kind: "ref", name: "ShipSessionEventEnvelope" } },
+    { name: "ReplayComplete", fields: null },
+  ],
+};
+
 // Registry for resolving refs
 const testRegistry: SchemaRegistry = new Map<string, Schema>([
   ["Point", PointSchema as Schema],
@@ -80,6 +186,14 @@ const testRegistry: SchemaRegistry = new Map<string, Schema>([
   ["Hello", HelloSchema as Schema],
   ["Message", MessageSchema as Schema],
   ["MetadataEntry", MetadataEntrySchema as Schema],
+  ["ShipToolCallKind", ShipToolCallKindSchema as Schema],
+  ["ShipToolCallStatus", ShipToolCallStatusSchema as Schema],
+  ["ShipPermissionResolution", ShipPermissionResolutionSchema as Schema],
+  ["ShipContentBlock", ShipContentBlockSchema as Schema],
+  ["ShipBlockPatch", ShipBlockPatchSchema as Schema],
+  ["ShipSessionEvent", ShipSessionEventSchema as Schema],
+  ["ShipSessionEventEnvelope", ShipSessionEventEnvelopeSchema as Schema],
+  ["ShipSubscribeMessage", ShipSubscribeMessageSchema as Schema],
 ]);
 
 // ============================================================================
@@ -446,6 +560,117 @@ describe("wire protocol types", () => {
     const encoded = encodeWithSchema(value, schema, testRegistry);
     const decoded = decodeWithSchema(encoded, 0, schema, testRegistry);
     expect(decoded.value).toEqual(value);
+  });
+});
+
+describe("Ship-style enum variants with a `kind` field", () => {
+  it("roundtrips SubscribeMessage.Event -> BlockAppend -> ContentBlock.ToolCall", () => {
+    const value = {
+      tag: "Event",
+      value: {
+        seq: 7n,
+        event: {
+          tag: "BlockAppend",
+          block_id: "block-1",
+          role: "assistant",
+          block: {
+            tag: "ToolCall",
+            id: "tool-1",
+            title: "Inspect logs",
+            kind: { tag: "Read" },
+            status: { tag: "Running" },
+          },
+        },
+      },
+    };
+
+    const encoded = encodeWithSchema(
+      value,
+      { kind: "ref", name: "ShipSubscribeMessage" },
+      testRegistry,
+    );
+    const decoded = decodeWithSchema(
+      encoded,
+      0,
+      { kind: "ref", name: "ShipSubscribeMessage" },
+      testRegistry,
+    );
+
+    expect(decoded.value).toEqual(value);
+  });
+
+  it("roundtrips ContentBlock.Permission without routing through a synthetic `.value` field", () => {
+    const value = {
+      tag: "Permission",
+      id: "perm-1",
+      title: "Allow write",
+      kind: { tag: "Execute" },
+      resolution: { tag: "Approved" },
+    };
+
+    const encoded = encodeWithSchema(value, { kind: "ref", name: "ShipContentBlock" }, testRegistry);
+    const decoded = decodeWithSchema(
+      encoded,
+      0,
+      { kind: "ref", name: "ShipContentBlock" },
+      testRegistry,
+    );
+
+    expect(decoded.value).toEqual(value);
+  });
+
+  it("roundtrips BlockPatch.ToolCallUpdate with named fields including `kind`", () => {
+    const value = {
+      tag: "ToolCallUpdate",
+      id: "tool-1",
+      kind: { tag: "Read" },
+      status: { tag: "Success" },
+    };
+
+    const encoded = encodeWithSchema(value, { kind: "ref", name: "ShipBlockPatch" }, testRegistry);
+    const decoded = decodeWithSchema(
+      encoded,
+      0,
+      { kind: "ref", name: "ShipBlockPatch" },
+      testRegistry,
+    );
+
+    expect(decoded.value).toEqual(value);
+  });
+
+  it("reports nested struct-variant field paths without inserting `.value`", () => {
+    const value = {
+      tag: "Event",
+      value: {
+        seq: 11n,
+        event: {
+          tag: "BlockAppend",
+          block_id: "block-2",
+          role: "assistant",
+          block: {
+            tag: "ToolCall",
+            id: "tool-2",
+            title: "Run command",
+            kind: { tag: "Execute" },
+            status: { tag: "Running" },
+          },
+        },
+      },
+    };
+
+    const encoded = encodeWithSchema(
+      value,
+      { kind: "ref", name: "ShipSubscribeMessage" },
+      testRegistry,
+    );
+    encoded[encoded.length - 1] = 9;
+
+    expect(() =>
+      decodeWithSchema(encoded, 0, { kind: "ref", name: "ShipSubscribeMessage" }, testRegistry),
+    ).toThrow(/Path: Event.value.event.BlockAppend.block.ToolCall.status/);
+    expect(() =>
+      decodeWithSchema(encoded, 0, { kind: "ref", name: "ShipSubscribeMessage" }, testRegistry),
+    ).not.toThrow(/ToolCall.value/);
   });
 });
 


### PR DESCRIPTION
## Summary
Roam's TypeScript enum helpers were classifying any variant payload object with a field named `kind` as a newtype schema node. That breaks normal named-field variants like Ship's `ContentBlock::ToolCall`, because decode incorrectly goes through `.value` and eventually fails with `Unknown schema kind: [object Object]`.

This change centralizes variant field classification in `roam-postcard`, so only actual schema nodes count as newtypes. Named-field variants that happen to contain a field literally named `kind` now remain struct variants during encode/decode.

## Changes
- replace repeated `kind`-field heuristics with one explicit classifier in `roam-postcard`
- add helper regressions for named-field enum variants whose fields include `kind`
- add Ship-shaped postcard codec coverage for `SubscribeMessage -> Event -> BlockAppend -> ContentBlock.ToolCall`, `ContentBlock.Permission`, and `BlockPatch.ToolCallUpdate`
- add a `roam-codegen` regression to keep generated TypeScript descriptors for these variants in normal named-field form

## Testing
- `pnpm --filter @bearcove/roam-postcard test`
- `pnpm --filter @bearcove/roam-core test`
- `pnpm --filter @bearcove/roam-postcard check`
- `pnpm --filter @bearcove/roam-core check`
- `cargo nextest run -p roam-codegen generated_typescript_keeps_struct_variants_with_kind_fields_named`
