### PR TITLE
Add opt-in request context for Rust service methods

### DIFF
--- a/rust/roam-inprocess/Cargo.toml
+++ b/rust/roam-inprocess/Cargo.toml
@@ -12,6 +12,9 @@ description = "In-process transport for roam — WASM-to-JS message passing with
 
 [package.metadata]
 
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
 [dependencies]
 roam-types.workspace = true
 

--- a/rust/roam-inprocess/arborium-header.html
+++ b/rust/roam-inprocess/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@2/dist/arborium.iife.js"></script>

--- a/rust/roam-macros-core/src/lib.rs
+++ b/rust/roam-macros-core/src/lib.rs
@@ -260,6 +260,7 @@ fn generate_service_trait(parsed: &ServiceTrait, roam: &TokenStream2) -> TokenSt
 fn generate_trait_method(method: &ServiceMethod, roam: &TokenStream2) -> TokenStream2 {
     let method_name = format_ident!("{}", method.name().to_snake_case());
     let method_doc = method.doc().map(|d| quote! { #[doc = #d] });
+    let wants_context = method.wants_context();
 
     let return_type = method.return_type();
     let (ok_ty_ref, err_ty_ref) = method_ok_and_err_types(&return_type);
@@ -279,20 +280,33 @@ fn generate_trait_method(method: &ServiceMethod, roam: &TokenStream2) -> TokenSt
         })
         .collect();
 
+    let context_param = wants_context.then(|| quote! { cx: &#roam::RequestContext<'_> });
+
     if ok_has_roam_lifetime {
         let ok_ty = ok_ty_ref.to_token_stream();
         let err_ty = err_ty_ref
             .map(Type::to_token_stream)
             .unwrap_or_else(|| quote! { ::core::convert::Infallible });
+        let mut signature_params = Vec::new();
+        if let Some(context_param) = context_param.clone() {
+            signature_params.push(context_param);
+        }
+        signature_params.push(quote! { call: impl #roam::Call<'roam, #ok_ty, #err_ty> });
+        signature_params.extend(params);
         quote! {
             #method_doc
-            fn #method_name #method_lifetime (&self, call: impl #roam::Call<'roam, #ok_ty, #err_ty>, #(#params),*) -> impl std::future::Future<Output = ()> + Send;
+            fn #method_name #method_lifetime (&self, #(#signature_params),*) -> impl std::future::Future<Output = ()> + Send;
         }
     } else {
         let output_ty = return_type.to_token_stream();
+        let mut signature_params = Vec::new();
+        if let Some(context_param) = context_param {
+            signature_params.push(context_param);
+        }
+        signature_params.extend(params);
         quote! {
             #method_doc
-            fn #method_name (&self, #(#params),*) -> impl std::future::Future<Output = #output_ty> + Send;
+            fn #method_name (&self, #(#signature_params),*) -> impl std::future::Future<Output = #output_ty> + Send;
         }
     }
 }
@@ -375,6 +389,7 @@ fn generate_dispatch_arm(
 ) -> TokenStream2 {
     let method_fn = format_ident!("{}", method.name().to_snake_case());
     let idx = method_index;
+    let wants_context = method.wants_context();
 
     // Build args tuple type for deserialization
     let arg_types: Vec<TokenStream2> = method
@@ -450,20 +465,42 @@ fn generate_dispatch_arm(
         .map(Type::to_token_stream)
         .unwrap_or_else(|| quote! { ::core::convert::Infallible });
 
+    let context_setup = if wants_context {
+        quote! {
+            let context = #roam::RequestContext::new(
+                #descriptor_fn_name().methods[#idx],
+                &call.metadata,
+            );
+        }
+    } else {
+        quote! {}
+    };
+
+    let plain_handler_args: Vec<TokenStream2> = std::iter::empty()
+        .chain(wants_context.then(|| quote! { &context }))
+        .chain(arg_names.iter().map(|name| quote! { #name }))
+        .collect();
+
+    let borrowed_handler_args: Vec<TokenStream2> = std::iter::empty()
+        .chain(wants_context.then(|| quote! { &context }))
+        .chain(std::iter::once(quote! { sink_call }))
+        .chain(arg_names.iter().map(|name| quote! { #name }))
+        .collect();
+
     let invoke_and_reply = if ok_has_roam_lifetime {
         quote! {
             let sink_call = #roam::SinkCall::new(reply);
-            self.handler.#method_fn(sink_call, #(#arg_names),*).await;
+            self.handler.#method_fn(#(#borrowed_handler_args),*).await;
         }
     } else if is_fallible {
         quote! {
-            let result = self.handler.#method_fn(#(#arg_names),*).await;
+            let result = self.handler.#method_fn(#(#plain_handler_args),*).await;
             let sink_call = #roam::SinkCall::new(reply);
             #roam::Call::<'_, #ok_ty, #err_ty>::reply(sink_call, result).await;
         }
     } else {
         quote! {
-            let value = self.handler.#method_fn(#(#arg_names),*).await;
+            let value = self.handler.#method_fn(#(#plain_handler_args),*).await;
             let sink_call = #roam::SinkCall::new(reply);
             #roam::Call::<'_, #ok_ty, #err_ty>::ok(sink_call, value).await;
         }
@@ -480,6 +517,7 @@ fn generate_dispatch_arm(
             };
             #channel_binding
             #destructure
+            #context_setup
             #invoke_and_reply
             return;
         }
@@ -789,6 +827,18 @@ mod tests {
     fn no_args() {
         assert_snapshot!(generate(quote! {
             trait Ping { async fn ping(&self) -> u64; }
+        }));
+    }
+
+    #[test]
+    fn explicit_request_context_opt_in() {
+        assert_snapshot!(generate(quote! {
+            trait Audit {
+                #[roam::context]
+                async fn record(&self, payload: String) -> &'roam str;
+
+                async fn ping(&self) -> u64;
+            }
         }));
     }
 

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__explicit_request_context_opt_in.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__explicit_request_context_opt_in.snap
@@ -1,0 +1,215 @@
+---
+source: rust/roam-macros-core/src/lib.rs
+assertion_line: 835
+expression: "generate(quote!\n{\n    trait Audit\n    {\n        #[roam::context] async fn record(&self, payload: String) -> &'roam\n        str; async fn ping(&self) -> u64;\n    }\n})"
+---
+#[allow(non_snake_case, clippy::all)]
+pub fn audit_service_descriptor() -> &'static ::roam::session::ServiceDescriptor {
+    static DESCRIPTOR: std::sync::OnceLock<&'static ::roam::session::ServiceDescriptor> =
+        std::sync::OnceLock::new();
+    DESCRIPTOR.get_or_init(|| {
+        let methods: Vec<&'static ::roam::session::MethodDescriptor> = vec![
+            ::roam::hash::method_descriptor::<(String,), &'static str>(
+                "Audit",
+                "record",
+                &["payload"],
+                None,
+            ),
+            ::roam::hash::method_descriptor::<(), u64>("Audit", "ping", &[], None),
+        ];
+        Box::leak(Box::new(::roam::session::ServiceDescriptor {
+            service_name: "Audit",
+            methods: Box::leak(methods.into_boxed_slice()),
+            doc: None,
+        }))
+    })
+}
+pub trait Audit
+where
+    Self: Send + Sync,
+{
+    fn record<'roam>(
+        &self,
+        cx: &::roam::RequestContext<'_>,
+        call: impl ::roam::Call<'roam, &'roam str, ::core::convert::Infallible>,
+        payload: String,
+    ) -> impl std::future::Future<Output = ()> + Send;
+    fn ping(&self) -> impl std::future::Future<Output = u64> + Send;
+}
+#[doc = r" Dispatcher for this service."]
+#[doc = r""]
+#[doc = r" Wraps a handler and implements [`#roam::Handler`] by routing incoming"]
+#[doc = r" calls to the appropriate trait method by method ID."]
+#[derive(Clone)]
+pub struct AuditDispatcher<H> {
+    handler: H,
+}
+impl<H> AuditDispatcher<H>
+where
+    H: Audit + Clone + Send + Sync + 'static,
+{
+    #[doc = r" Create a new dispatcher wrapping the given handler."]
+    pub fn new(handler: H) -> Self {
+        Self { handler }
+    }
+}
+impl<H, R> ::roam::Handler<R> for AuditDispatcher<H>
+where
+    H: Audit + Clone + Send + Sync + 'static,
+    R: ::roam::ReplySink,
+{
+    async fn handle(&self, call: ::roam::SelfRef<::roam::RequestCall<'static>>, reply: R) {
+        let method_id = call.method_id;
+        let args_bytes = match &call.args {
+            ::roam::Payload::Incoming(bytes) => bytes,
+            _ => {
+                reply
+                    .send_error(::roam::RoamError::<::core::convert::Infallible>::InvalidPayload)
+                    .await;
+                return;
+            }
+        };
+        if method_id == audit_service_descriptor().methods[0usize].id {
+            let args: (String,) = match ::roam::facet_postcard::from_slice_borrowed(args_bytes) {
+                Ok(v) => v,
+                Err(_) => {
+                    reply
+                        .send_error(
+                            ::roam::RoamError::<::core::convert::Infallible>::InvalidPayload,
+                        )
+                        .await;
+                    return;
+                }
+            };
+            let (payload,) = args;
+            let context = ::roam::RequestContext::new(
+                audit_service_descriptor().methods[0usize],
+                &call.metadata,
+            );
+            let sink_call = ::roam::SinkCall::new(reply);
+            self.handler.record(&context, sink_call, payload).await;
+            return;
+        }
+        if method_id == audit_service_descriptor().methods[1usize].id {
+            let args: () = match ::roam::facet_postcard::from_slice_borrowed(args_bytes) {
+                Ok(v) => v,
+                Err(_) => {
+                    reply
+                        .send_error(
+                            ::roam::RoamError::<::core::convert::Infallible>::InvalidPayload,
+                        )
+                        .await;
+                    return;
+                }
+            };
+            let () = args;
+            let value = self.handler.ping().await;
+            let sink_call = ::roam::SinkCall::new(reply);
+            ::roam::Call::<'_, u64, ::core::convert::Infallible>::ok(sink_call, value).await;
+            return;
+        }
+        reply
+            .send_error(::roam::RoamError::<::core::convert::Infallible>::UnknownMethod)
+            .await;
+    }
+}
+#[doc = "Client for the `Audit` service.\n\nStores a type-erased [`Caller`](:: roam::Caller) implementation."]
+#[must_use = "Dropping this client may close the connection if it is the last caller."]
+#[derive(Clone)]
+pub struct AuditClient {
+    caller: ::roam::ErasedCaller,
+}
+impl AuditClient {
+    #[doc = r" Create a new client wrapping the given caller."]
+    pub fn new(caller: impl ::roam::Caller) -> Self {
+        Self {
+            caller: ::roam::ErasedCaller::new(caller),
+        }
+    }
+    #[doc = r" Resolve when the underlying connection closes."]
+    pub async fn closed(&self) {
+        ::roam::Caller::closed(&self.caller).await;
+    }
+    #[doc = r" Return whether the underlying connection is still considered connected."]
+    pub fn is_connected(&self) -> bool {
+        ::roam::Caller::is_connected(&self.caller)
+    }
+    pub async fn record(
+        &self,
+        payload: String,
+    ) -> Result<::roam::SelfRef<&'static str>, ::roam::RoamError> {
+        let method_id = audit_service_descriptor().methods[0usize].id;
+        let args = (payload,);
+        let channels = vec![];
+        let req = ::roam::RequestCall {
+            method_id,
+            args: ::roam::Payload::outgoing(&args),
+            channels,
+            metadata: Default::default(),
+        };
+        let response = ::roam::Caller::call(&self.caller, req)
+            .await
+            .map_err(|e| match e {
+                ::roam::RoamError::UnknownMethod => {
+                    ::roam::RoamError::<::core::convert::Infallible>::UnknownMethod
+                }
+                ::roam::RoamError::InvalidPayload => {
+                    ::roam::RoamError::<::core::convert::Infallible>::InvalidPayload
+                }
+                ::roam::RoamError::Cancelled => {
+                    ::roam::RoamError::<::core::convert::Infallible>::Cancelled
+                }
+                ::roam::RoamError::User(never) => match never {},
+            })?;
+        response.try_repack(|resp, _bytes| {
+            let ret_bytes = match &resp.ret {
+                ::roam::Payload::Incoming(bytes) => bytes,
+                _ => return Err(::roam::RoamError::<::core::convert::Infallible>::InvalidPayload),
+            };
+            let result: Result<&'static str, ::roam::RoamError<::core::convert::Infallible>> =
+                ::roam::facet_postcard::from_slice_borrowed(ret_bytes).map_err(|_| {
+                    ::roam::RoamError::<::core::convert::Infallible>::InvalidPayload
+                })?;
+            let ret = result?;
+            Ok(ret)
+        })
+    }
+    pub async fn ping(&self) -> Result<u64, ::roam::RoamError> {
+        let method_id = audit_service_descriptor().methods[1usize].id;
+        let args = ();
+        let channels = vec![];
+        let req = ::roam::RequestCall {
+            method_id,
+            args: ::roam::Payload::outgoing(&args),
+            channels,
+            metadata: Default::default(),
+        };
+        let response = ::roam::Caller::call(&self.caller, req)
+            .await
+            .map_err(|e| match e {
+                ::roam::RoamError::UnknownMethod => {
+                    ::roam::RoamError::<::core::convert::Infallible>::UnknownMethod
+                }
+                ::roam::RoamError::InvalidPayload => {
+                    ::roam::RoamError::<::core::convert::Infallible>::InvalidPayload
+                }
+                ::roam::RoamError::Cancelled => {
+                    ::roam::RoamError::<::core::convert::Infallible>::Cancelled
+                }
+                ::roam::RoamError::User(never) => match never {},
+            })?;
+        let ret_bytes = match &response.ret {
+            ::roam::Payload::Incoming(bytes) => bytes,
+            _ => return Err(::roam::RoamError::<::core::convert::Infallible>::InvalidPayload),
+        };
+        let result: Result<u64, ::roam::RoamError<::core::convert::Infallible>> =
+            ::roam::facet_postcard::from_slice(ret_bytes)
+                .map_err(|_| ::roam::RoamError::<::core::convert::Infallible>::InvalidPayload)?;
+        result
+    }
+}
+impl From<::roam::DriverCaller> for AuditClient {
+    fn from(caller: ::roam::DriverCaller) -> Self {
+        Self::new(caller)
+    }
+}

--- a/rust/roam-macros-parse/src/lib.rs
+++ b/rust/roam-macros-parse/src/lib.rs
@@ -443,6 +443,11 @@ impl ServiceMethod {
     pub fn has_generics(&self) -> bool {
         !self.generics.is_empty()
     }
+
+    /// Check whether this method explicitly opts into request context injection.
+    pub fn wants_context(&self) -> bool {
+        has_attr_path(&self.attributes, &["roam", "context"])
+    }
 }
 
 // ============================================================================
@@ -497,6 +502,32 @@ fn collect_doc_string(attrs: &Any<RawAttribute>) -> Option<String> {
     } else {
         Some(docs.join("\n"))
     }
+}
+
+fn has_attr_path(attrs: &Any<RawAttribute>, expected: &[&str]) -> bool {
+    attrs
+        .iter()
+        .any(|attr| attr_path_matches(&attr.value, expected))
+}
+
+fn attr_path_matches(attr: &RawAttribute, expected: &[&str]) -> bool {
+    let mut iter = attr.body.content.clone().to_token_iter();
+    let Ok(path) = TypePath::parse(&mut iter) else {
+        return false;
+    };
+    if EndOfStream::parse(&mut iter).is_err() {
+        return false;
+    }
+
+    let actual = std::iter::once(path.first.to_string())
+        .chain(path.rest.iter().map(|seg| seg.value.second.to_string()))
+        .collect::<Vec<_>>();
+
+    actual.len() == expected.len()
+        && actual
+            .iter()
+            .zip(expected.iter())
+            .all(|(actual, expected)| actual == expected)
 }
 
 /// Parse a trait definition from a token stream.
@@ -576,6 +607,23 @@ mod tests {
         let method = trait_def.methods().next().expect("method");
         assert!(method.has_generics());
         assert!(method.is_mut_receiver());
+    }
+
+    #[test]
+    fn method_helpers_detect_explicit_request_context_opt_in() {
+        let trait_def = parse(
+            r#"
+            trait Svc {
+                #[roam::context]
+                async fn contextual(&self) -> u32;
+
+                async fn plain(&self) -> u32;
+            }
+            "#,
+        );
+        let mut methods = trait_def.methods();
+        assert!(methods.next().expect("contextual method").wants_context());
+        assert!(!methods.next().expect("plain method").wants_context());
     }
 
     #[test]

--- a/rust/roam-types/src/lib.rs
+++ b/rust/roam-types/src/lib.rs
@@ -94,6 +94,9 @@ pub use conduit::*;
 mod metadata;
 pub use metadata::*;
 
+mod request_context;
+pub use request_context::*;
+
 mod calls;
 pub use calls::*;
 

--- a/rust/roam-types/src/request_context.rs
+++ b/rust/roam-types/src/request_context.rs
@@ -1,0 +1,28 @@
+use crate::{MetadataEntry, MethodDescriptor};
+
+/// Borrowed per-request context exposed to opted-in Rust service handlers.
+///
+/// This is constructed by generated dispatchers from the inbound request and
+/// borrows request metadata directly rather than cloning it.
+#[derive(Clone, Copy, Debug)]
+pub struct RequestContext<'a> {
+    method: &'static MethodDescriptor,
+    metadata: &'a [MetadataEntry<'static>],
+}
+
+impl<'a> RequestContext<'a> {
+    /// Create a new borrowed request context.
+    pub fn new(method: &'static MethodDescriptor, metadata: &'a [MetadataEntry<'static>]) -> Self {
+        Self { method, metadata }
+    }
+
+    /// Static descriptor for the method being handled.
+    pub fn method(&self) -> &'static MethodDescriptor {
+        self.method
+    }
+
+    /// Request metadata borrowed from the inbound call.
+    pub fn metadata(&self) -> &'a [MetadataEntry<'static>] {
+        self.metadata
+    }
+}

--- a/rust/roam/src/lib.rs
+++ b/rust/roam/src/lib.rs
@@ -49,6 +49,7 @@ pub use roam_types::{
     Payload,
     ReplySink,
     RequestCall,
+    RequestContext,
     RequestResponse,
     ResponseParts,
     RoamError,

--- a/rust/roam/tests/service_macro_shared.rs
+++ b/rust/roam/tests/service_macro_shared.rs
@@ -17,6 +17,27 @@ impl Adder for MyAdder {
     }
 }
 
+#[roam::service]
+trait ContextProbe {
+    #[roam::context]
+    async fn describe(&self) -> String;
+
+    async fn plain(&self) -> String;
+}
+
+#[derive(Clone)]
+struct ContextProbeService;
+
+impl ContextProbe for ContextProbeService {
+    async fn describe(&self, cx: &roam::RequestContext<'_>) -> String {
+        format!("{}:{}", cx.method().method_name, cx.metadata().len(),)
+    }
+
+    async fn plain(&self) -> String {
+        "plain".to_string()
+    }
+}
+
 pub async fn run_adder_end_to_end<L>(
     message_conduit_pair: impl FnOnce() -> (MessageConduit<L>, MessageConduit<L>),
 ) where
@@ -48,5 +69,44 @@ pub async fn run_adder_end_to_end<L>(
 
     let response = client.add(100, -42).await.expect("add call should succeed");
     assert_eq!(response, 58);
+    server_task.abort();
+}
+
+pub async fn run_request_context_end_to_end<L>(
+    message_conduit_pair: impl FnOnce() -> (MessageConduit<L>, MessageConduit<L>),
+) where
+    L: Link + Send + 'static,
+    L::Tx: Send + 'static,
+    L::Rx: Send + 'static,
+{
+    let (client_conduit, server_conduit) = message_conduit_pair();
+
+    let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::task::spawn(async move {
+        let (server_caller_guard, _sh) = acceptor(server_conduit)
+            .establish::<ContextProbeClient>(ContextProbeDispatcher::new(ContextProbeService))
+            .await
+            .expect("server handshake failed");
+        let _ = server_ready_tx.send(());
+        let _server_caller_guard = server_caller_guard;
+        std::future::pending::<()>().await;
+    });
+
+    let (client, _sh) = initiator(client_conduit)
+        .establish::<ContextProbeClient>(())
+        .await
+        .expect("client handshake failed");
+
+    server_ready_rx.await.expect("server setup failed");
+
+    let described = client
+        .describe()
+        .await
+        .expect("describe call should succeed");
+    assert_eq!(described, "describe:0");
+
+    let plain = client.plain().await.expect("plain call should succeed");
+    assert_eq!(plain, "plain");
+
     server_task.abort();
 }

--- a/rust/roam/tests/service_macro_tests.rs
+++ b/rust/roam/tests/service_macro_tests.rs
@@ -13,3 +13,8 @@ fn message_conduit_pair() -> (MessageConduit, MessageConduit) {
 async fn adder_service_macro_end_to_end() {
     service_macro_shared::run_adder_end_to_end(message_conduit_pair).await;
 }
+
+#[tokio::test]
+async fn request_context_opt_in_end_to_end() {
+    service_macro_shared::run_request_context_end_to_end(message_conduit_pair).await;
+}

--- a/rust/roam/tests/shm_service_macro_tests.rs
+++ b/rust/roam/tests/shm_service_macro_tests.rs
@@ -42,3 +42,9 @@ async fn adder_service_macro_end_to_end_over_shm() {
     let (a, b, _dir) = message_conduit_pair().await;
     service_macro_shared::run_adder_end_to_end(|| (a, b)).await;
 }
+
+#[tokio::test]
+async fn request_context_opt_in_end_to_end_over_shm() {
+    let (a, b, _dir) = message_conduit_pair().await;
+    service_macro_shared::run_request_context_end_to_end(|| (a, b)).await;
+}


### PR DESCRIPTION
## Summary

This adds explicit request-context opt-in for Rust `#[roam::service]` handlers without introducing task-local state or changing client call signatures. It is the request-context slice of the broader middleware/retry work tracked in #171.

## Changes

- add `#[roam::context]` method opt-in detection in `roam-macros-parse`
- add borrowed `roam::RequestContext<'_>` exposing the current method descriptor and inbound metadata without copying metadata per request
- generate an extra `&RequestContext` server-side parameter only for opted-in methods, and construct it in the dispatcher from the inbound `RequestCall`
- add macro snapshot coverage plus end-to-end tests over both memory-link and SHM transports
- include the rustdoc header metadata/header files auto-staged by the repo hook for `roam-inprocess`

## Testing

- `cargo nextest run -p roam-macros-parse -p roam-macros-core -p roam`
