### PR TITLE
Add Rust server middleware and logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,6 +2299,8 @@ dependencies = [
  "shm-primitives",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/roam-macros-core/src/lib.rs
+++ b/rust/roam-macros-core/src/lib.rs
@@ -357,6 +357,7 @@ fn generate_dispatcher(parsed: &ServiceTrait, roam: &TokenStream2) -> TokenStrea
         #[derive(Clone)]
         pub struct #dispatcher_name<H> {
             handler: H,
+            middlewares: Vec<::std::sync::Arc<dyn #roam::ServerMiddleware>>,
         }
 
         impl<H> #dispatcher_name<H>
@@ -365,7 +366,32 @@ fn generate_dispatcher(parsed: &ServiceTrait, roam: &TokenStream2) -> TokenStrea
         {
             /// Create a new dispatcher wrapping the given handler.
             pub fn new(handler: H) -> Self {
-                Self { handler }
+                Self {
+                    handler,
+                    middlewares: vec![],
+                }
+            }
+
+            /// Append a server middleware to this dispatcher.
+            pub fn with_middleware(mut self, middleware: impl #roam::ServerMiddleware) -> Self {
+                self.middlewares.push(::std::sync::Arc::new(middleware));
+                self
+            }
+
+            async fn run_pre_hooks(&self, context: &#roam::RequestContext<'_>) {
+                for middleware in &self.middlewares {
+                    middleware.pre(context).await;
+                }
+            }
+
+            async fn run_post_hooks(
+                &self,
+                context: &#roam::RequestContext<'_>,
+                outcome: #roam::ServerCallOutcome,
+            ) {
+                for middleware in self.middlewares.iter().rev() {
+                    middleware.post(context, outcome).await;
+                }
             }
         }
 
@@ -465,15 +491,18 @@ fn generate_dispatch_arm(
         .map(Type::to_token_stream)
         .unwrap_or_else(|| quote! { ::core::convert::Infallible });
 
-    let context_setup = if wants_context {
+    let context_setup = {
         quote! {
-            let context = #roam::RequestContext::new(
+            let extensions = #roam::Extensions::new();
+            let context = #roam::RequestContext::with_extensions(
                 #descriptor_fn_name().methods[#idx],
                 &call.metadata,
+                &extensions,
             );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
         }
-    } else {
-        quote! {}
     };
 
     let plain_handler_args: Vec<TokenStream2> = std::iter::empty()
@@ -489,20 +518,32 @@ fn generate_dispatch_arm(
 
     let invoke_and_reply = if ok_has_roam_lifetime {
         quote! {
+            let (reply, outcome_handle) = #roam::observe_reply(reply);
             let sink_call = #roam::SinkCall::new(reply);
             self.handler.#method_fn(#(#borrowed_handler_args),*).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome()).await;
+            }
         }
     } else if is_fallible {
         quote! {
+            let (reply, outcome_handle) = #roam::observe_reply(reply);
             let result = self.handler.#method_fn(#(#plain_handler_args),*).await;
             let sink_call = #roam::SinkCall::new(reply);
             #roam::Call::<'_, #ok_ty, #err_ty>::reply(sink_call, result).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome()).await;
+            }
         }
     } else {
         quote! {
+            let (reply, outcome_handle) = #roam::observe_reply(reply);
             let value = self.handler.#method_fn(#(#plain_handler_args),*).await;
             let sink_call = #roam::SinkCall::new(reply);
             #roam::Call::<'_, #ok_ty, #err_ty>::ok(sink_call, value).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome()).await;
+            }
         }
     };
 

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__adder_infallible.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__adder_infallible.snap
@@ -34,6 +34,7 @@ where
 #[derive(Clone)]
 pub struct AdderDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> AdderDispatcher<H>
 where
@@ -41,7 +42,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for AdderDispatcher<H>
@@ -73,9 +96,23 @@ where
                 }
             };
             let (a, b) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                adder_service_descriptor().methods[0usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let value = self.handler.add(a, b).await;
             let sink_call = ::roam::SinkCall::new(reply);
             ::roam::Call::<'_, i32, ::core::convert::Infallible>::ok(sink_call, value).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
@@ -58,6 +58,7 @@ where
 #[derive(Clone)]
 pub struct WordLabDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> WordLabDispatcher<H>
 where
@@ -65,7 +66,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for WordLabDispatcher<H>
@@ -98,9 +121,23 @@ where
                     }
                 };
             let (word,) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                word_lab_service_descriptor().methods[0usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let value = self.handler.is_short(word).await;
             let sink_call = ::roam::SinkCall::new(reply);
             ::roam::Call::<'_, bool, ::core::convert::Infallible>::ok(sink_call, value).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         if method_id == word_lab_service_descriptor().methods[1usize].id {
@@ -116,8 +153,22 @@ where
                 }
             };
             let (word,) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                word_lab_service_descriptor().methods[1usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let sink_call = ::roam::SinkCall::new(reply);
             self.handler.classify(sink_call, word).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         if method_id == word_lab_service_descriptor().methods[2usize].id {
@@ -152,9 +203,23 @@ where
                 }
             }
             let (prefix, input, output) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                word_lab_service_descriptor().methods[2usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let value = self.handler.transform(prefix, input, output).await;
             let sink_call = ::roam::SinkCall::new(reply);
             ::roam::Call::<'_, u32, ::core::convert::Infallible>::ok(sink_call, value).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_cow_return.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_cow_return.snap
@@ -36,6 +36,7 @@ where
 #[derive(Clone)]
 pub struct TextSvcDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> TextSvcDispatcher<H>
 where
@@ -43,7 +44,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for TextSvcDispatcher<H>
@@ -75,8 +98,22 @@ where
                 }
             };
             let (input,) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                text_svc_service_descriptor().methods[0usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let sink_call = ::roam::SinkCall::new(reply);
             self.handler.normalize(sink_call, input).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return.snap
@@ -38,6 +38,7 @@ where
 #[derive(Clone)]
 pub struct HasherDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> HasherDispatcher<H>
 where
@@ -45,7 +46,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for HasherDispatcher<H>
@@ -77,8 +100,22 @@ where
                 }
             };
             let (payload,) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                hasher_service_descriptor().methods[0usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let sink_call = ::roam::SinkCall::new(reply);
             self.handler.hash(sink_call, payload).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return_call_style.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return_call_style.snap
@@ -38,6 +38,7 @@ where
 #[derive(Clone)]
 pub struct HasherDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> HasherDispatcher<H>
 where
@@ -45,7 +46,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for HasherDispatcher<H>
@@ -77,8 +100,22 @@ where
                 }
             };
             let (payload,) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                hasher_service_descriptor().methods[0usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let sink_call = ::roam::SinkCall::new(reply);
             self.handler.hash(sink_call, payload).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__explicit_request_context_opt_in.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__explicit_request_context_opt_in.snap
@@ -1,6 +1,5 @@
 ---
 source: rust/roam-macros-core/src/lib.rs
-assertion_line: 835
 expression: "generate(quote!\n{\n    trait Audit\n    {\n        #[roam::context] async fn record(&self, payload: String) -> &'roam\n        str; async fn ping(&self) -> u64;\n    }\n})"
 ---
 #[allow(non_snake_case, clippy::all)]
@@ -43,6 +42,7 @@ where
 #[derive(Clone)]
 pub struct AuditDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> AuditDispatcher<H>
 where
@@ -50,7 +50,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for AuditDispatcher<H>
@@ -82,12 +104,22 @@ where
                 }
             };
             let (payload,) = args;
-            let context = ::roam::RequestContext::new(
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
                 audit_service_descriptor().methods[0usize],
                 &call.metadata,
+                &extensions,
             );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let sink_call = ::roam::SinkCall::new(reply);
             self.handler.record(&context, sink_call, payload).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         if method_id == audit_service_descriptor().methods[1usize].id {
@@ -103,9 +135,23 @@ where
                 }
             };
             let () = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                audit_service_descriptor().methods[1usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let value = self.handler.ping().await;
             let sink_call = ::roam::SinkCall::new(reply);
             ::roam::Call::<'_, u64, ::core::convert::Infallible>::ok(sink_call, value).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__fallible.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__fallible.snap
@@ -36,6 +36,7 @@ where
 #[derive(Clone)]
 pub struct CalcDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> CalcDispatcher<H>
 where
@@ -43,7 +44,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for CalcDispatcher<H>
@@ -75,9 +98,23 @@ where
                 }
             };
             let (a, b) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                calc_service_descriptor().methods[0usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let result = self.handler.div(a, b).await;
             let sink_call = ::roam::SinkCall::new(reply);
             ::roam::Call::<'_, f64, DivError>::reply(sink_call, result).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__no_args.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__no_args.snap
@@ -34,6 +34,7 @@ where
 #[derive(Clone)]
 pub struct PingDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> PingDispatcher<H>
 where
@@ -41,7 +42,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for PingDispatcher<H>
@@ -73,9 +96,23 @@ where
                 }
             };
             let () = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                ping_service_descriptor().methods[0usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let value = self.handler.ping().await;
             let sink_call = ::roam::SinkCall::new(reply);
             ::roam::Call::<'_, u64, ::core::convert::Infallible>::ok(sink_call, value).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__streaming_tx.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__streaming_tx.snap
@@ -38,6 +38,7 @@ where
 #[derive(Clone)]
 pub struct StreamerDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> StreamerDispatcher<H>
 where
@@ -45,7 +46,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for StreamerDispatcher<H>
@@ -95,9 +118,23 @@ where
                 }
             }
             let (start, output) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                streamer_service_descriptor().methods[0usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let value = self.handler.count_up(start, output).await;
             let sink_call = ::roam::SinkCall::new(reply);
             ::roam::Call::<'_, i32, ::core::convert::Infallible>::ok(sink_call, value).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__unit_return.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__unit_return.snap
@@ -34,6 +34,7 @@ where
 #[derive(Clone)]
 pub struct NotifierDispatcher<H> {
     handler: H,
+    middlewares: Vec<::std::sync::Arc<dyn ::roam::ServerMiddleware>>,
 }
 impl<H> NotifierDispatcher<H>
 where
@@ -41,7 +42,29 @@ where
 {
     #[doc = r" Create a new dispatcher wrapping the given handler."]
     pub fn new(handler: H) -> Self {
-        Self { handler }
+        Self {
+            handler,
+            middlewares: vec![],
+        }
+    }
+    #[doc = r" Append a server middleware to this dispatcher."]
+    pub fn with_middleware(mut self, middleware: impl ::roam::ServerMiddleware) -> Self {
+        self.middlewares.push(::std::sync::Arc::new(middleware));
+        self
+    }
+    async fn run_pre_hooks(&self, context: &::roam::RequestContext<'_>) {
+        for middleware in &self.middlewares {
+            middleware.pre(context).await;
+        }
+    }
+    async fn run_post_hooks(
+        &self,
+        context: &::roam::RequestContext<'_>,
+        outcome: ::roam::ServerCallOutcome,
+    ) {
+        for middleware in self.middlewares.iter().rev() {
+            middleware.post(context, outcome).await;
+        }
     }
 }
 impl<H, R> ::roam::Handler<R> for NotifierDispatcher<H>
@@ -73,9 +96,23 @@ where
                 }
             };
             let (msg,) = args;
+            let extensions = ::roam::Extensions::new();
+            let context = ::roam::RequestContext::with_extensions(
+                notifier_service_descriptor().methods[0usize],
+                &call.metadata,
+                &extensions,
+            );
+            if !self.middlewares.is_empty() {
+                self.run_pre_hooks(&context).await;
+            }
+            let (reply, outcome_handle) = ::roam::observe_reply(reply);
             let value = self.handler.notify(msg).await;
             let sink_call = ::roam::SinkCall::new(reply);
             ::roam::Call::<'_, (), ::core::convert::Infallible>::ok(sink_call, value).await;
+            if !self.middlewares.is_empty() {
+                self.run_post_hooks(&context, outcome_handle.outcome())
+                    .await;
+            }
             return;
         }
         reply

--- a/rust/roam-types/src/lib.rs
+++ b/rust/roam-types/src/lib.rs
@@ -97,6 +97,9 @@ pub use metadata::*;
 mod request_context;
 pub use request_context::*;
 
+mod server_middleware;
+pub use server_middleware::*;
+
 mod calls;
 pub use calls::*;
 

--- a/rust/roam-types/src/request_context.rs
+++ b/rust/roam-types/src/request_context.rs
@@ -1,4 +1,6 @@
-use crate::{MetadataEntry, MethodDescriptor};
+use std::sync::OnceLock;
+
+use crate::{Extensions, MetadataEntry, MethodDescriptor};
 
 /// Borrowed per-request context exposed to opted-in Rust service handlers.
 ///
@@ -8,12 +10,26 @@ use crate::{MetadataEntry, MethodDescriptor};
 pub struct RequestContext<'a> {
     method: &'static MethodDescriptor,
     metadata: &'a [MetadataEntry<'static>],
+    extensions: &'a Extensions,
 }
 
 impl<'a> RequestContext<'a> {
     /// Create a new borrowed request context.
     pub fn new(method: &'static MethodDescriptor, metadata: &'a [MetadataEntry<'static>]) -> Self {
-        Self { method, metadata }
+        Self::with_extensions(method, metadata, empty_extensions())
+    }
+
+    /// Create a new borrowed request context with middleware extensions.
+    pub fn with_extensions(
+        method: &'static MethodDescriptor,
+        metadata: &'a [MetadataEntry<'static>],
+        extensions: &'a Extensions,
+    ) -> Self {
+        Self {
+            method,
+            metadata,
+            extensions,
+        }
     }
 
     /// Static descriptor for the method being handled.
@@ -25,4 +41,14 @@ impl<'a> RequestContext<'a> {
     pub fn metadata(&self) -> &'a [MetadataEntry<'static>] {
         self.metadata
     }
+
+    /// Per-request middleware extensions bag.
+    pub fn extensions(&self) -> &'a Extensions {
+        self.extensions
+    }
+}
+
+fn empty_extensions() -> &'static Extensions {
+    static EMPTY: OnceLock<Extensions> = OnceLock::new();
+    EMPTY.get_or_init(Extensions::new)
 }

--- a/rust/roam-types/src/server_middleware.rs
+++ b/rust/roam-types/src/server_middleware.rs
@@ -1,0 +1,205 @@
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
+
+use crate::{ReplySink, RequestContext, RequestResponse};
+
+/// Per-request type-indexed storage shared across middleware hooks and handlers.
+#[derive(Debug, Default)]
+pub struct Extensions {
+    inner: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+}
+
+impl Extensions {
+    /// Create a new empty extensions bag.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a typed value into the bag, returning the previous value of the same type.
+    pub fn insert<T>(&self, value: T) -> Option<T>
+    where
+        T: Send + Sync + 'static,
+    {
+        let previous = self
+            .inner
+            .lock()
+            .expect("extensions mutex poisoned")
+            .insert(TypeId::of::<T>(), Box::new(value));
+        previous
+            .map(|boxed| {
+                boxed
+                    .downcast::<T>()
+                    .expect("extensions type id and boxed value disagreed")
+            })
+            .map(|boxed| *boxed)
+    }
+
+    /// Returns `true` if a value of type `T` is present.
+    pub fn contains<T>(&self) -> bool
+    where
+        T: Send + Sync + 'static,
+    {
+        self.inner
+            .lock()
+            .expect("extensions mutex poisoned")
+            .contains_key(&TypeId::of::<T>())
+    }
+
+    /// Borrow a typed value from the bag for the duration of `f`.
+    pub fn with<T, R>(&self, f: impl FnOnce(&T) -> R) -> Option<R>
+    where
+        T: Send + Sync + 'static,
+    {
+        let guard = self.inner.lock().expect("extensions mutex poisoned");
+        let value = guard.get(&TypeId::of::<T>())?;
+        let value = value
+            .downcast_ref::<T>()
+            .expect("extensions type id and boxed value disagreed");
+        Some(f(value))
+    }
+
+    /// Mutably borrow a typed value from the bag for the duration of `f`.
+    pub fn with_mut<T, R>(&self, f: impl FnOnce(&mut T) -> R) -> Option<R>
+    where
+        T: Send + Sync + 'static,
+    {
+        let mut guard = self.inner.lock().expect("extensions mutex poisoned");
+        let value = guard.get_mut(&TypeId::of::<T>())?;
+        let value = value
+            .downcast_mut::<T>()
+            .expect("extensions type id and boxed value disagreed");
+        Some(f(value))
+    }
+
+    /// Clone a typed value from the bag.
+    pub fn get_cloned<T>(&self) -> Option<T>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.with(|value: &T| value.clone())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxMiddlewareFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+pub type BoxMiddlewareFuture<'a> = Pin<Box<dyn Future<Output = ()> + 'a>>;
+
+/// Outcome observed by server middleware after handler dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerCallOutcome {
+    /// The handler sent a reply through the reply sink.
+    Replied,
+    /// The handler returned without replying; the runtime will synthesize cancellation.
+    DroppedWithoutReply,
+}
+
+impl ServerCallOutcome {
+    pub fn replied(self) -> bool {
+        matches!(self, Self::Replied)
+    }
+}
+
+/// Observe inbound server requests before and after dispatch.
+pub trait ServerMiddleware: Send + Sync + 'static {
+    fn pre<'a>(&'a self, _context: &'a RequestContext<'a>) -> BoxMiddlewareFuture<'a> {
+        Box::pin(async {})
+    }
+
+    fn post<'a>(
+        &'a self,
+        _context: &'a RequestContext<'a>,
+        _outcome: ServerCallOutcome,
+    ) -> BoxMiddlewareFuture<'a> {
+        Box::pin(async {})
+    }
+}
+
+#[derive(Clone)]
+#[doc(hidden)]
+pub struct ServerCallOutcomeHandle {
+    outcome: Arc<Mutex<ServerCallOutcome>>,
+}
+
+impl ServerCallOutcomeHandle {
+    pub fn outcome(&self) -> ServerCallOutcome {
+        *self
+            .outcome
+            .lock()
+            .expect("server call outcome mutex poisoned")
+    }
+}
+
+#[doc(hidden)]
+pub struct ObservedReplySink<R> {
+    inner: Option<R>,
+    outcome: ServerCallOutcomeHandle,
+}
+
+#[doc(hidden)]
+pub fn observe_reply<R>(reply: R) -> (ObservedReplySink<R>, ServerCallOutcomeHandle) {
+    let outcome = ServerCallOutcomeHandle {
+        outcome: Arc::new(Mutex::new(ServerCallOutcome::DroppedWithoutReply)),
+    };
+    (
+        ObservedReplySink {
+            inner: Some(reply),
+            outcome: outcome.clone(),
+        },
+        outcome,
+    )
+}
+
+impl<R> ReplySink for ObservedReplySink<R>
+where
+    R: ReplySink,
+{
+    async fn send_reply(mut self, response: RequestResponse<'_>) {
+        *self
+            .outcome
+            .outcome
+            .lock()
+            .expect("server call outcome mutex poisoned") = ServerCallOutcome::Replied;
+        let reply = self
+            .inner
+            .take()
+            .expect("observed reply sink can only reply once");
+        reply.send_reply(response).await;
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn channel_binder(&self) -> Option<&dyn crate::ChannelBinder> {
+        self.inner.as_ref().and_then(|reply| reply.channel_binder())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Extensions, ServerCallOutcome};
+
+    #[test]
+    fn extensions_store_values_by_type() {
+        let extensions = Extensions::new();
+        assert!(!extensions.contains::<u32>());
+        assert_eq!(extensions.insert(41_u32), None);
+        assert!(extensions.contains::<u32>());
+        assert_eq!(extensions.get_cloned::<u32>(), Some(41));
+        let updated = extensions.with_mut::<u32, _>(|value| {
+            *value += 1;
+            *value
+        });
+        assert_eq!(updated, Some(42));
+        assert_eq!(extensions.get_cloned::<u32>(), Some(42));
+    }
+
+    #[test]
+    fn server_call_outcome_reports_reply_state() {
+        assert!(ServerCallOutcome::Replied.replied());
+        assert!(!ServerCallOutcome::DroppedWithoutReply.replied());
+    }
+}

--- a/rust/roam/Cargo.toml
+++ b/rust/roam/Cargo.toml
@@ -28,6 +28,7 @@ roam-service-macros.workspace = true
 roam-core = { workspace = true, optional = true }
 facet.workspace = true
 facet-postcard.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net"] }
@@ -36,3 +37,4 @@ roam-core = { path = "../roam-core" }
 shm-primitives = { path = "../shm-primitives" }
 roam-shm = { path = "../roam-shm" }
 tempfile.workspace = true
+tracing-subscriber.workspace = true

--- a/rust/roam/src/lib.rs
+++ b/rust/roam/src/lib.rs
@@ -3,8 +3,11 @@
 //! This is the facade crate. It re-exports everything needed by both
 //! hand-written code and `#[roam::service]` macro-generated code.
 
+mod server_logging;
+
 // Re-export the proc macro
 pub use roam_service_macros::service;
+pub use server_logging::{ServerLogging, ServerLoggingOptions};
 
 // Re-export facet (generated code uses `roam::facet::Facet`)
 pub use facet;
@@ -18,6 +21,7 @@ pub use roam_hash as hash;
 // Re-export roam-types items used by generated code
 pub use roam_types::{
     Backing,
+    BoxMiddlewareFuture,
     // Traits
     Call,
     Caller,
@@ -32,6 +36,7 @@ pub use roam_types::{
     ConnectionId,
     ConnectionSettings,
     ErasedCaller,
+    Extensions,
     Handler,
     Link,
     LinkRx,
@@ -57,6 +62,8 @@ pub use roam_types::{
     Rx,
     RxError,
     SelfRef,
+    ServerCallOutcome,
+    ServerMiddleware,
     ServiceDescriptor,
     SinkCall,
     // Channels
@@ -65,6 +72,7 @@ pub use roam_types::{
     WriteSlot,
     // Channels
     channel,
+    observe_reply,
 };
 
 // Re-export runtime/session primitives from `roam-core`.

--- a/rust/roam/src/server_logging.rs
+++ b/rust/roam/src/server_logging.rs
@@ -1,0 +1,282 @@
+use std::time::Instant;
+
+use tracing::debug;
+
+use crate::{
+    BoxMiddlewareFuture, MetadataEntry, MetadataFlags, MetadataValue, RequestContext,
+    ServerCallOutcome, ServerMiddleware,
+};
+
+#[derive(Debug, Clone)]
+pub struct ServerLoggingOptions {
+    pub log_metadata: bool,
+}
+
+impl Default for ServerLoggingOptions {
+    fn default() -> Self {
+        Self {
+            log_metadata: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ServerLogging {
+    options: ServerLoggingOptions,
+}
+
+impl ServerLogging {
+    pub fn new(options: ServerLoggingOptions) -> Self {
+        Self { options }
+    }
+
+    pub fn with_metadata(mut self, log_metadata: bool) -> Self {
+        self.options.log_metadata = log_metadata;
+        self
+    }
+}
+
+impl ServerMiddleware for ServerLogging {
+    fn pre<'a>(&'a self, context: &'a RequestContext<'a>) -> BoxMiddlewareFuture<'a> {
+        Box::pin(async move {
+            context.extensions().insert(RequestStart(Instant::now()));
+            let method = context.method();
+            if self.options.log_metadata {
+                debug!(
+                    target: "roam::server",
+                    service = method.service_name,
+                    method = method.method_name,
+                    metadata = ?RedactedMetadata(context.metadata()),
+                    "rpc request"
+                );
+            } else {
+                debug!(
+                    target: "roam::server",
+                    service = method.service_name,
+                    method = method.method_name,
+                    "rpc request"
+                );
+            }
+        })
+    }
+
+    fn post<'a>(
+        &'a self,
+        context: &'a RequestContext<'a>,
+        outcome: ServerCallOutcome,
+    ) -> BoxMiddlewareFuture<'a> {
+        Box::pin(async move {
+            let method = context.method();
+            let duration_ms = context
+                .extensions()
+                .with::<RequestStart, _>(|start| start.0.elapsed().as_secs_f64() * 1_000.0);
+            debug!(
+                target: "roam::server",
+                service = method.service_name,
+                method = method.method_name,
+                outcome = ?outcome,
+                duration_ms,
+                "rpc response"
+            );
+        })
+    }
+}
+
+#[derive(Debug)]
+struct RequestStart(Instant);
+
+#[derive(Clone, Copy)]
+struct RedactedMetadata<'a>(&'a [MetadataEntry<'static>]);
+
+impl std::fmt::Debug for RedactedMetadata<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut entries = f.debug_list();
+        for entry in self.0 {
+            entries.entry(&MetadataEntryDebug(entry));
+        }
+        entries.finish()
+    }
+}
+
+struct MetadataEntryDebug<'a>(&'a MetadataEntry<'static>);
+
+impl std::fmt::Debug for MetadataEntryDebug<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let entry = self.0;
+        let mut debug = f.debug_struct("MetadataEntry");
+        debug.field("key", &entry.key);
+        if entry.flags.contains(MetadataFlags::SENSITIVE) {
+            debug.field("value", &"[REDACTED]");
+        } else {
+            debug.field("value", &MetadataValueDebug(&entry.value));
+        }
+        debug.field("flags", &entry.flags);
+        debug.finish()
+    }
+}
+
+struct MetadataValueDebug<'a>(&'a MetadataValue<'a>);
+
+impl std::fmt::Debug for MetadataValueDebug<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            MetadataValue::String(value) => value.fmt(f),
+            MetadataValue::Bytes(bytes) => write!(f, "<{} bytes>", bytes.len()),
+            MetadataValue::U64(value) => value.fmt(f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io,
+        sync::{Arc, Mutex},
+    };
+
+    use tracing_subscriber::{
+        Layer,
+        filter::LevelFilter,
+        fmt::{self, MakeWriter},
+        layer::SubscriberExt,
+    };
+
+    use super::{
+        MetadataEntryDebug, MetadataValueDebug, RedactedMetadata, ServerLogging,
+        ServerLoggingOptions,
+    };
+    use crate::{
+        Extensions, MetadataEntry, MetadataFlags, MetadataValue, RequestContext, ServerCallOutcome,
+        ServerMiddleware,
+    };
+
+    #[test]
+    fn metadata_debug_redacts_sensitive_values() {
+        let metadata = vec![
+            MetadataEntry {
+                key: "authorization",
+                value: MetadataValue::String("Bearer secret"),
+                flags: MetadataFlags::SENSITIVE,
+            },
+            MetadataEntry {
+                key: "blob",
+                value: MetadataValue::Bytes(&[1, 2, 3]),
+                flags: MetadataFlags::NONE,
+            },
+            MetadataEntry {
+                key: "attempt",
+                value: MetadataValue::U64(2),
+                flags: MetadataFlags::NONE,
+            },
+        ];
+
+        assert_eq!(
+            format!("{:?}", RedactedMetadata(&metadata)),
+            "[MetadataEntry { key: \"authorization\", value: \"[REDACTED]\", flags: MetadataFlags(1) }, MetadataEntry { key: \"blob\", value: <3 bytes>, flags: MetadataFlags(0) }, MetadataEntry { key: \"attempt\", value: 2, flags: MetadataFlags(0) }]"
+        );
+
+        let bytes = MetadataValue::Bytes(&[0; 4]);
+        assert_eq!(format!("{:?}", MetadataValueDebug(&bytes)), "<4 bytes>");
+        assert_eq!(
+            format!(
+                "{:?}",
+                MetadataEntryDebug(&MetadataEntry {
+                    key: "plain",
+                    value: MetadataValue::String("value"),
+                    flags: MetadataFlags::NONE,
+                })
+            ),
+            "MetadataEntry { key: \"plain\", value: \"value\", flags: MetadataFlags(0) }"
+        );
+    }
+
+    #[tokio::test]
+    async fn server_logging_emits_redacted_request_and_response_logs() {
+        let writer = SharedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .without_time()
+                .with_ansi(false)
+                .with_writer(writer.clone())
+                .with_filter(LevelFilter::DEBUG),
+        );
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        static METHOD: crate::MethodDescriptor = crate::MethodDescriptor {
+            id: crate::MethodId(7),
+            service_name: "Audit",
+            method_name: "record",
+            args: &[],
+            return_shape: &<() as facet::Facet<'static>>::SHAPE,
+            doc: None,
+        };
+
+        let metadata = vec![
+            MetadataEntry {
+                key: "authorization",
+                value: MetadataValue::String("Bearer secret"),
+                flags: MetadataFlags::SENSITIVE,
+            },
+            MetadataEntry {
+                key: "attempt",
+                value: MetadataValue::U64(2),
+                flags: MetadataFlags::NONE,
+            },
+        ];
+        let extensions = Extensions::new();
+        let context = RequestContext::with_extensions(&METHOD, &metadata, &extensions);
+
+        let logging = ServerLogging::new(ServerLoggingOptions { log_metadata: true });
+        logging.pre(&context).await;
+        logging.post(&context, ServerCallOutcome::Replied).await;
+
+        let output = writer.output();
+        assert!(output.contains("rpc request"));
+        assert!(output.contains("rpc response"));
+        assert!(output.contains("authorization"));
+        assert!(output.contains("[REDACTED]"));
+        assert!(!output.contains("Bearer secret"));
+        assert!(output.contains("attempt"));
+        assert!(output.contains("Replied"));
+    }
+
+    #[derive(Clone, Default)]
+    struct SharedWriter {
+        output: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl SharedWriter {
+        fn output(&self) -> String {
+            let bytes = self.output.lock().expect("shared writer mutex poisoned");
+            String::from_utf8(bytes.clone()).expect("log output should be utf-8")
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedWriter {
+        type Writer = SharedWriterGuard;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedWriterGuard {
+                output: Arc::clone(&self.output),
+            }
+        }
+    }
+
+    struct SharedWriterGuard {
+        output: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl io::Write for SharedWriterGuard {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.output
+                .lock()
+                .expect("shared writer mutex poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+}

--- a/rust/roam/tests/service_macro_shared.rs
+++ b/rust/roam/tests/service_macro_shared.rs
@@ -1,5 +1,6 @@
 use roam_core::{BareConduit, acceptor, initiator};
 use roam_types::Link;
+use std::sync::{Arc, Mutex};
 
 type MessageConduit<L> = BareConduit<roam_types::MessageFamily, L>;
 
@@ -36,6 +37,77 @@ impl ContextProbe for ContextProbeService {
     async fn plain(&self) -> String {
         "plain".to_string()
     }
+}
+
+#[roam::service]
+trait MiddlewareProbe {
+    #[roam::context]
+    async fn inspect(&self) -> String;
+}
+
+#[derive(Clone)]
+struct MiddlewareProbeService;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MiddlewareValue(String);
+
+impl MiddlewareProbe for MiddlewareProbeService {
+    async fn inspect(&self, cx: &roam::RequestContext<'_>) -> String {
+        cx.extensions()
+            .get_cloned::<MiddlewareValue>()
+            .expect("middleware should have populated request extensions")
+            .0
+    }
+}
+
+#[derive(Clone)]
+struct RecordingMiddleware {
+    name: &'static str,
+    events: Arc<Mutex<Vec<String>>>,
+    mode: MiddlewareMode,
+}
+
+#[derive(Clone, Copy)]
+enum MiddlewareMode {
+    Seed,
+    Append(&'static str),
+}
+
+impl roam::ServerMiddleware for RecordingMiddleware {
+    fn pre<'a>(&'a self, context: &'a roam::RequestContext<'a>) -> roam::BoxMiddlewareFuture<'a> {
+        Box::pin(async move {
+            record_event(&self.events, format!("{}:pre", self.name));
+            match self.mode {
+                MiddlewareMode::Seed => {
+                    let _ = context
+                        .extensions()
+                        .insert(MiddlewareValue(self.name.to_string()));
+                }
+                MiddlewareMode::Append(suffix) => {
+                    let updated = context
+                        .extensions()
+                        .with_mut::<MiddlewareValue, _>(|value| {
+                            value.0.push_str(suffix);
+                        });
+                    assert!(updated.is_some(), "seed middleware should run first");
+                }
+            }
+        })
+    }
+
+    fn post<'a>(
+        &'a self,
+        _context: &'a roam::RequestContext<'a>,
+        outcome: roam::ServerCallOutcome,
+    ) -> roam::BoxMiddlewareFuture<'a> {
+        Box::pin(async move {
+            record_event(&self.events, format!("{}:post:{outcome:?}", self.name));
+        })
+    }
+}
+
+fn record_event(events: &Arc<Mutex<Vec<String>>>, event: String) {
+    events.lock().expect("events mutex poisoned").push(event);
 }
 
 pub async fn run_adder_end_to_end<L>(
@@ -107,6 +179,72 @@ pub async fn run_request_context_end_to_end<L>(
 
     let plain = client.plain().await.expect("plain call should succeed");
     assert_eq!(plain, "plain");
+
+    server_task.abort();
+}
+
+pub async fn run_server_middleware_end_to_end<L>(
+    message_conduit_pair: impl FnOnce() -> (MessageConduit<L>, MessageConduit<L>),
+) where
+    L: Link + Send + 'static,
+    L::Tx: Send + 'static,
+    L::Rx: Send + 'static,
+{
+    let (client_conduit, server_conduit) = message_conduit_pair();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_events = Arc::clone(&events);
+    let server_task = tokio::task::spawn(async move {
+        let first = RecordingMiddleware {
+            name: "first",
+            events: Arc::clone(&server_events),
+            mode: MiddlewareMode::Seed,
+        };
+        let second = RecordingMiddleware {
+            name: "second",
+            events: Arc::clone(&server_events),
+            mode: MiddlewareMode::Append("+second"),
+        };
+        let dispatcher = MiddlewareProbeDispatcher::new(MiddlewareProbeService)
+            .with_middleware(first)
+            .with_middleware(second);
+        let (server_caller_guard, _sh) = acceptor(server_conduit)
+            .establish::<MiddlewareProbeClient>(dispatcher)
+            .await
+            .expect("server handshake failed");
+        let _ = server_ready_tx.send(());
+        let _server_caller_guard = server_caller_guard;
+        std::future::pending::<()>().await;
+    });
+
+    let (client, _sh) = initiator(client_conduit)
+        .establish::<MiddlewareProbeClient>(())
+        .await
+        .expect("client handshake failed");
+
+    server_ready_rx.await.expect("server setup failed");
+
+    let observed = client.inspect().await.expect("inspect call should succeed");
+    assert_eq!(observed, "first+second");
+
+    for _ in 0..32 {
+        if events.lock().expect("events mutex poisoned").len() == 4 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    let events = events.lock().expect("events mutex poisoned").clone();
+    assert_eq!(
+        events,
+        vec![
+            "first:pre".to_string(),
+            "second:pre".to_string(),
+            "second:post:Replied".to_string(),
+            "first:post:Replied".to_string(),
+        ]
+    );
 
     server_task.abort();
 }

--- a/rust/roam/tests/service_macro_tests.rs
+++ b/rust/roam/tests/service_macro_tests.rs
@@ -18,3 +18,8 @@ async fn adder_service_macro_end_to_end() {
 async fn request_context_opt_in_end_to_end() {
     service_macro_shared::run_request_context_end_to_end(message_conduit_pair).await;
 }
+
+#[tokio::test]
+async fn server_middleware_end_to_end() {
+    service_macro_shared::run_server_middleware_end_to_end(message_conduit_pair).await;
+}

--- a/rust/roam/tests/shm_service_macro_tests.rs
+++ b/rust/roam/tests/shm_service_macro_tests.rs
@@ -48,3 +48,9 @@ async fn request_context_opt_in_end_to_end_over_shm() {
     let (a, b, _dir) = message_conduit_pair().await;
     service_macro_shared::run_request_context_end_to_end(|| (a, b)).await;
 }
+
+#[tokio::test]
+async fn server_middleware_end_to_end_over_shm() {
+    let (a, b, _dir) = message_conduit_pair().await;
+    service_macro_shared::run_server_middleware_end_to_end(|| (a, b)).await;
+}


### PR DESCRIPTION
## Summary
Adds the first Rust server-side middleware slice for #171.
Generated dispatchers can now install middleware, expose per-request extensions, and run pre/post hooks around handler dispatch.

## Changes
- add `ServerMiddleware`, per-request `Extensions`, reply outcome observation, and request-context extension plumbing in the Rust runtime
- generate `.with_middleware(...)` on Rust dispatchers and thread middleware hooks through macro output
- add built-in `ServerLogging` with request/response timing and `SENSITIVE` metadata redaction
- add end-to-end tests for middleware ordering and extension visibility, plus updated macro snapshots

## Testing
- `cargo nextest run -p roam-types -p roam-macros-core -p roam`

Closes #171
