### PR TITLE
Integrate retry spec and TS Tracey coverage

### DIFF
--- a/.config/tracey/config.styx
+++ b/.config/tracey/config.styx
@@ -14,6 +14,16 @@ specs (
                 name swift
                 include (swift/roam-runtime/**/*.swift)
             }
+            {
+                name typescript
+                include (
+                    typescript/packages/roam-core/src/session.ts
+                    typescript/packages/roam-core/src/stable_conduit.ts
+                    typescript/packages/roam-core/src/driver.ts
+                    typescript/packages/roam-core/src/channeling/registry.ts
+                    typescript/packages/roam-core/src/channeling/registry.test.ts
+                )
+            }
         )
     }
 )

--- a/docs/content/spec/_index.md
+++ b/docs/content/spec/_index.md
@@ -9,6 +9,7 @@ The Roam specification defines the protocol and runtime model across layers:
 - Requests and channels
 - Connections and sessions
 - Conduit behavior
+- Retry semantics and operation continuity
 - Link transports (stream, WebSocket, shared memory)
 
 Start with [Introduction](./intro/), then continue through the protocol chapters in this section.

--- a/docs/content/spec/conn.md
+++ b/docs/content/spec/conn.md
@@ -174,6 +174,10 @@ weight = 11
 > `StableConduit` provides automatic reconnection (over fresh links) and replay of
 > missed messages. It comes with its own Packet framing.
 
+`StableConduit` continuity does not, by itself, answer what happens to an RPC
+whose outcome is now ambiguous. Operation-level retry and session resumption
+semantics are defined in [Retry](./retry/).
+
 > r[conduit.split]
 >
 > Conduits can be passed around whole, but before use, they MUST be split into

--- a/docs/content/spec/rpc.md
+++ b/docs/content/spec/rpc.md
@@ -12,6 +12,10 @@ If you're coming from roam v6 APIs, see the
 > The RPC layer sits on top of connections. It defines how requests are made,
 > how responses are returned, and how data flows over channels.
 
+Transparent retry is specified separately in [Retry](./retry/). The RPC layer
+defines the request/response/channel model for a single attempt; the retry
+layer defines when multiple attempts address the same logical operation.
+
 > r[rpc.service]
 >
 > A service is a set of methods. In Rust, a service is defined as a trait
@@ -179,6 +183,9 @@ registered on the session builder; otherwise they are rejected.
 >   * A list of channel IDs for channels that appear in the arguments,
 >     allocated by the caller
 >   * Metadata (key-value pairs for tracing, auth, deadlines, etc.)
+
+When retry support is active, request metadata also carries the operation
+identity described in [Retry](./retry/).
 
 > r[rpc.response]
 >

--- a/docs/content/spec/stable.md
+++ b/docs/content/spec/stable.md
@@ -11,6 +11,10 @@ weight = 14
 > layer above it sees a reliable, ordered stream of items, even when the
 > underlying link fails and is replaced.
 
+StableConduit continuity is below the RPC retry layer. It preserves conduit
+items; it does not by itself define when an RPC should be retried, resumed, or
+replayed as the same logical operation. See [Retry](./retry/).
+
 > r[stable.link-source]
 >
 > A StableConduit is constructed with a LinkSource — an async provider
@@ -141,3 +145,7 @@ weight = 14
 > expired or the server restarted), it MUST reject the resume attempt.
 > The client MUST treat this as a session loss and surface an error to
 > the layers above.
+
+What happens after that session loss is governed by [Retry](./retry/): stable
+reconnection stops at conduit continuity, while operation-level retry and
+session resumption are defined separately there.

--- a/typescript/packages/roam-core/src/channeling/registry.test.ts
+++ b/typescript/packages/roam-core/src/channeling/registry.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { ChannelRegistry } from "./registry.ts";
 
 describe("ChannelRegistry", () => {
+  // r[verify rpc.channel.binding]
+  // r[verify rpc.channel.item]
   it("buffers incoming data until the receiver is registered", async () => {
     const registry = new ChannelRegistry();
     const channelId = 7n;
@@ -17,6 +19,8 @@ describe("ChannelRegistry", () => {
     await expect(rx.recv()).resolves.toEqual(second);
   });
 
+  // r[verify rpc.channel.close]
+  // r[verify rpc.channel.reset]
   it("preserves buffered terminal close before the receiver is registered", async () => {
     const registry = new ChannelRegistry();
     const channelId = 9n;

--- a/typescript/packages/roam-core/src/channeling/registry.ts
+++ b/typescript/packages/roam-core/src/channeling/registry.ts
@@ -212,8 +212,6 @@ export class OutgoingSender {
  *
  * Handles both incoming channels (Data from wire → Rx<T>) and
  * outgoing channels (Tx<T> → Data to wire).
- *
- * r[impl channeling.unknown] - Unknown channel IDs cause Goodbye.
  */
 export class ChannelRegistry {
   constructor(
@@ -239,7 +237,8 @@ export class ChannelRegistry {
   /**
    * Register an incoming channel and return the receiver for Rx<T>.
    *
-   * r[impl channeling.allocation.caller] - Caller allocates channel IDs.
+   * r[impl rpc.channel.allocation] - Caller allocates channel IDs.
+   * r[impl rpc.channel.binding.callee-args.rx] - Callee binds incoming Rx by channel ID.
    */
   registerIncoming(
     channelId: ChannelId,
@@ -302,7 +301,8 @@ export class ChannelRegistry {
   /**
    * Register an outgoing channel and return the sender for Tx<T>.
    *
-   * r[impl channeling.allocation.caller] - Caller allocates channel IDs.
+   * r[impl rpc.channel.allocation] - Caller allocates channel IDs.
+   * r[impl rpc.channel.binding.callee-args.tx] - Callee binds outgoing Tx by channel ID.
    */
   registerOutgoing(
     channelId: ChannelId,
@@ -322,8 +322,9 @@ export class ChannelRegistry {
   /**
    * Route a Data message payload to the appropriate incoming channel.
    *
-   * r[impl channeling.data] - Data messages routed by channel_id.
-   * r[impl channeling.data-after-close] - Reject data on closed channels.
+   * r[impl rpc.channel.item] - Channel items route by channel ID.
+   * r[impl rpc.channel.binding] - Items may arrive before the callee registers the Rx handle.
+   * r[impl rpc.channel.close] - Data after close is rejected.
    */
   routeData(channelId: ChannelId, payload: Uint8Array): void {
     // Check for data-after-close
@@ -412,7 +413,8 @@ export class ChannelRegistry {
   /**
    * Close an incoming channel.
    *
-   * r[impl channeling.close] - Close terminates the channel.
+   * r[impl rpc.channel.close] - Close terminates the channel.
+   * r[impl rpc.channel.reset] - Reset also terminates the channel locally.
    */
   close(channelId: ChannelId): void {
     const pending = this.pendingIncoming.get(channelId);

--- a/typescript/packages/roam-core/src/driver.ts
+++ b/typescript/packages/roam-core/src/driver.ts
@@ -101,6 +101,7 @@ export class Driver {
   }
 
   async run(): Promise<void> {
+    // r[impl rpc.session-setup]
     let pendingIncoming: Promise<IncomingCall | null> | null = null;
 
     while (true) {
@@ -166,6 +167,8 @@ export class Driver {
   }
 
   private async handleCall(incoming: IncomingCall): Promise<void> {
+    // r[impl rpc.unknown-method]
+    // r[impl rpc.response.one-per-request]
     const descriptor = this.dispatcher.getDescriptor();
     const method = descriptor.methods.find((candidate) => candidate.id === incoming.methodId);
     if (!method) {
@@ -227,6 +230,9 @@ export class Driver {
     incoming: IncomingCall,
     taskSender: TaskSender,
   ): unknown[] {
+    // r[impl rpc.channel.binding]
+    // r[impl rpc.channel.binding.callee-args.rx]
+    // r[impl rpc.channel.binding.callee-args.tx]
     const decoded = decodeWithSchema(
       incoming.args,
       0,

--- a/typescript/packages/roam-core/src/session.ts
+++ b/typescript/packages/roam-core/src/session.ts
@@ -89,6 +89,8 @@ async function makeSessionConduit(
   transport: SessionTransport,
   options: SessionTransportOptions,
 ): Promise<Conduit<Message>> {
+  // r[impl conduit.bare]
+  // r[impl conduit.stable]
   const conduit = options.conduit ?? "bare";
   if (isLinkSource(transport)) {
     if (conduit === "stable") {
@@ -189,6 +191,7 @@ class SessionCore {
     settings: ConnectionSettings,
     metadata: Metadata = [],
   ): Promise<ConnectionHandle> {
+    // r[impl connection.open]
     this.assertOpen();
     const connectionId = this.allocateConnectionId();
     const result = deferred<ConnectionHandle>();
@@ -208,6 +211,7 @@ class SessionCore {
   }
 
   async closeConnection(connectionId: bigint, metadata: Metadata = []): Promise<void> {
+    // r[impl connection.close]
     if (connectionId === 0n) {
       throw new SessionError("cannot close root connection");
     }
@@ -271,6 +275,7 @@ class SessionCore {
   }
 
   private async run(): Promise<void> {
+    // r[impl session.message]
     while (!this.closed) {
       const message = await this.conduit.recv();
       if (!message) {
@@ -323,6 +328,9 @@ class SessionCore {
     connectionId: bigint,
     value: { connection_settings: ConnectionSettings; metadata: Metadata },
   ): Promise<void> {
+    // r[impl connection.open]
+    // r[impl connection.open.rejection]
+    // r[impl session.connection-settings.open]
     if (!this.onConnection) {
       await this.sendMessage({
         connection_id: connectionId,
@@ -387,6 +395,9 @@ class SessionCore {
     connectionId: bigint,
     request: RequestMessage,
   ): Promise<void> {
+    // r[impl rpc.request]
+    // r[impl rpc.response]
+    // r[impl rpc.cancel]
     const connection = this.getConnection(connectionId);
     switch (request.body.tag) {
       case "Call":
@@ -412,6 +423,10 @@ class SessionCore {
     connectionId: bigint,
     channel: ChannelMessage,
   ): void {
+    // r[impl rpc.channel.item]
+    // r[impl rpc.channel.close]
+    // r[impl rpc.channel.reset]
+    // r[impl rpc.flow-control.credit.grant]
     const connection = this.getConnection(connectionId);
     switch (channel.body.tag) {
       case "Item":
@@ -704,6 +719,9 @@ export class Session {
     conduit: Conduit<Message>,
     options: SessionBuilderOptions = {},
   ): Promise<Session> {
+    // r[impl session.handshake]
+    // r[impl session.connection-settings.hello]
+    // r[impl session.parity]
     const localSettings: ConnectionSettings = {
       parity: parityOdd(),
       max_concurrent_requests: options.maxConcurrentRequests ?? 64,
@@ -725,6 +743,9 @@ export class Session {
     conduit: Conduit<Message>,
     options: SessionBuilderOptions = {},
   ): Promise<Session> {
+    // r[impl session.handshake]
+    // r[impl session.connection-settings.hello]
+    // r[impl session.parity]
     const hello = await waitForHello(conduit);
     const localSettings: ConnectionSettings = {
       parity: parityEven(),

--- a/typescript/packages/roam-core/src/stable_conduit.ts
+++ b/typescript/packages/roam-core/src/stable_conduit.ts
@@ -186,6 +186,8 @@ export class StableConduit implements Conduit<Message> {
   constructor(private readonly source: LinkSource) {}
 
   static async connect(source: LinkSource): Promise<StableConduit> {
+    // r[impl stable]
+    // r[impl stable.link-source]
     const conduit = new StableConduit(source);
     await conduit.attachFreshLink();
     conduit.ensureRecvLoop();
@@ -193,6 +195,9 @@ export class StableConduit implements Conduit<Message> {
   }
 
   async send(item: Message): Promise<void> {
+    // r[impl stable.framing]
+    // r[impl stable.ack]
+    // r[impl stable.replay-buffer]
     const itemBytes = encodeMessage(item);
     while (!this.closed) {
       try {
@@ -215,6 +220,8 @@ export class StableConduit implements Conduit<Message> {
   }
 
   async recv(): Promise<Message | null> {
+    // r[impl stable.seq.monotonic]
+    // r[impl stable.ack.trim]
     const queued = this.recvQueue.shift();
     if (queued) {
       return queued;
@@ -244,6 +251,12 @@ export class StableConduit implements Conduit<Message> {
   }
 
   private async attachFreshLink(): Promise<void> {
+    // r[impl stable.handshake]
+    // r[impl stable.reconnect]
+    // r[impl stable.reconnect.server-replay]
+    // r[impl stable.reconnect.client-replay]
+    // r[impl stable.replay-buffer.order]
+    // r[impl retry.reconnect.stable-conduit]
     const attachment = await this.source.nextLink();
     const link = attachment.link;
 
@@ -355,6 +368,8 @@ export class StableConduit implements Conduit<Message> {
   }
 
   private async ensureReconnected(): Promise<void> {
+    // r[impl stable.reconnect]
+    // r[impl stable.reconnect.failure]
     if (this.closed) {
       throw new Error("StableConduit closed");
     }


### PR DESCRIPTION
## Summary
This tightens spec discipline around the new TypeScript runtime without changing behavior.

It does two things:
- adds a scoped `roam/typescript` implementation to Tracey for the new TS runtime surface
- integrates the standalone retry spec back into the surrounding spec pages

## Changes
- add `roam/typescript` to Tracey config in `.config/tracey/config.styx`
- annotate the new TS runtime files for session, stable conduit, driver, and channel buffering
- add verification annotations to the new TS channel buffering regression test
- add retry references to `docs/content/spec/_index.md`, `conn.md`, `rpc.md`, and `stable.md`

## Validation
- `tracey_reload`
- `tracey_validate` for `roam/typescript`
- `pnpm --filter @bearcove/roam-core check`
- `pnpm --filter @bearcove/roam-core test`
