### PR TITLE
Add Rust client middleware and logging

### DIFF
--- a/rust/roam-macros-core/src/lib.rs
+++ b/rust/roam-macros-core/src/lib.rs
@@ -602,6 +602,15 @@ fn generate_client(parsed: &ServiceTrait, roam: &TokenStream2) -> TokenStream2 {
                 }
             }
 
+            /// Append a client middleware to this client.
+            pub fn with_middleware(self, middleware: impl #roam::ClientMiddleware) -> Self {
+                Self {
+                    caller: self
+                        .caller
+                        .with_middleware(#descriptor_fn_name(), middleware),
+                }
+            }
+
             /// Resolve when the underlying connection closes.
             pub async fn closed(&self) {
                 #roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__adder_infallible.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__adder_infallible.snap
@@ -133,6 +133,14 @@ impl AdderClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(adder_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
@@ -240,6 +240,14 @@ impl WordLabClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(word_lab_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_cow_return.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_cow_return.snap
@@ -134,6 +134,14 @@ impl TextSvcClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(text_svc_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return.snap
@@ -136,6 +136,14 @@ impl HasherClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(hasher_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return_call_style.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__borrowed_roam_return_call_style.snap
@@ -136,6 +136,14 @@ impl HasherClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(hasher_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__explicit_request_context_opt_in.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__explicit_request_context_opt_in.snap
@@ -172,6 +172,14 @@ impl AuditClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(audit_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__fallible.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__fallible.snap
@@ -135,6 +135,14 @@ impl CalcClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(calc_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__no_args.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__no_args.snap
@@ -133,6 +133,14 @@ impl PingClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(ping_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__streaming_tx.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__streaming_tx.snap
@@ -155,6 +155,14 @@ impl StreamerClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(streamer_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__unit_return.snap
+++ b/rust/roam-macros-core/src/snapshots/roam_macros_core__tests__unit_return.snap
@@ -133,6 +133,14 @@ impl NotifierClient {
             caller: ::roam::ErasedCaller::new(caller),
         }
     }
+    #[doc = r" Append a client middleware to this client."]
+    pub fn with_middleware(self, middleware: impl ::roam::ClientMiddleware) -> Self {
+        Self {
+            caller: self
+                .caller
+                .with_middleware(notifier_service_descriptor(), middleware),
+        }
+    }
     #[doc = r" Resolve when the underlying connection closes."]
     pub async fn closed(&self) {
         ::roam::Caller::closed(&self.caller).await;

--- a/rust/roam-types/src/calls.rs
+++ b/rust/roam-types/src/calls.rs
@@ -1,6 +1,9 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
-use crate::{MaybeSend, MaybeSync, Metadata, RequestCall, RequestResponse, RoamError, SelfRef};
+use crate::{
+    ClientCallOutcome, ClientContext, ClientMiddleware, ClientRequest, Extensions, MaybeSend,
+    MaybeSync, Metadata, RequestCall, RequestResponse, RoamError, SelfRef, ServiceDescriptor,
+};
 
 // As a recap, a service defined like so:
 //
@@ -278,23 +281,72 @@ impl<C: Caller> ErasedCallerDyn for C {
 #[derive(Clone)]
 pub struct ErasedCaller {
     inner: Arc<dyn ErasedCallerDyn>,
+    service: Option<&'static ServiceDescriptor>,
+    middlewares: Vec<Arc<dyn ClientMiddleware>>,
 }
 
 impl ErasedCaller {
     pub fn new<C: Caller>(caller: C) -> Self {
         Self {
             inner: Arc::new(caller),
+            service: None,
+            middlewares: vec![],
         }
+    }
+
+    pub fn with_middleware(
+        mut self,
+        service: &'static ServiceDescriptor,
+        middleware: impl ClientMiddleware,
+    ) -> Self {
+        if let Some(existing_service) = self.service {
+            assert_eq!(
+                existing_service.service_name, service.service_name,
+                "ErasedCaller middleware service mismatch"
+            );
+        } else {
+            self.service = Some(service);
+        }
+        self.middlewares.push(Arc::new(middleware));
+        self
     }
 }
 
 impl Caller for ErasedCaller {
     fn call<'a>(
         &'a self,
-        call: RequestCall<'a>,
+        mut call: RequestCall<'a>,
     ) -> impl Future<Output = Result<SelfRef<RequestResponse<'static>>, RoamError>> + MaybeSend + 'a
     {
-        self.inner.call(call)
+        async move {
+            let Some(service) = self.service else {
+                return self.inner.call(call).await;
+            };
+
+            let extensions = Extensions::new();
+            let method = service.by_id(call.method_id);
+            let context = ClientContext::new(method, call.method_id, &extensions);
+            let mut owned_metadata = crate::client_middleware::OwnedMetadata::default();
+
+            if !self.middlewares.is_empty() {
+                for middleware in &self.middlewares {
+                    let mut request = ClientRequest::new(&mut call, &mut owned_metadata);
+                    middleware.pre(&context, &mut request).await;
+                }
+            }
+
+            let result = self.inner.call(call).await;
+            if !self.middlewares.is_empty() {
+                let outcome = match &result {
+                    Ok(_) => ClientCallOutcome::Response,
+                    Err(error) => ClientCallOutcome::Error(error),
+                };
+                for middleware in self.middlewares.iter().rev() {
+                    middleware.post(&context, outcome).await;
+                }
+            }
+            result
+        }
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/rust/roam-types/src/client_middleware.rs
+++ b/rust/roam-types/src/client_middleware.rs
@@ -1,0 +1,401 @@
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use crate::server_middleware::BoxMiddlewareFuture;
+use crate::{
+    Caller, Extensions, Metadata, MetadataEntry, MetadataFlags, MetadataValue, MethodDescriptor,
+    MethodId, RequestCall, RequestResponse, RoamError, SelfRef, ServiceDescriptor,
+};
+
+/// Borrowed per-call context exposed to client middleware.
+#[derive(Clone, Copy, Debug)]
+pub struct ClientContext<'a> {
+    method: Option<&'static MethodDescriptor>,
+    method_id: MethodId,
+    extensions: &'a Extensions,
+}
+
+impl<'a> ClientContext<'a> {
+    pub fn new(
+        method: Option<&'static MethodDescriptor>,
+        method_id: MethodId,
+        extensions: &'a Extensions,
+    ) -> Self {
+        Self {
+            method,
+            method_id,
+            extensions,
+        }
+    }
+
+    pub fn method(&self) -> Option<&'static MethodDescriptor> {
+        self.method
+    }
+
+    pub fn method_id(&self) -> MethodId {
+        self.method_id
+    }
+
+    pub fn extensions(&self) -> &'a Extensions {
+        self.extensions
+    }
+}
+
+/// Borrowed request wrapper exposed to client middleware.
+///
+/// This allows middleware to add dynamic metadata while keeping the backing
+/// storage alive until the wrapped caller finishes sending the request.
+pub struct ClientRequest<'call, 'state> {
+    call: &'state mut RequestCall<'call>,
+    owned_metadata: &'state mut OwnedMetadata,
+}
+
+impl<'call, 'state> ClientRequest<'call, 'state> {
+    pub(crate) fn new(
+        call: &'state mut RequestCall<'call>,
+        owned_metadata: &'state mut OwnedMetadata,
+    ) -> Self {
+        Self {
+            call,
+            owned_metadata,
+        }
+    }
+
+    pub fn call(&self) -> &RequestCall<'call> {
+        self.call
+    }
+
+    pub fn metadata(&self) -> &[MetadataEntry<'call>] {
+        &self.call.metadata
+    }
+
+    pub fn metadata_mut(&mut self) -> &mut Metadata<'call> {
+        &mut self.call.metadata
+    }
+
+    pub fn push_string_metadata(
+        &mut self,
+        key: &'static str,
+        value: impl Into<String>,
+        flags: MetadataFlags,
+    ) {
+        let value = self.owned_metadata.store_string(value.into());
+        self.call.metadata.push(MetadataEntry {
+            key,
+            value: MetadataValue::String(value),
+            flags,
+        });
+    }
+
+    pub fn push_bytes_metadata(
+        &mut self,
+        key: &'static str,
+        value: impl Into<Vec<u8>>,
+        flags: MetadataFlags,
+    ) {
+        let value = self.owned_metadata.store_bytes(value.into());
+        self.call.metadata.push(MetadataEntry {
+            key,
+            value: MetadataValue::Bytes(value),
+            flags,
+        });
+    }
+
+    pub fn push_u64_metadata(&mut self, key: &'static str, value: u64, flags: MetadataFlags) {
+        self.call.metadata.push(MetadataEntry {
+            key,
+            value: MetadataValue::U64(value),
+            flags,
+        });
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct OwnedMetadata {
+    strings: Vec<Box<str>>,
+    bytes: Vec<Box<[u8]>>,
+}
+
+impl OwnedMetadata {
+    fn store_string<'a>(&mut self, value: String) -> &'a str {
+        self.strings.push(value.into_boxed_str());
+        let value = self
+            .strings
+            .last()
+            .expect("owned string metadata should exist after push");
+        let value: *const str = &**value;
+        // SAFETY: the boxed string is owned by this `OwnedMetadata` and remains alive
+        // until the wrapped caller finishes awaiting the inner `call`.
+        unsafe { &*value }
+    }
+
+    fn store_bytes<'a>(&mut self, value: Vec<u8>) -> &'a [u8] {
+        self.bytes.push(value.into_boxed_slice());
+        let value = self
+            .bytes
+            .last()
+            .expect("owned bytes metadata should exist after push");
+        let value: *const [u8] = &**value;
+        // SAFETY: the boxed bytes are owned by this `OwnedMetadata` and remain alive
+        // until the wrapped caller finishes awaiting the inner `call`.
+        unsafe { &*value }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum ClientCallOutcome<'a> {
+    Response,
+    Error(&'a RoamError),
+}
+
+impl ClientCallOutcome<'_> {
+    pub fn is_ok(self) -> bool {
+        matches!(self, Self::Response)
+    }
+}
+
+pub trait ClientMiddleware: Send + Sync + 'static {
+    fn pre<'a, 'call>(
+        &'a self,
+        _context: &'a ClientContext<'a>,
+        _request: &'a mut ClientRequest<'call, 'a>,
+    ) -> BoxMiddlewareFuture<'a> {
+        Box::pin(async {})
+    }
+
+    fn post<'a>(
+        &'a self,
+        _context: &'a ClientContext<'a>,
+        _outcome: ClientCallOutcome<'a>,
+    ) -> BoxMiddlewareFuture<'a> {
+        Box::pin(async {})
+    }
+}
+
+#[derive(Clone)]
+pub struct MiddlewareCaller<C> {
+    caller: C,
+    service: &'static ServiceDescriptor,
+    middlewares: Vec<Arc<dyn ClientMiddleware>>,
+}
+
+impl<C> MiddlewareCaller<C> {
+    pub fn new(caller: C, service: &'static ServiceDescriptor) -> Self {
+        Self {
+            caller,
+            service,
+            middlewares: vec![],
+        }
+    }
+
+    pub fn with_middleware(mut self, middleware: impl ClientMiddleware) -> Self {
+        self.middlewares.push(Arc::new(middleware));
+        self
+    }
+}
+
+impl<C> Caller for MiddlewareCaller<C>
+where
+    C: Caller,
+{
+    fn call<'a>(
+        &'a self,
+        mut call: RequestCall<'a>,
+    ) -> impl Future<Output = Result<SelfRef<RequestResponse<'static>>, RoamError>> + crate::MaybeSend + 'a
+    {
+        async move {
+            let extensions = Extensions::new();
+            let method = self.service.by_id(call.method_id);
+            let context = ClientContext::new(method, call.method_id, &extensions);
+            let mut owned_metadata = OwnedMetadata::default();
+            if !self.middlewares.is_empty() {
+                for middleware in &self.middlewares {
+                    let mut request = ClientRequest::new(&mut call, &mut owned_metadata);
+                    middleware.pre(&context, &mut request).await;
+                }
+            }
+
+            let result = self.caller.call(call).await;
+            if !self.middlewares.is_empty() {
+                let outcome = match &result {
+                    Ok(_) => ClientCallOutcome::Response,
+                    Err(error) => ClientCallOutcome::Error(error),
+                };
+                for middleware in self.middlewares.iter().rev() {
+                    middleware.post(&context, outcome).await;
+                }
+            }
+            result
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn closed(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        self.caller.closed()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn closed(&self) -> Pin<Box<dyn Future<Output = ()> + '_>> {
+        self.caller.closed()
+    }
+
+    fn is_connected(&self) -> bool {
+        self.caller.is_connected()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn channel_binder(&self) -> Option<&dyn crate::ChannelBinder> {
+        self.caller.channel_binder()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use crate::{Backing, Payload};
+
+    use super::{
+        BoxMiddlewareFuture, ClientCallOutcome, ClientContext, ClientMiddleware, ClientRequest,
+        MetadataFlags, MethodDescriptor, MethodId, MiddlewareCaller, OwnedMetadata, RequestCall,
+        RequestResponse, RoamError, SelfRef,
+    };
+    use crate::Caller;
+
+    #[test]
+    fn client_request_can_add_owned_metadata() {
+        let mut call = RequestCall {
+            method_id: MethodId(1),
+            channels: vec![],
+            metadata: vec![],
+            args: Payload::Incoming(&[]),
+        };
+        let mut owned = OwnedMetadata::default();
+        let mut request = ClientRequest::new(&mut call, &mut owned);
+        request.push_string_metadata("x-test", "value".to_string(), MetadataFlags::NONE);
+        request.push_bytes_metadata("x-bytes", vec![1, 2, 3], MetadataFlags::NONE);
+        request.push_u64_metadata("x-num", 7, MetadataFlags::NONE);
+
+        assert_eq!(request.metadata().len(), 3);
+        assert!(matches!(
+            request.metadata()[0].value,
+            crate::MetadataValue::String("value")
+        ));
+        assert!(matches!(
+            request.metadata()[1].value,
+            crate::MetadataValue::Bytes(bytes) if bytes == [1, 2, 3]
+        ));
+        assert!(matches!(
+            request.metadata()[2].value,
+            crate::MetadataValue::U64(7)
+        ));
+    }
+
+    #[derive(Clone)]
+    struct RecordingCaller {
+        seen_metadata: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Caller for RecordingCaller {
+        fn call<'a>(
+            &'a self,
+            call: RequestCall<'a>,
+        ) -> impl Future<Output = Result<SelfRef<RequestResponse<'static>>, RoamError>>
+        + crate::MaybeSend
+        + 'a {
+            async move {
+                let seen = call
+                    .metadata
+                    .iter()
+                    .map(|entry| match entry.value {
+                        crate::MetadataValue::String(value) => format!("{}={value}", entry.key),
+                        crate::MetadataValue::Bytes(bytes) => {
+                            format!("{}=<{} bytes>", entry.key, bytes.len())
+                        }
+                        crate::MetadataValue::U64(value) => format!("{}={value}", entry.key),
+                    })
+                    .collect::<Vec<_>>();
+                *self
+                    .seen_metadata
+                    .lock()
+                    .expect("seen metadata mutex poisoned") = seen;
+
+                Ok(SelfRef::owning(
+                    Backing::Boxed(Box::<[u8]>::default()),
+                    RequestResponse {
+                        channels: vec![],
+                        metadata: vec![],
+                        ret: Payload::Incoming(&[]),
+                    },
+                ))
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct InjectMetadata;
+
+    impl ClientMiddleware for InjectMetadata {
+        fn pre<'a, 'call>(
+            &'a self,
+            context: &'a ClientContext<'a>,
+            request: &'a mut ClientRequest<'call, 'a>,
+        ) -> BoxMiddlewareFuture<'a> {
+            Box::pin(async move {
+                context.extensions().insert(41_u32);
+                request.push_string_metadata("x-test", "value".to_string(), MetadataFlags::NONE);
+            })
+        }
+
+        fn post<'a>(
+            &'a self,
+            context: &'a ClientContext<'a>,
+            outcome: ClientCallOutcome<'a>,
+        ) -> BoxMiddlewareFuture<'a> {
+            Box::pin(async move {
+                assert_eq!(context.extensions().get_cloned::<u32>(), Some(41));
+                assert!(outcome.is_ok());
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn middleware_caller_runs_hooks_and_mutates_metadata() {
+        static METHOD: MethodDescriptor = MethodDescriptor {
+            id: MethodId(7),
+            service_name: "Audit",
+            method_name: "record",
+            args: &[],
+            return_shape: &<() as facet::Facet<'static>>::SHAPE,
+            doc: None,
+        };
+        static SERVICE: crate::ServiceDescriptor = crate::ServiceDescriptor {
+            service_name: "Audit",
+            methods: &[&METHOD],
+            doc: None,
+        };
+
+        let seen_metadata = Arc::new(Mutex::new(Vec::new()));
+        let caller = MiddlewareCaller::new(
+            RecordingCaller {
+                seen_metadata: Arc::clone(&seen_metadata),
+            },
+            &SERVICE,
+        )
+        .with_middleware(InjectMetadata);
+
+        let response = caller
+            .call(RequestCall {
+                method_id: MethodId(7),
+                channels: vec![],
+                metadata: vec![],
+                args: Payload::Incoming(&[]),
+            })
+            .await;
+
+        assert!(response.is_ok());
+        assert_eq!(
+            *seen_metadata.lock().expect("seen metadata mutex poisoned"),
+            vec!["x-test=value".to_string()]
+        );
+    }
+}

--- a/rust/roam-types/src/lib.rs
+++ b/rust/roam-types/src/lib.rs
@@ -100,6 +100,9 @@ pub use request_context::*;
 mod server_middleware;
 pub use server_middleware::*;
 
+mod client_middleware;
+pub use client_middleware::*;
+
 mod calls;
 pub use calls::*;
 

--- a/rust/roam/src/client_logging.rs
+++ b/rust/roam/src/client_logging.rs
@@ -1,0 +1,309 @@
+use std::time::Instant;
+
+use tracing::debug;
+
+use crate::{
+    BoxMiddlewareFuture, ClientCallOutcome, ClientContext, ClientMiddleware, ClientRequest,
+    MetadataEntry, MetadataFlags, MetadataValue,
+};
+
+#[derive(Debug, Clone)]
+pub struct ClientLoggingOptions {
+    pub log_metadata: bool,
+}
+
+impl Default for ClientLoggingOptions {
+    fn default() -> Self {
+        Self {
+            log_metadata: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ClientLogging {
+    options: ClientLoggingOptions,
+}
+
+impl ClientLogging {
+    pub fn new(options: ClientLoggingOptions) -> Self {
+        Self { options }
+    }
+
+    pub fn with_metadata(mut self, log_metadata: bool) -> Self {
+        self.options.log_metadata = log_metadata;
+        self
+    }
+}
+
+impl ClientMiddleware for ClientLogging {
+    fn pre<'a, 'call>(
+        &'a self,
+        context: &'a ClientContext<'a>,
+        request: &'a mut ClientRequest<'call, 'a>,
+    ) -> BoxMiddlewareFuture<'a> {
+        Box::pin(async move {
+            context.extensions().insert(RequestStart(Instant::now()));
+            let method = context.method();
+            if self.options.log_metadata {
+                debug!(
+                    target: "roam::client",
+                    service = method.map(|method| method.service_name),
+                    method = method.map(|method| method.method_name),
+                    method_id = %context.method_id(),
+                    metadata = ?RedactedMetadata(request.metadata()),
+                    "rpc request"
+                );
+            } else {
+                debug!(
+                    target: "roam::client",
+                    service = method.map(|method| method.service_name),
+                    method = method.map(|method| method.method_name),
+                    method_id = %context.method_id(),
+                    "rpc request"
+                );
+            }
+        })
+    }
+
+    fn post<'a>(
+        &'a self,
+        context: &'a ClientContext<'a>,
+        outcome: ClientCallOutcome<'a>,
+    ) -> BoxMiddlewareFuture<'a> {
+        Box::pin(async move {
+            let method = context.method();
+            let duration_ms = context
+                .extensions()
+                .with::<RequestStart, _>(|start| start.0.elapsed().as_secs_f64() * 1_000.0);
+            match outcome {
+                ClientCallOutcome::Response => {
+                    debug!(
+                        target: "roam::client",
+                        service = method.map(|method| method.service_name),
+                        method = method.map(|method| method.method_name),
+                        method_id = %context.method_id(),
+                        duration_ms,
+                        outcome = "response",
+                        "rpc response"
+                    );
+                }
+                ClientCallOutcome::Error(error) => {
+                    debug!(
+                        target: "roam::client",
+                        service = method.map(|method| method.service_name),
+                        method = method.map(|method| method.method_name),
+                        method_id = %context.method_id(),
+                        duration_ms,
+                        error = ?error,
+                        outcome = "error",
+                        "rpc response"
+                    );
+                }
+            }
+        })
+    }
+}
+
+#[derive(Debug)]
+struct RequestStart(Instant);
+
+#[derive(Clone, Copy)]
+struct RedactedMetadata<'a>(&'a [MetadataEntry<'a>]);
+
+impl std::fmt::Debug for RedactedMetadata<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut entries = f.debug_list();
+        for entry in self.0 {
+            entries.entry(&MetadataEntryDebug(entry));
+        }
+        entries.finish()
+    }
+}
+
+struct MetadataEntryDebug<'a>(&'a MetadataEntry<'a>);
+
+impl std::fmt::Debug for MetadataEntryDebug<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let entry = self.0;
+        let mut debug = f.debug_struct("MetadataEntry");
+        debug.field("key", &entry.key);
+        if entry.flags.contains(MetadataFlags::SENSITIVE) {
+            debug.field("value", &"[REDACTED]");
+        } else {
+            debug.field("value", &MetadataValueDebug(&entry.value));
+        }
+        debug.field("flags", &entry.flags);
+        debug.finish()
+    }
+}
+
+struct MetadataValueDebug<'a>(&'a MetadataValue<'a>);
+
+impl std::fmt::Debug for MetadataValueDebug<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            MetadataValue::String(value) => value.fmt(f),
+            MetadataValue::Bytes(bytes) => write!(f, "<{} bytes>", bytes.len()),
+            MetadataValue::U64(value) => value.fmt(f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io,
+        sync::{Arc, Mutex},
+    };
+
+    use tracing_subscriber::{
+        Layer,
+        filter::LevelFilter,
+        fmt::{self, MakeWriter},
+        layer::SubscriberExt,
+    };
+
+    use super::{ClientLogging, ClientLoggingOptions, RedactedMetadata};
+    use crate::{
+        Caller, MetadataEntry, MetadataFlags, MetadataValue, MethodDescriptor, MethodId,
+        MiddlewareCaller, Payload, RequestCall, RequestResponse, RoamError, SelfRef,
+        ServiceDescriptor,
+    };
+
+    #[test]
+    fn metadata_debug_redacts_sensitive_values() {
+        let metadata = vec![
+            MetadataEntry {
+                key: "authorization",
+                value: MetadataValue::String("Bearer secret"),
+                flags: MetadataFlags::SENSITIVE,
+            },
+            MetadataEntry {
+                key: "blob",
+                value: MetadataValue::Bytes(&[1, 2, 3]),
+                flags: MetadataFlags::NONE,
+            },
+        ];
+
+        assert_eq!(
+            format!("{:?}", RedactedMetadata(&metadata)),
+            "[MetadataEntry { key: \"authorization\", value: \"[REDACTED]\", flags: MetadataFlags(1) }, MetadataEntry { key: \"blob\", value: <3 bytes>, flags: MetadataFlags(0) }]"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_logging_emits_redacted_request_and_response_logs() {
+        let writer = SharedWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .without_time()
+                .with_ansi(false)
+                .with_writer(writer.clone())
+                .with_filter(LevelFilter::DEBUG),
+        );
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        static METHOD: MethodDescriptor = MethodDescriptor {
+            id: MethodId(7),
+            service_name: "Audit",
+            method_name: "record",
+            args: &[],
+            return_shape: &<() as facet::Facet<'static>>::SHAPE,
+            doc: None,
+        };
+
+        static SERVICE: ServiceDescriptor = ServiceDescriptor {
+            service_name: "Audit",
+            methods: &[&METHOD],
+            doc: None,
+        };
+
+        let logging = ClientLogging::new(ClientLoggingOptions { log_metadata: true });
+        let caller =
+            MiddlewareCaller::new(AlwaysCancelledCaller, &SERVICE).with_middleware(logging);
+        let _ = caller
+            .call(RequestCall {
+                method_id: MethodId(7),
+                channels: vec![],
+                metadata: vec![
+                    MetadataEntry {
+                        key: "authorization",
+                        value: MetadataValue::String("Bearer secret"),
+                        flags: MetadataFlags::SENSITIVE,
+                    },
+                    MetadataEntry {
+                        key: "attempt",
+                        value: MetadataValue::U64(2),
+                        flags: MetadataFlags::NONE,
+                    },
+                ],
+                args: Payload::Incoming(&[]),
+            })
+            .await;
+
+        let output = writer.output();
+        assert!(output.contains("rpc request"));
+        assert!(output.contains("rpc response"));
+        assert!(output.contains("authorization"));
+        assert!(output.contains("[REDACTED]"));
+        assert!(!output.contains("Bearer secret"));
+        assert!(output.contains("attempt"));
+        assert!(output.contains("Cancelled"));
+    }
+
+    #[derive(Clone)]
+    struct AlwaysCancelledCaller;
+
+    impl Caller for AlwaysCancelledCaller {
+        fn call<'a>(
+            &'a self,
+            _call: RequestCall<'a>,
+        ) -> impl std::future::Future<
+            Output = Result<SelfRef<RequestResponse<'static>>, RoamError>,
+        > + Send
+        + 'a {
+            async move { Err(RoamError::Cancelled) }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct SharedWriter {
+        output: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl SharedWriter {
+        fn output(&self) -> String {
+            let bytes = self.output.lock().expect("shared writer mutex poisoned");
+            String::from_utf8(bytes.clone()).expect("log output should be utf-8")
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedWriter {
+        type Writer = SharedWriterGuard;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedWriterGuard {
+                output: Arc::clone(&self.output),
+            }
+        }
+    }
+
+    struct SharedWriterGuard {
+        output: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl io::Write for SharedWriterGuard {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.output
+                .lock()
+                .expect("shared writer mutex poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+}

--- a/rust/roam/src/lib.rs
+++ b/rust/roam/src/lib.rs
@@ -3,9 +3,11 @@
 //! This is the facade crate. It re-exports everything needed by both
 //! hand-written code and `#[roam::service]` macro-generated code.
 
+mod client_logging;
 mod server_logging;
 
 // Re-export the proc macro
+pub use client_logging::{ClientLogging, ClientLoggingOptions};
 pub use roam_service_macros::service;
 pub use server_logging::{ServerLogging, ServerLoggingOptions};
 
@@ -27,6 +29,10 @@ pub use roam_types::{
     Caller,
     // Descriptors
     ChannelId,
+    ClientCallOutcome,
+    ClientContext,
+    ClientMiddleware,
+    ClientRequest,
     Conduit,
     ConduitAcceptor,
     ConduitRx,
@@ -49,6 +55,7 @@ pub use roam_types::{
     MetadataValue,
     MethodDescriptor,
     MethodId,
+    MiddlewareCaller,
     MsgFamily,
     Parity,
     Payload,

--- a/rust/roam/tests/service_macro_shared.rs
+++ b/rust/roam/tests/service_macro_shared.rs
@@ -40,6 +40,28 @@ impl ContextProbe for ContextProbeService {
 }
 
 #[roam::service]
+trait ClientMiddlewareProbe {
+    #[roam::context]
+    async fn inspect(&self) -> String;
+}
+
+#[derive(Clone)]
+struct ClientMiddlewareProbeService;
+
+impl ClientMiddlewareProbe for ClientMiddlewareProbeService {
+    async fn inspect(&self, cx: &roam::RequestContext<'_>) -> String {
+        cx.metadata()
+            .iter()
+            .find(|entry| entry.key == "x-client-value")
+            .and_then(|entry| match entry.value {
+                roam::MetadataValue::String(value) => Some(value.to_string()),
+                _ => None,
+            })
+            .expect("client middleware should inject request metadata")
+    }
+}
+
+#[roam::service]
 trait MiddlewareProbe {
     #[roam::context]
     async fn inspect(&self) -> String;
@@ -108,6 +130,71 @@ impl roam::ServerMiddleware for RecordingMiddleware {
 
 fn record_event(events: &Arc<Mutex<Vec<String>>>, event: String) {
     events.lock().expect("events mutex poisoned").push(event);
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ClientMiddlewareSeed(String);
+
+#[derive(Clone)]
+struct RecordingClientMiddleware {
+    name: &'static str,
+    events: Arc<Mutex<Vec<String>>>,
+    inject_metadata: bool,
+}
+
+impl roam::ClientMiddleware for RecordingClientMiddleware {
+    fn pre<'a, 'call>(
+        &'a self,
+        context: &'a roam::ClientContext<'a>,
+        request: &'a mut roam::ClientRequest<'call, 'a>,
+    ) -> roam::BoxMiddlewareFuture<'a> {
+        Box::pin(async move {
+            record_event(&self.events, format!("{}:pre", self.name));
+            match self.name {
+                "first" => {
+                    context
+                        .extensions()
+                        .insert(ClientMiddlewareSeed(self.name.to_string()));
+                }
+                "second" => {
+                    assert_eq!(
+                        context.extensions().get_cloned::<ClientMiddlewareSeed>(),
+                        Some(ClientMiddlewareSeed("first".to_string()))
+                    );
+                    assert_eq!(
+                        context.method().map(|method| method.method_name),
+                        Some("inspect")
+                    );
+                }
+                _ => {}
+            }
+
+            if self.inject_metadata {
+                request.push_string_metadata(
+                    "x-client-value",
+                    format!("{}-value", self.name),
+                    roam::MetadataFlags::NONE,
+                );
+            }
+        })
+    }
+
+    fn post<'a>(
+        &'a self,
+        _context: &'a roam::ClientContext<'a>,
+        outcome: roam::ClientCallOutcome<'a>,
+    ) -> roam::BoxMiddlewareFuture<'a> {
+        Box::pin(async move {
+            record_event(
+                &self.events,
+                format!(
+                    "{}:post:{}",
+                    self.name,
+                    if outcome.is_ok() { "ok" } else { "err" }
+                ),
+            );
+        })
+    }
 }
 
 pub async fn run_adder_end_to_end<L>(
@@ -243,6 +330,65 @@ pub async fn run_server_middleware_end_to_end<L>(
             "second:pre".to_string(),
             "second:post:Replied".to_string(),
             "first:post:Replied".to_string(),
+        ]
+    );
+
+    server_task.abort();
+}
+
+pub async fn run_client_middleware_end_to_end<L>(
+    message_conduit_pair: impl FnOnce() -> (MessageConduit<L>, MessageConduit<L>),
+) where
+    L: Link + Send + 'static,
+    L::Tx: Send + 'static,
+    L::Rx: Send + 'static,
+{
+    let (client_conduit, server_conduit) = message_conduit_pair();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::task::spawn(async move {
+        let (server_caller_guard, _sh) = acceptor(server_conduit)
+            .establish::<ClientMiddlewareProbeClient>(ClientMiddlewareProbeDispatcher::new(
+                ClientMiddlewareProbeService,
+            ))
+            .await
+            .expect("server handshake failed");
+        let _ = server_ready_tx.send(());
+        let _server_caller_guard = server_caller_guard;
+        std::future::pending::<()>().await;
+    });
+
+    let (client, _sh) = initiator(client_conduit)
+        .establish::<ClientMiddlewareProbeClient>(())
+        .await
+        .expect("client handshake failed");
+
+    server_ready_rx.await.expect("server setup failed");
+
+    let client = client
+        .with_middleware(RecordingClientMiddleware {
+            name: "first",
+            events: Arc::clone(&events),
+            inject_metadata: true,
+        })
+        .with_middleware(RecordingClientMiddleware {
+            name: "second",
+            events: Arc::clone(&events),
+            inject_metadata: false,
+        });
+
+    let observed = client.inspect().await.expect("inspect call should succeed");
+    assert_eq!(observed, "first-value");
+
+    let events = events.lock().expect("events mutex poisoned").clone();
+    assert_eq!(
+        events,
+        vec![
+            "first:pre".to_string(),
+            "second:pre".to_string(),
+            "second:post:ok".to_string(),
+            "first:post:ok".to_string(),
         ]
     );
 

--- a/rust/roam/tests/service_macro_tests.rs
+++ b/rust/roam/tests/service_macro_tests.rs
@@ -23,3 +23,8 @@ async fn request_context_opt_in_end_to_end() {
 async fn server_middleware_end_to_end() {
     service_macro_shared::run_server_middleware_end_to_end(message_conduit_pair).await;
 }
+
+#[tokio::test]
+async fn client_middleware_end_to_end() {
+    service_macro_shared::run_client_middleware_end_to_end(message_conduit_pair).await;
+}

--- a/rust/roam/tests/shm_service_macro_tests.rs
+++ b/rust/roam/tests/shm_service_macro_tests.rs
@@ -54,3 +54,9 @@ async fn server_middleware_end_to_end_over_shm() {
     let (a, b, _dir) = message_conduit_pair().await;
     service_macro_shared::run_server_middleware_end_to_end(|| (a, b)).await;
 }
+
+#[tokio::test]
+async fn client_middleware_end_to_end_over_shm() {
+    let (a, b, _dir) = message_conduit_pair().await;
+    service_macro_shared::run_client_middleware_end_to_end(|| (a, b)).await;
+}


### PR DESCRIPTION
## Summary
Adds the Rust client-side half of middleware support for #171.
Generated clients now expose `.with_middleware(...)`, runtime callers can run client middleware around requests, and the facade includes a built-in client logging middleware.

## Changes
- add `ClientMiddleware`, `ClientContext`, `ClientRequest`, `ClientCallOutcome`, and runtime caller wrapping in `roam-types`
- extend `ErasedCaller` and generated Rust clients to accumulate middleware in runtime code instead of generated per-method orchestration
- add built-in `ClientLogging` with timing and `SENSITIVE` metadata redaction
- add end-to-end tests for metadata injection and middleware ordering, plus updated macro snapshots

## Testing
- `cargo nextest run -p roam-types -p roam-macros-core -p roam`

Part of #171
