### PR TITLE
Add manual session resumption on a new conduit

### DIFF
--- a/rust/roam-core/src/session/builders.rs
+++ b/rust/roam-core/src/session/builders.rs
@@ -57,6 +57,7 @@ pub struct SessionInitiatorBuilder<'a, C> {
     metadata: Metadata<'a>,
     on_connection: Option<Box<dyn ConnectionAcceptor>>,
     keepalive: Option<SessionKeepaliveConfig>,
+    resumable: bool,
     spawn_fn: SpawnFn,
 }
 
@@ -71,6 +72,7 @@ impl<'a, C> SessionInitiatorBuilder<'a, C> {
             metadata: vec![],
             on_connection: None,
             keepalive: None,
+            resumable: false,
             spawn_fn: default_spawn_fn(),
         }
     }
@@ -105,6 +107,11 @@ impl<'a, C> SessionInitiatorBuilder<'a, C> {
         self
     }
 
+    pub fn resumable(mut self) -> Self {
+        self.resumable = true;
+        self
+    }
+
     /// Override the function used to spawn the session background task.
     /// Defaults to `tokio::spawn` on non-WASM and `wasm_bindgen_futures::spawn_local` on WASM.
     #[cfg(not(target_arch = "wasm32"))]
@@ -134,16 +141,19 @@ impl<'a, C> SessionInitiatorBuilder<'a, C> {
         let (tx, rx) = self.conduit.split();
         let (open_tx, open_rx) = mpsc::channel::<OpenRequest>("session.open", 4);
         let (close_tx, close_rx) = mpsc::channel::<CloseRequest>("session.close", 4);
+        let (resume_tx, resume_rx) = mpsc::channel::<super::ResumeRequest>("session.resume", 1);
         let (control_tx, control_rx) = mpsc::unbounded_channel("session.control");
-        let mut session: Session<C> = Session::pre_handshake(
+        let mut session = Session::pre_handshake(
             tx,
             rx,
             self.on_connection,
             open_rx,
             close_rx,
+            resume_rx,
             control_tx.clone(),
             control_rx,
             self.keepalive,
+            self.resumable,
         );
         let handle = session
             .establish_as_initiator(self.root_settings, self.metadata)
@@ -151,6 +161,7 @@ impl<'a, C> SessionInitiatorBuilder<'a, C> {
         let session_handle = SessionHandle {
             open_tx,
             close_tx,
+            resume_tx,
             control_tx,
         };
         let mut driver = Driver::new(handle, handler);
@@ -170,6 +181,7 @@ pub struct SessionAcceptorBuilder<'a, C> {
     metadata: Metadata<'a>,
     on_connection: Option<Box<dyn ConnectionAcceptor>>,
     keepalive: Option<SessionKeepaliveConfig>,
+    resumable: bool,
     spawn_fn: SpawnFn,
 }
 
@@ -184,6 +196,7 @@ impl<'a, C> SessionAcceptorBuilder<'a, C> {
             metadata: vec![],
             on_connection: None,
             keepalive: None,
+            resumable: false,
             spawn_fn: default_spawn_fn(),
         }
     }
@@ -210,6 +223,11 @@ impl<'a, C> SessionAcceptorBuilder<'a, C> {
 
     pub fn keepalive(mut self, keepalive: SessionKeepaliveConfig) -> Self {
         self.keepalive = Some(keepalive);
+        self
+    }
+
+    pub fn resumable(mut self) -> Self {
+        self.resumable = true;
         self
     }
 
@@ -243,16 +261,19 @@ impl<'a, C> SessionAcceptorBuilder<'a, C> {
         let (tx, rx) = self.conduit.split();
         let (open_tx, open_rx) = mpsc::channel::<OpenRequest>("session.open", 4);
         let (close_tx, close_rx) = mpsc::channel::<CloseRequest>("session.close", 4);
+        let (resume_tx, resume_rx) = mpsc::channel::<super::ResumeRequest>("session.resume", 1);
         let (control_tx, control_rx) = mpsc::unbounded_channel("session.control");
-        let mut session: Session<C> = Session::pre_handshake(
+        let mut session = Session::pre_handshake(
             tx,
             rx,
             self.on_connection,
             open_rx,
             close_rx,
+            resume_rx,
             control_tx.clone(),
             control_rx,
             self.keepalive,
+            self.resumable,
         );
         let handle = session
             .establish_as_acceptor(self.root_settings, self.metadata)
@@ -260,6 +281,7 @@ impl<'a, C> SessionAcceptorBuilder<'a, C> {
         let session_handle = SessionHandle {
             open_tx,
             close_tx,
+            resume_tx,
             control_tx,
         };
         let mut driver = Driver::new(handle, handler);

--- a/rust/roam-core/src/session/mod.rs
+++ b/rust/roam-core/src/session/mod.rs
@@ -5,8 +5,9 @@ use roam_types::{
     ChannelMessage, Conduit, ConduitRx, ConduitTx, ConduitTxPermit, ConnectionAccept,
     ConnectionClose, ConnectionId, ConnectionOpen, ConnectionReject, ConnectionSettings,
     IdAllocator, MaybeSend, MaybeSync, Message, MessageFamily, MessagePayload, Metadata, Parity,
-    RequestBody, RequestId, RequestMessage, RequestResponse, SelfRef, SessionRole,
-    append_retry_support_metadata, metadata_supports_retry,
+    RequestBody, RequestId, RequestMessage, RequestResponse, SelfRef, SessionResumeKey,
+    SessionRole, append_retry_support_metadata, append_session_resume_key_metadata,
+    metadata_session_resume_key, metadata_supports_retry,
 };
 use tokio::sync::watch;
 use tracing::{debug, warn};
@@ -72,6 +73,12 @@ struct CloseRequest {
     result_tx: moire::sync::oneshot::Sender<Result<(), SessionError>>,
 }
 
+struct ResumeRequest {
+    tx: Arc<dyn DynConduitTx>,
+    rx: Box<dyn DynConduitRx>,
+    result_tx: moire::sync::oneshot::Sender<Result<(), SessionError>>,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum DropControlRequest {
     Shutdown,
@@ -108,6 +115,7 @@ fn send_drop_control(
 pub struct SessionHandle {
     open_tx: mpsc::Sender<OpenRequest>,
     close_tx: mpsc::Sender<CloseRequest>,
+    resume_tx: mpsc::Sender<ResumeRequest>,
     control_tx: mpsc::UnboundedSender<DropControlRequest>,
 }
 
@@ -162,6 +170,28 @@ impl SessionHandle {
             .map_err(|_| SessionError::Protocol("session closed".into()))?
     }
 
+    pub async fn resume<I: crate::IntoConduit>(&self, into_conduit: I) -> Result<(), SessionError>
+    where
+        I::Conduit: Conduit<Msg = MessageFamily> + 'static,
+        <I::Conduit as Conduit>::Tx: MaybeSend + MaybeSync + 'static,
+        for<'p> <<I::Conduit as Conduit>::Tx as ConduitTx>::Permit<'p>: MaybeSend,
+        <I::Conduit as Conduit>::Rx: MaybeSend + 'static,
+    {
+        let (tx, rx) = into_conduit.into_conduit().split();
+        let (result_tx, result_rx) = moire::sync::oneshot::channel("session.resume_result");
+        self.resume_tx
+            .send(ResumeRequest {
+                tx: Arc::new(tx),
+                rx: Box::new(rx),
+                result_tx,
+            })
+            .await
+            .map_err(|_| SessionError::Protocol("session closed".into()))?;
+        result_rx
+            .await
+            .map_err(|_| SessionError::Protocol("session closed".into()))?
+    }
+
     /// Request shutdown of the entire session (root + all virtual connections).
     pub fn shutdown(&self) -> Result<(), SessionError> {
         send_drop_control(&self.control_tx, DropControlRequest::Shutdown)
@@ -176,9 +206,9 @@ impl SessionHandle {
 /// Session state machine.
 // r[impl session]
 // r[impl rpc.one-service-per-connection]
-pub struct Session<C: Conduit> {
+pub struct Session {
     /// Conduit receiver
-    rx: C::Rx,
+    rx: Box<dyn DynConduitRx>,
 
     // r[impl session.role]
     role: SessionRole,
@@ -190,6 +220,10 @@ pub struct Session<C: Conduit> {
     /// Shared core (for sending) — also held by all ConnectionSenders.
     sess_core: Arc<SessionCore>,
     peer_supports_retry: bool,
+    local_root_settings: ConnectionSettings,
+    peer_root_settings: Option<ConnectionSettings>,
+    resumable: bool,
+    session_resume_key: Option<SessionResumeKey>,
 
     /// Connection state (active, pending inbound, pending outbound).
     conns: BTreeMap<ConnectionId, ConnectionSlot>,
@@ -207,6 +241,9 @@ pub struct Session<C: Conduit> {
 
     /// Receiver for close requests from SessionHandle.
     close_rx: mpsc::Receiver<CloseRequest>,
+
+    /// Receiver for resume requests from SessionHandle.
+    resume_rx: mpsc::Receiver<ResumeRequest>,
 
     /// Sender/receiver for drop-driven session/connection control requests.
     control_tx: mpsc::UnboundedSender<DropControlRequest>,
@@ -498,6 +535,7 @@ pub enum SessionError {
     Io(std::io::Error),
     Protocol(String),
     Rejected(Metadata<'static>),
+    NotResumable,
 }
 
 impl std::fmt::Display for SessionError {
@@ -506,43 +544,63 @@ impl std::fmt::Display for SessionError {
             Self::Io(e) => write!(f, "io error: {e}"),
             Self::Protocol(msg) => write!(f, "protocol error: {msg}"),
             Self::Rejected(_) => write!(f, "connection rejected"),
+            Self::NotResumable => write!(f, "session is not resumable"),
         }
     }
 }
 
 impl std::error::Error for SessionError {}
 
-impl<C> Session<C>
-where
-    C: Conduit<Msg = MessageFamily>,
-    C::Tx: MaybeSend + MaybeSync + 'static,
-    for<'p> <C::Tx as ConduitTx>::Permit<'p>: MaybeSend,
-    C::Rx: MaybeSend,
-{
+fn fresh_session_resume_key() -> Result<SessionResumeKey, SessionError> {
+    let mut bytes = [0u8; 16];
+    getrandom::fill(&mut bytes).map_err(|error| {
+        SessionError::Protocol(format!("failed to generate session key: {error}"))
+    })?;
+    Ok(SessionResumeKey(bytes))
+}
+
+impl Session {
     #[allow(clippy::too_many_arguments)]
-    fn pre_handshake(
-        tx: C::Tx,
-        rx: C::Rx,
+    fn pre_handshake<Tx, Rx>(
+        tx: Tx,
+        rx: Rx,
         on_connection: Option<Box<dyn ConnectionAcceptor>>,
         open_rx: mpsc::Receiver<OpenRequest>,
         close_rx: mpsc::Receiver<CloseRequest>,
+        resume_rx: mpsc::Receiver<ResumeRequest>,
         control_tx: mpsc::UnboundedSender<DropControlRequest>,
         control_rx: mpsc::UnboundedReceiver<DropControlRequest>,
         keepalive: Option<SessionKeepaliveConfig>,
-    ) -> Self {
-        let sess_core = Arc::new(SessionCore { tx: Box::new(tx) });
+        resumable: bool,
+    ) -> Self
+    where
+        Tx: ConduitTx<Msg = MessageFamily> + MaybeSend + MaybeSync + 'static,
+        for<'p> <Tx as ConduitTx>::Permit<'p>: MaybeSend,
+        Rx: ConduitRx<Msg = MessageFamily> + MaybeSend + 'static,
+    {
+        let sess_core = Arc::new(SessionCore {
+            tx: std::sync::Mutex::new(Arc::new(tx) as Arc<dyn DynConduitTx>),
+        });
         Session {
-            rx,
+            rx: Box::new(rx),
             role: SessionRole::Initiator, // overwritten in establish_as_*
             parity: Parity::Odd,          // overwritten in establish_as_*
             sess_core,
             peer_supports_retry: false,
+            local_root_settings: ConnectionSettings {
+                parity: Parity::Odd,
+                max_concurrent_requests: 64,
+            },
+            peer_root_settings: None,
+            resumable,
+            session_resume_key: None,
             conns: BTreeMap::new(),
             root_closed_internal: false,
             conn_ids: IdAllocator::new(Parity::Odd), // overwritten in establish_as_*
             on_connection,
             open_rx,
             close_rx,
+            resume_rx,
             control_tx,
             control_rx,
             keepalive,
@@ -560,6 +618,7 @@ where
         self.role = SessionRole::Initiator;
         self.parity = settings.parity;
         self.conn_ids = IdAllocator::new(settings.parity);
+        self.local_root_settings = settings.clone();
 
         let mut hello_metadata = metadata.to_vec();
         append_retry_support_metadata(&mut hello_metadata);
@@ -578,30 +637,37 @@ where
             .map_err(|_| SessionError::Protocol("failed to send Hello".into()))?;
 
         // Receive HelloYourself
-        let (peer_settings, peer_supports_retry) = match self.rx.recv().await {
-            Ok(Some(msg)) => {
-                let payload = msg.map(|m| m.payload);
-                match &*payload {
-                    MessagePayload::HelloYourself(hy) => (
-                        hy.connection_settings.clone(),
-                        metadata_supports_retry(&hy.metadata),
-                    ),
-                    MessagePayload::ProtocolError(e) => {
-                        return Err(SessionError::Protocol(e.description.to_owned()));
-                    }
-                    _ => {
-                        return Err(SessionError::Protocol("expected HelloYourself".into()));
+        let (peer_settings, peer_supports_retry, session_resume_key) =
+            match self.rx.recv_msg().await {
+                Ok(Some(msg)) => {
+                    let payload = msg.map(|m| m.payload);
+                    match &*payload {
+                        MessagePayload::HelloYourself(hy) => (
+                            hy.connection_settings.clone(),
+                            metadata_supports_retry(&hy.metadata),
+                            metadata_session_resume_key(&hy.metadata),
+                        ),
+                        MessagePayload::ProtocolError(e) => {
+                            return Err(SessionError::Protocol(e.description.to_owned()));
+                        }
+                        _ => {
+                            return Err(SessionError::Protocol("expected HelloYourself".into()));
+                        }
                     }
                 }
-            }
-            Ok(None) => {
-                return Err(SessionError::Protocol(
-                    "peer closed during handshake".into(),
-                ));
-            }
-            Err(e) => return Err(SessionError::Protocol(e.to_string())),
-        };
+                Ok(None) => {
+                    return Err(SessionError::Protocol(
+                        "peer closed during handshake".into(),
+                    ));
+                }
+                Err(e) => return Err(SessionError::Protocol(e.to_string())),
+            };
         self.peer_supports_retry = peer_supports_retry;
+        self.peer_root_settings = Some(peer_settings.clone());
+        self.session_resume_key = session_resume_key;
+        if self.resumable && self.session_resume_key.is_none() {
+            return Err(SessionError::NotResumable);
+        }
 
         Ok(self.make_root_handle(settings, peer_settings))
     }
@@ -618,7 +684,7 @@ where
         self.role = SessionRole::Acceptor;
 
         // Receive Hello
-        let (peer_settings, peer_supports_retry) = match self.rx.recv().await {
+        let (peer_settings, peer_supports_retry) = match self.rx.recv_msg().await {
             Ok(Some(msg)) => {
                 let payload = msg.map(|m| m.payload);
                 match &*payload {
@@ -658,9 +724,20 @@ where
         };
         self.parity = our_settings.parity;
         self.conn_ids = IdAllocator::new(our_settings.parity);
+        self.local_root_settings = our_settings.clone();
+        self.peer_root_settings = Some(peer_settings.clone());
 
         let mut hello_metadata = metadata.to_vec();
         append_retry_support_metadata(&mut hello_metadata);
+        if self.resumable {
+            self.session_resume_key = Some(fresh_session_resume_key()?);
+            append_session_resume_key_metadata(
+                &mut hello_metadata,
+                self.session_resume_key
+                    .as_ref()
+                    .expect("resumable acceptor must set a session key"),
+            );
+        }
 
         // Send HelloYourself
         self.sess_core
@@ -739,16 +816,20 @@ where
 
         loop {
             tokio::select! {
-                msg = self.rx.recv() => {
+                msg = self.rx.recv_msg() => {
                     match msg {
                         Ok(Some(msg)) => self.handle_message(msg, &mut keepalive_runtime).await,
                         Ok(None) => {
                             warn!("session recv loop ended: conduit returned EOF");
-                            break;
+                            if !self.handle_conduit_break(&mut keepalive_runtime).await {
+                                break;
+                            }
                         }
                         Err(error) => {
                             warn!(error = %error, "session recv loop ended: conduit recv error");
-                            break;
+                            if !self.handle_conduit_break(&mut keepalive_runtime).await {
+                                break;
+                            }
                         }
                     }
                 }
@@ -757,6 +838,11 @@ where
                 }
                 Some(req) = self.close_rx.recv() => {
                     self.handle_close_request(req).await;
+                }
+                Some(req) = self.resume_rx.recv() => {
+                    let _ = req.result_tx.send(Err(SessionError::Protocol(
+                        "resume is only valid while the session is disconnected".into(),
+                    )));
                 }
                 Some(req) = self.control_rx.recv() => {
                     if !self.handle_drop_control_request(req).await {
@@ -778,6 +864,161 @@ where
         // Drop all connection slots so per-connection drivers exit immediately.
         self.close_all_connections();
         debug!("session recv loop exited");
+    }
+
+    async fn handle_conduit_break(
+        &mut self,
+        keepalive_runtime: &mut Option<KeepaliveRuntime>,
+    ) -> bool {
+        if !self.resumable {
+            return false;
+        }
+
+        loop {
+            tokio::select! {
+                Some(req) = self.resume_rx.recv() => {
+                    let result = self.resume_session(req.tx, req.rx).await;
+                    let ok = result.is_ok();
+                    let _ = req.result_tx.send(result);
+                    if ok {
+                        *keepalive_runtime = self.make_keepalive_runtime();
+                        return true;
+                    }
+                }
+                Some(req) = self.control_rx.recv() => {
+                    if !self.handle_drop_control_request(req).await {
+                        return false;
+                    }
+                }
+                Some(req) = self.open_rx.recv() => {
+                    let _ = req.result_tx.send(Err(SessionError::Protocol(
+                        "session is disconnected; resume before opening connections".into(),
+                    )));
+                }
+                Some(req) = self.close_rx.recv() => {
+                    let _ = req.result_tx.send(Err(SessionError::Protocol(
+                        "session is disconnected; resume before closing connections".into(),
+                    )));
+                }
+                else => return false,
+            }
+        }
+    }
+
+    async fn resume_session(
+        &mut self,
+        tx: Arc<dyn DynConduitTx>,
+        mut rx: Box<dyn DynConduitRx>,
+    ) -> Result<(), SessionError> {
+        let Some(peer_settings) = self.peer_root_settings.clone() else {
+            return Err(SessionError::Protocol("missing peer root settings".into()));
+        };
+
+        match self.role {
+            SessionRole::Initiator => {
+                let Some(session_resume_key) = self.session_resume_key else {
+                    return Err(SessionError::NotResumable);
+                };
+                let mut metadata = Vec::new();
+                append_retry_support_metadata(&mut metadata);
+                append_session_resume_key_metadata(&mut metadata, &session_resume_key);
+                tx.send_msg(Message {
+                    connection_id: ConnectionId::ROOT,
+                    payload: MessagePayload::Hello(roam_types::Hello {
+                        version: PROTOCOL_VERSION,
+                        connection_settings: self.local_root_settings.clone(),
+                        metadata,
+                    }),
+                })
+                .await
+                .map_err(SessionError::Io)?;
+
+                let msg = rx.recv_msg().await.map_err(SessionError::Io)?;
+                let Some(msg) = msg else {
+                    return Err(SessionError::Protocol(
+                        "peer closed during session resume".into(),
+                    ));
+                };
+                let payload = msg.map(|m| m.payload);
+                let hy = match &*payload {
+                    MessagePayload::HelloYourself(hy) => hy,
+                    MessagePayload::ProtocolError(e) => {
+                        return Err(SessionError::Protocol(e.description.to_owned()));
+                    }
+                    _ => {
+                        return Err(SessionError::Protocol(
+                            "expected HelloYourself during session resume".into(),
+                        ));
+                    }
+                };
+                if hy.connection_settings != peer_settings {
+                    return Err(SessionError::Protocol(
+                        "peer root settings changed across session resume".into(),
+                    ));
+                }
+                self.peer_supports_retry = metadata_supports_retry(&hy.metadata);
+                self.session_resume_key =
+                    metadata_session_resume_key(&hy.metadata).or(self.session_resume_key);
+            }
+            SessionRole::Acceptor => {
+                let msg = rx.recv_msg().await.map_err(SessionError::Io)?;
+                let Some(msg) = msg else {
+                    return Err(SessionError::Protocol(
+                        "peer closed during session resume".into(),
+                    ));
+                };
+                let payload = msg.map(|m| m.payload);
+                let hello = match &*payload {
+                    MessagePayload::Hello(hello) => hello,
+                    MessagePayload::ProtocolError(e) => {
+                        return Err(SessionError::Protocol(e.description.to_owned()));
+                    }
+                    _ => {
+                        return Err(SessionError::Protocol(
+                            "expected Hello during session resume".into(),
+                        ));
+                    }
+                };
+                if hello.version != PROTOCOL_VERSION {
+                    return Err(SessionError::Protocol(format!(
+                        "version mismatch: got {}, expected {PROTOCOL_VERSION}",
+                        hello.version
+                    )));
+                }
+                if hello.connection_settings != peer_settings {
+                    return Err(SessionError::Protocol(
+                        "peer root settings changed across session resume".into(),
+                    ));
+                }
+                let Some(expected_key) = self.session_resume_key else {
+                    return Err(SessionError::NotResumable);
+                };
+                let Some(actual_key) = metadata_session_resume_key(&hello.metadata) else {
+                    return Err(SessionError::Protocol("missing session resume key".into()));
+                };
+                if actual_key != expected_key {
+                    return Err(SessionError::Protocol("session resume key mismatch".into()));
+                }
+                self.peer_supports_retry = metadata_supports_retry(&hello.metadata);
+
+                let mut metadata = Vec::new();
+                append_retry_support_metadata(&mut metadata);
+                append_session_resume_key_metadata(&mut metadata, &expected_key);
+                tx.send_msg(Message {
+                    connection_id: ConnectionId::ROOT,
+                    payload: MessagePayload::HelloYourself(roam_types::HelloYourself {
+                        connection_settings: self.local_root_settings.clone(),
+                        metadata,
+                    }),
+                })
+                .await
+                .map_err(SessionError::Io)?;
+            }
+        }
+
+        self.sess_core.replace_tx(tx);
+        self.rx = rx;
+        Ok(())
     }
 
     async fn handle_message(
@@ -1196,12 +1437,17 @@ where
 }
 
 pub(crate) struct SessionCore {
-    tx: Box<dyn DynConduitTx>,
+    tx: std::sync::Mutex<Arc<dyn DynConduitTx>>,
 }
 
 impl SessionCore {
     pub(crate) async fn send<'a>(&self, msg: Message<'a>) -> Result<(), ()> {
-        self.tx.send_msg(msg).await.map_err(|_| ())
+        let tx = self.tx.lock().expect("session tx mutex poisoned").clone();
+        tx.send_msg(msg).await.map_err(|_| ())
+    }
+
+    fn replace_tx(&self, tx: Arc<dyn DynConduitTx>) {
+        *self.tx.lock().expect("session tx mutex poisoned") = tx;
     }
 }
 
@@ -1217,6 +1463,19 @@ pub trait DynConduitTx: Send + Sync {
 #[cfg(target_arch = "wasm32")]
 pub trait DynConduitTx {
     fn send_msg<'a>(&'a self, msg: Message<'a>) -> BoxFuture<'a, std::io::Result<()>>;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub trait DynConduitRx: Send {
+    fn recv_msg<'a>(
+        &'a mut self,
+    ) -> BoxFuture<'a, std::io::Result<Option<SelfRef<Message<'static>>>>>;
+}
+#[cfg(target_arch = "wasm32")]
+pub trait DynConduitRx {
+    fn recv_msg<'a>(
+        &'a mut self,
+    ) -> BoxFuture<'a, std::io::Result<Option<SelfRef<Message<'static>>>>>;
 }
 
 // r[impl zerocopy.send]
@@ -1236,18 +1495,29 @@ where
     }
 }
 
+impl<T> DynConduitRx for T
+where
+    T: ConduitRx<Msg = MessageFamily> + MaybeSend,
+{
+    fn recv_msg<'a>(
+        &'a mut self,
+    ) -> BoxFuture<'a, std::io::Result<Option<SelfRef<Message<'static>>>>> {
+        Box::pin(async move {
+            self.recv()
+                .await
+                .map_err(|error| std::io::Error::other(error.to_string()))
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use moire::sync::mpsc;
-    use roam_types::{
-        Backing, Conduit, ConnectionAccept, ConnectionReject, MessageFamily, SelfRef,
-    };
+    use roam_types::{Backing, Conduit, ConnectionAccept, ConnectionReject, SelfRef};
 
     use super::*;
 
-    type TestConduit = crate::BareConduit<MessageFamily, crate::MemoryLink>;
-
-    fn make_session() -> Session<TestConduit> {
+    fn make_session() -> Session {
         let (a, b) = crate::memory_link_pair(32);
         // Keep the peer link alive so sess_core sends don't fail with broken pipe.
         std::mem::forget(b);
@@ -1255,9 +1525,10 @@ mod tests {
         let (tx, rx) = conduit.split();
         let (_open_tx, open_rx) = mpsc::channel::<OpenRequest>("session.open.test", 4);
         let (_close_tx, close_rx) = mpsc::channel::<CloseRequest>("session.close.test", 4);
+        let (_resume_tx, resume_rx) = mpsc::channel::<ResumeRequest>("session.resume.test", 1);
         let (control_tx, control_rx) = mpsc::unbounded_channel("session.control.test");
         Session::pre_handshake(
-            tx, rx, None, open_rx, close_rx, control_tx, control_rx, None,
+            tx, rx, None, open_rx, close_rx, resume_rx, control_tx, control_rx, None, false,
         )
     }
 

--- a/rust/roam-core/src/tests/driver_tests.rs
+++ b/rust/roam-core/src/tests/driver_tests.rs
@@ -1,15 +1,17 @@
 use facet::Facet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
 
+use moire::sync::mpsc;
 use moire::task::FutureExt;
 use roam_types::{
-    Caller, ChannelBinder, ChannelBody, ChannelClose, ChannelGrantCredit, ChannelId, ChannelItem,
-    ChannelMessage, ChannelSink, Conduit, ConduitRx, ConnectionSettings, Handler,
-    IncomingChannelMessage, Message, MessageFamily, MessagePayload, Metadata, MethodId, Parity,
-    Payload, ReplySink, RequestBody, RequestCall, RequestCancel, RequestMessage, RequestResponse,
-    RetryPolicy, RoamError, RpcPlan, SelfRef, Tx, bind_channels_caller_args, channel,
-    ensure_operation_id, metadata_operation_id,
+    Backing, Caller, ChannelBinder, ChannelBody, ChannelClose, ChannelGrantCredit, ChannelId,
+    ChannelItem, ChannelMessage, ChannelSink, Conduit, ConduitRx, ConnectionSettings, Handler,
+    IncomingChannelMessage, Link, LinkRx, LinkTx, LinkTxPermit, Message, MessageFamily,
+    MessagePayload, Metadata, MethodId, Parity, Payload, ReplySink, RequestBody, RequestCall,
+    RequestCancel, RequestMessage, RequestResponse, RetryPolicy, RoamError, RpcPlan, SelfRef, Tx,
+    WriteSlot, bind_channels_caller_args, channel, ensure_operation_id, metadata_operation_id,
 };
 
 use crate::session::{
@@ -23,6 +25,126 @@ type MessageConduit = BareConduit<MessageFamily, crate::MemoryLink>;
 fn message_conduit_pair() -> (MessageConduit, MessageConduit) {
     let (a, b) = memory_link_pair(64);
     (BareConduit::new(a), BareConduit::new(b))
+}
+
+struct BreakableLink {
+    tx: mpsc::Sender<Option<Vec<u8>>>,
+    rx: mpsc::Receiver<Option<Vec<u8>>>,
+}
+
+#[derive(Clone)]
+struct BreakHandle {
+    tx: mpsc::Sender<Option<Vec<u8>>>,
+}
+
+fn breakable_link_pair(buffer: usize) -> (BreakableLink, BreakHandle, BreakableLink, BreakHandle) {
+    let (tx_a, rx_b) = mpsc::channel("breakable_link.a→b", buffer);
+    let (tx_b, rx_a) = mpsc::channel("breakable_link.b→a", buffer);
+
+    let a_handle = BreakHandle { tx: tx_b.clone() };
+    let b_handle = BreakHandle { tx: tx_a.clone() };
+
+    (
+        BreakableLink { tx: tx_a, rx: rx_a },
+        a_handle,
+        BreakableLink { tx: tx_b, rx: rx_b },
+        b_handle,
+    )
+}
+
+impl BreakHandle {
+    async fn close(&self) {
+        let _ = self.tx.send(None).await;
+    }
+}
+
+impl Link for BreakableLink {
+    type Tx = BreakableLinkTx;
+    type Rx = BreakableLinkRx;
+
+    fn split(self) -> (Self::Tx, Self::Rx) {
+        (
+            BreakableLinkTx { tx: self.tx },
+            BreakableLinkRx { rx: self.rx },
+        )
+    }
+}
+
+#[derive(Clone)]
+struct BreakableLinkTx {
+    tx: mpsc::Sender<Option<Vec<u8>>>,
+}
+
+struct BreakableLinkTxPermit {
+    permit: mpsc::OwnedPermit<Option<Vec<u8>>>,
+}
+
+impl LinkTx for BreakableLinkTx {
+    type Permit = BreakableLinkTxPermit;
+
+    async fn reserve(&self) -> std::io::Result<Self::Permit> {
+        let permit = self.tx.clone().reserve_owned().await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::ConnectionReset, "receiver dropped")
+        })?;
+        Ok(BreakableLinkTxPermit { permit })
+    }
+
+    async fn close(self) -> std::io::Result<()> {
+        drop(self.tx);
+        Ok(())
+    }
+}
+
+struct BreakableWriteSlot {
+    buf: Vec<u8>,
+    permit: mpsc::OwnedPermit<Option<Vec<u8>>>,
+}
+
+impl LinkTxPermit for BreakableLinkTxPermit {
+    type Slot = BreakableWriteSlot;
+
+    fn alloc(self, len: usize) -> std::io::Result<Self::Slot> {
+        Ok(BreakableWriteSlot {
+            buf: vec![0u8; len],
+            permit: self.permit,
+        })
+    }
+}
+
+impl WriteSlot for BreakableWriteSlot {
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.buf
+    }
+
+    fn commit(self) {
+        drop(self.permit.send(Some(self.buf)));
+    }
+}
+
+struct BreakableLinkRx {
+    rx: mpsc::Receiver<Option<Vec<u8>>>,
+}
+
+#[derive(Debug)]
+struct BreakableLinkRxError;
+
+impl std::fmt::Display for BreakableLinkRxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "breakable link rx error")
+    }
+}
+
+impl std::error::Error for BreakableLinkRxError {}
+
+impl LinkRx for BreakableLinkRx {
+    type Error = BreakableLinkRxError;
+
+    async fn recv(&mut self) -> Result<Option<Backing>, Self::Error> {
+        match self.rx.recv().await {
+            Some(Some(bytes)) => Ok(Some(Backing::Boxed(bytes.into_boxed_slice()))),
+            Some(None) | None => Ok(None),
+        }
+    }
 }
 
 /// Conduit wrapper used by keepalive tests: drops inbound Pong messages.
@@ -142,6 +264,11 @@ struct PersistentReplyingHandler {
     release: Arc<tokio::sync::Notify>,
 }
 
+struct ResumableReplyingHandler {
+    started: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
 struct OperationIdHandler;
 
 impl Handler<DriverReplySink> for OperationIdHandler {
@@ -218,6 +345,30 @@ impl Handler<DriverReplySink> for PersistentReplyingHandler {
         reply
             .send_reply(RequestResponse {
                 ret: Payload::outgoing(&123_u32),
+                channels: vec![],
+                metadata: Default::default(),
+            })
+            .await;
+    }
+}
+
+impl Handler<DriverReplySink> for ResumableReplyingHandler {
+    fn retry_policy(&self, _method_id: MethodId) -> RetryPolicy {
+        RetryPolicy::PERSIST
+    }
+
+    async fn handle(&self, call: SelfRef<RequestCall<'static>>, reply: DriverReplySink) {
+        self.started.notify_waiters();
+        self.release.notified().await;
+
+        let args_bytes = match &call.args {
+            Payload::Incoming(bytes) => *bytes,
+            _ => panic!("expected incoming payload"),
+        };
+        let result: u32 = facet_postcard::from_slice(args_bytes).expect("deserialize args");
+        reply
+            .send_reply(RequestResponse {
+                ret: Payload::outgoing(&result),
                 channels: vec![],
                 metadata: Default::default(),
             })
@@ -822,6 +973,87 @@ async fn duplicate_operation_id_attaches_live_and_replays_sealed_outcome() {
     let value: u32 = facet_postcard::from_slice(ret_bytes).expect("deserialize response");
     assert_eq!(value, 11);
     assert_eq!(runs_check.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn resumable_session_keeps_pending_call_alive_across_manual_resume() {
+    let (client_link1, client_break1, server_link1, server_break1) = breakable_link_pair(64);
+    let client_conduit1 = BareConduit::new(client_link1);
+    let server_conduit1 = BareConduit::new(server_link1);
+
+    let started = Arc::new(tokio::sync::Notify::new());
+    let started_for_wait = Arc::clone(&started);
+    let started_wait = started_for_wait.notified();
+    let release = Arc::new(tokio::sync::Notify::new());
+
+    let (server_established, client_established) = tokio::try_join!(
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            acceptor(server_conduit1)
+                .resumable()
+                .establish::<DriverCaller>(ResumableReplyingHandler {
+                    started,
+                    release: Arc::clone(&release),
+                }),
+        ),
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            initiator(client_conduit1)
+                .resumable()
+                .establish::<DriverCaller>(()),
+        ),
+    )
+    .expect("initial session establishment timed out");
+    let (_server_caller, server_session_handle) =
+        server_established.expect("server handshake failed");
+    let (caller, client_session_handle) = client_established.expect("client handshake failed");
+
+    let call_task = moire::task::spawn(
+        async move {
+            caller
+                .call(RequestCall {
+                    method_id: MethodId(1),
+                    args: Payload::outgoing(&55_u32),
+                    channels: vec![],
+                    metadata: Default::default(),
+                })
+                .await
+        }
+        .named("resume_pending_call"),
+    );
+
+    tokio::time::timeout(Duration::from_secs(1), started_wait)
+        .await
+        .expect("timed out waiting for handler start");
+
+    client_break1.close().await;
+    server_break1.close().await;
+    tokio::time::sleep(Duration::from_millis(25)).await;
+
+    let (client_link2, client_break2, server_link2, server_break2) = breakable_link_pair(64);
+    tokio::try_join!(
+        client_session_handle.resume(BareConduit::new(client_link2)),
+        server_session_handle.resume(BareConduit::new(server_link2)),
+    )
+    .expect("session resume should succeed");
+
+    release.notify_waiters();
+
+    let response = call_task
+        .await
+        .expect("call task join")
+        .expect("call should succeed after session resume");
+    let ret_bytes = match &response.ret {
+        Payload::Incoming(bytes) => *bytes,
+        _ => panic!("expected incoming payload in response"),
+    };
+    let value: u32 = facet_postcard::from_slice(ret_bytes).expect("deserialize response");
+    assert_eq!(value, 55);
+
+    let _ = client_session_handle.shutdown();
+    let _ = server_session_handle.shutdown();
+    client_break2.close().await;
+    server_break2.close().await;
 }
 
 #[tokio::test]

--- a/rust/roam-types/src/lib.rs
+++ b/rust/roam-types/src/lib.rs
@@ -97,6 +97,9 @@ pub use metadata::*;
 mod retry_support;
 pub use retry_support::*;
 
+mod session_resume_support;
+pub use session_resume_support::*;
+
 mod request_context;
 pub use request_context::*;
 

--- a/rust/roam-types/src/message.rs
+++ b/rust/roam-types/src/message.rs
@@ -23,6 +23,9 @@ pub struct ConnectionSettings {
     pub max_concurrent_requests: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SessionResumeKey(pub [u8; 16]);
+
 impl<'payload> Message<'payload> {
     // Message has no methods on purpose. it's all just plain data.
     // Adding constructors or getters is forbidden.

--- a/rust/roam-types/src/session_resume_support.rs
+++ b/rust/roam-types/src/session_resume_support.rs
@@ -1,0 +1,32 @@
+use crate::{Metadata, MetadataEntry, MetadataFlags, MetadataValue, SessionResumeKey};
+
+pub const SESSION_RESUME_KEY_METADATA_KEY: &str = "roam-session-key";
+
+pub fn append_session_resume_key_metadata<'a>(
+    metadata: &mut Metadata<'a>,
+    key: &'a SessionResumeKey,
+) {
+    metadata.push(MetadataEntry {
+        key: SESSION_RESUME_KEY_METADATA_KEY,
+        value: MetadataValue::Bytes(&key.0),
+        flags: MetadataFlags::NONE,
+    });
+}
+
+pub fn metadata_session_resume_key(
+    metadata: &[crate::MetadataEntry<'_>],
+) -> Option<SessionResumeKey> {
+    metadata.iter().find_map(|entry| {
+        if entry.key != SESSION_RESUME_KEY_METADATA_KEY {
+            return None;
+        }
+        match entry.value {
+            MetadataValue::Bytes(bytes) if bytes.len() == 16 => {
+                let mut key = [0u8; 16];
+                key.copy_from_slice(bytes);
+                Some(SessionResumeKey(key))
+            }
+            _ => None,
+        }
+    })
+}

--- a/typescript/packages/roam-core/src/session.resume.test.ts
+++ b/typescript/packages/roam-core/src/session.resume.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import type { Message } from "@bearcove/roam-wire";
+import { BareConduit } from "./conduit.ts";
+import { Driver, type Dispatcher } from "./driver.ts";
+import { RequestContext } from "./request_context.ts";
+import { Session, SessionError, type SessionHandle } from "./session.ts";
+import type { MethodDescriptor, ServiceDescriptor } from "./channeling/index.ts";
+
+class MemoryLink {
+  private readonly queue: Uint8Array[] = [];
+  private waiting: ((value: Uint8Array | null) => void) | null = null;
+  private closed = false;
+
+  constructor(private readonly deliver: (payload: Uint8Array) => void) {}
+
+  async send(payload: Uint8Array): Promise<void> {
+    if (this.closed) {
+      throw new Error("closed");
+    }
+    this.deliver(payload);
+  }
+
+  recv(): Promise<Uint8Array | null> {
+    if (this.queue.length > 0) {
+      return Promise.resolve(this.queue.shift()!);
+    }
+    if (this.closed) {
+      return Promise.resolve(null);
+    }
+    return new Promise((resolve) => {
+      this.waiting = resolve;
+    });
+  }
+
+  push(payload: Uint8Array): void {
+    if (this.closed) {
+      return;
+    }
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve(payload);
+      return;
+    }
+    this.queue.push(payload);
+  }
+
+  close(): void {
+    this.closed = true;
+    const waiting = this.waiting;
+    this.waiting = null;
+    waiting?.(null);
+  }
+
+  isClosed(): boolean {
+    return this.closed;
+  }
+}
+
+function memoryLinkPair(): [MemoryLink, MemoryLink] {
+  let left!: MemoryLink;
+  let right!: MemoryLink;
+  left = new MemoryLink((payload) => right.push(payload));
+  right = new MemoryLink((payload) => left.push(payload));
+  return [left, right];
+}
+
+function makeDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs = 1_000,
+): Promise<T> {
+  const timeout = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]);
+}
+
+async function resumeWhenReady(
+  handle: SessionHandle,
+  conduit: BareConduit,
+): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      await handle.resume(conduit);
+      return;
+    } catch (error) {
+      if (
+        !(error instanceof SessionError)
+        || !error.message.includes("resume is only valid while the session is disconnected")
+      ) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw new Error("session never became disconnected");
+}
+
+const METHOD: MethodDescriptor = {
+  name: "echo",
+  id: 1n,
+  retry: { persist: true, idem: false },
+  args: { kind: "tuple", elements: [{ kind: "u32" }] },
+  result: {
+    kind: "enum",
+    variants: [
+      { name: "Ok", fields: { kind: "u32" } },
+      {
+        name: "Err",
+        fields: {
+          kind: "enum",
+          variants: [
+            { name: "User", fields: null },
+            { name: "UnknownMethod", fields: null },
+            { name: "InvalidPayload", fields: null },
+            { name: "Cancelled", fields: null },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+const DESCRIPTOR: ServiceDescriptor = {
+  service_name: "Test",
+  methods: [METHOD],
+};
+
+describe("session resumption", () => {
+  it("keeps a pending call alive across manual resume on a new conduit", async () => {
+    const [clientLink1, serverLink1] = memoryLinkPair();
+    const clientConduit1 = new BareConduit(clientLink1);
+    const serverConduit1 = new BareConduit(serverLink1);
+    const started = makeDeferred<void>();
+    const release = makeDeferred<void>();
+
+    const dispatcher: Dispatcher = {
+      getDescriptor() {
+        return DESCRIPTOR;
+      },
+      async dispatch(_context: RequestContext, _method, args, call) {
+        started.resolve();
+        await release.promise;
+        call.reply(args[0]);
+      },
+    };
+
+    const [serverSession, clientSession] = await withTimeout(
+      Promise.all([
+        Session.establishAcceptor(serverConduit1, { resumable: true }),
+        Session.establishInitiator(clientConduit1, { resumable: true }),
+      ]),
+      "initial session establishment",
+    );
+    const serverDriver = new Driver(serverSession.rootConnection(), dispatcher);
+    const serverRun = serverDriver.run();
+
+    const call = clientSession.rootConnection().caller().call({
+      method: "Test.echo",
+      args: { value: 55 },
+      descriptor: METHOD,
+    });
+
+    await withTimeout(started.promise, "handler start");
+
+    clientLink1.close();
+    serverLink1.close();
+
+    const [clientLink2, serverLink2] = memoryLinkPair();
+    const clientConduit2 = new BareConduit(clientLink2);
+    const serverConduit2 = new BareConduit(serverLink2);
+
+    await withTimeout(
+      Promise.all([
+        resumeWhenReady(serverSession.handle(), serverConduit2),
+        resumeWhenReady(clientSession.handle(), clientConduit2),
+      ]),
+      "session resume",
+    );
+
+    release.resolve();
+
+    await expect(withTimeout(call, "resumed call")).resolves.toBe(55);
+
+    clientLink2.close();
+    serverLink2.close();
+    clientSession.handle().shutdown();
+    serverSession.handle().shutdown();
+
+    await Promise.allSettled([
+      serverRun,
+      serverSession.closed(),
+      clientSession.closed(),
+    ]);
+  });
+});

--- a/typescript/packages/roam-core/src/session.ts
+++ b/typescript/packages/roam-core/src/session.ts
@@ -46,6 +46,10 @@ import {
   metadataSupportsRetry,
 } from "./retry.ts";
 import {
+  appendSessionResumeKeyMetadata,
+  metadataSessionResumeKey,
+} from "./session_resume.ts";
+import {
   firstIdForParity,
   oppositeParity,
   parityFromRole,
@@ -76,6 +80,7 @@ export interface SessionBuilderOptions {
   maxConcurrentRequests?: number;
   metadata?: Metadata;
   onConnection?: (connection: ConnectionHandle) => void | Promise<void>;
+  resumable?: boolean;
 }
 
 export type SessionConduitKind = "bare" | "stable";
@@ -88,6 +93,18 @@ type SessionTransport = Link | LinkSource;
 
 function isLinkSource(value: SessionTransport): value is LinkSource {
   return typeof (value as LinkSource).nextLink === "function";
+}
+
+function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 async function makeSessionConduit(
@@ -129,6 +146,7 @@ export class SessionError extends Error {
 }
 
 class SessionCore {
+  private conduit: Conduit<Message>;
   private readonly connections = new Map<bigint, ConnectionHandle>();
   private readonly pendingConnections = new Map<
     bigint,
@@ -141,19 +159,32 @@ class SessionCore {
   private sendChain: Promise<void> = Promise.resolve();
   private nextConnectionId: bigint;
   private closed = false;
+  private disconnected = false;
   private closeError: SessionError | null = null;
   private rootConnectionValue: ConnectionHandle | null = null;
   private runPromise: Promise<void> | null = null;
-  private readonly peerSupportsRetry: boolean;
+  private peerSupportsRetry: boolean;
+  private readonly resumable: boolean;
+  private sessionResumeKey: Uint8Array | null;
+  private readonly pendingResumes: Array<{
+    conduit: Conduit<Message>;
+    result: Deferred<void>;
+  }> = [];
+  private resumeWaiter: ((request: { conduit: Conduit<Message>; result: Deferred<void> } | null) => void) | null = null;
 
   constructor(
-    private readonly conduit: Conduit<Message>,
+    conduit: Conduit<Message>,
     private readonly localRootSettings: ConnectionSettings,
     private readonly peerRootSettings: ConnectionSettings,
     peerSupportsRetry: boolean,
+    resumable: boolean,
+    sessionResumeKey: Uint8Array | null,
     private readonly onConnection?: (connection: ConnectionHandle) => void | Promise<void>,
   ) {
+    this.conduit = conduit;
     this.peerSupportsRetry = peerSupportsRetry;
+    this.resumable = resumable;
+    this.sessionResumeKey = sessionResumeKey?.slice() ?? null;
     this.nextConnectionId = firstIdForParity(localRootSettings.parity);
     this.sessionHandle = new SessionHandle(this);
   }
@@ -201,7 +232,7 @@ class SessionCore {
     metadata: Metadata = [],
   ): Promise<ConnectionHandle> {
     // r[impl connection.open]
-    this.assertOpen();
+    this.assertConnected("resume before opening connections");
     const connectionId = this.allocateConnectionId();
     const result = deferred<ConnectionHandle>();
     this.pendingConnections.set(connectionId, {
@@ -221,6 +252,7 @@ class SessionCore {
 
   async closeConnection(connectionId: bigint, metadata: Metadata = []): Promise<void> {
     // r[impl connection.close]
+    this.assertConnected("resume before closing connections");
     if (connectionId === 0n) {
       throw new SessionError("cannot close root connection");
     }
@@ -236,7 +268,7 @@ class SessionCore {
   }
 
   async sendMessage(message: Message): Promise<void> {
-    this.assertOpen();
+    this.assertConnected("resume before sending");
 
     const op = this.sendChain.then(() => this.conduit.send(message));
     this.sendChain = op.then(() => undefined, () => undefined);
@@ -251,6 +283,7 @@ class SessionCore {
     this.closed = true;
     this.closeError = error;
     this.conduit.close();
+    this.rejectPendingResumes(error);
 
     for (const pending of this.pendingConnections.values()) {
       pending.result.reject(error);
@@ -263,9 +296,20 @@ class SessionCore {
     this.connections.clear();
   }
 
+  shutdown(): void {
+    this.fail(SessionError.closed());
+  }
+
   private assertOpen(): void {
     if (this.closed) {
       throw this.closeError ?? SessionError.closed();
+    }
+  }
+
+  private assertConnected(reason: string): void {
+    this.assertOpen();
+    if (this.disconnected) {
+      throw SessionError.protocol(`session is disconnected; ${reason}`);
     }
   }
 
@@ -288,9 +332,151 @@ class SessionCore {
     while (!this.closed) {
       const message = await this.conduit.recv();
       if (!message) {
+        if (await this.handleConduitBreak()) {
+          continue;
+        }
         throw SessionError.closed();
       }
       await this.handleMessage(message);
+    }
+  }
+
+  async resume(conduit: Conduit<Message>): Promise<void> {
+    this.assertOpen();
+    if (!this.resumable) {
+      throw SessionError.protocol("session is not resumable");
+    }
+    if (!this.disconnected) {
+      throw SessionError.protocol("resume is only valid while the session is disconnected");
+    }
+    const result = deferred<void>();
+    this.enqueueResume({ conduit, result });
+    await result.promise;
+  }
+
+  private async handleConduitBreak(): Promise<boolean> {
+    if (!this.resumable) {
+      return false;
+    }
+
+    this.disconnected = true;
+    while (!this.closed) {
+      const pending = await this.nextResume();
+      if (!pending) {
+        return false;
+      }
+      try {
+        await this.resumeOnConduit(pending.conduit);
+        this.disconnected = false;
+        pending.result.resolve();
+        return true;
+      } catch (error) {
+        pending.result.reject(
+          error instanceof SessionError ? error : new SessionError(String(error)),
+        );
+      }
+    }
+
+    return false;
+  }
+
+  private async resumeOnConduit(conduit: Conduit<Message>): Promise<void> {
+    const resumeKey = this.sessionResumeKey;
+    if (!resumeKey) {
+      throw SessionError.protocol("session is not resumable");
+    }
+
+    if (this.localRootSettings.parity.tag === "Odd") {
+      const helloMetadata = appendSessionResumeKeyMetadata(
+        appendRetrySupportMetadata([]),
+        resumeKey,
+      );
+      await conduit.send(
+        messageHello(
+          helloV7(
+            this.localRootSettings.parity,
+            this.localRootSettings.max_concurrent_requests,
+            helloMetadata,
+          ),
+        ),
+      );
+      const helloYourself = await waitForHelloYourself(conduit);
+      if (
+        helloYourself.connection_settings.parity.tag !== this.peerRootSettings.parity.tag
+        || helloYourself.connection_settings.max_concurrent_requests
+          !== this.peerRootSettings.max_concurrent_requests
+      ) {
+        throw SessionError.protocol(
+          `peer root settings changed across session resume: expected ${JSON.stringify(this.peerRootSettings)}, got ${JSON.stringify(helloYourself.connection_settings)}`,
+        );
+      }
+      const echoedKey = metadataSessionResumeKey(helloYourself.metadata);
+      if (!echoedKey || !sameBytes(echoedKey, resumeKey)) {
+        throw SessionError.protocol("session resume key mismatch");
+      }
+      this.peerSupportsRetry = metadataSupportsRetry(helloYourself.metadata);
+      this.conduit = conduit;
+      return;
+    }
+
+    const hello = await waitForHello(conduit);
+    if (
+      hello.connection_settings.parity.tag !== this.peerRootSettings.parity.tag
+      || hello.connection_settings.max_concurrent_requests
+        !== this.peerRootSettings.max_concurrent_requests
+    ) {
+      throw SessionError.protocol(
+        `peer root settings changed across session resume: expected ${JSON.stringify(this.peerRootSettings)}, got ${JSON.stringify(hello.connection_settings)}`,
+      );
+    }
+    const actualKey = metadataSessionResumeKey(hello.metadata);
+    if (!actualKey || !sameBytes(actualKey, resumeKey)) {
+      throw SessionError.protocol("session resume key mismatch");
+    }
+
+    const helloMetadata = appendSessionResumeKeyMetadata(
+      appendRetrySupportMetadata([]),
+      resumeKey,
+    );
+    await conduit.send(
+      messageHelloYourself({
+        connection_settings: this.localRootSettings,
+        metadata: helloMetadata,
+      }),
+    );
+    this.peerSupportsRetry = metadataSupportsRetry(hello.metadata);
+    this.conduit = conduit;
+  }
+
+  private enqueueResume(request: { conduit: Conduit<Message>; result: Deferred<void> }): void {
+    const waiter = this.resumeWaiter;
+    if (waiter) {
+      this.resumeWaiter = null;
+      waiter(request);
+      return;
+    }
+    this.pendingResumes.push(request);
+  }
+
+  private async nextResume(): Promise<{ conduit: Conduit<Message>; result: Deferred<void> } | null> {
+    const pending = this.pendingResumes.shift();
+    if (pending) {
+      return pending;
+    }
+    if (this.closed) {
+      return null;
+    }
+    return new Promise((resolve) => {
+      this.resumeWaiter = resolve;
+    });
+  }
+
+  private rejectPendingResumes(error: SessionError): void {
+    const waiter = this.resumeWaiter;
+    this.resumeWaiter = null;
+    waiter?.(null);
+    for (const pending of this.pendingResumes.splice(0)) {
+      pending.result.reject(error);
     }
   }
 
@@ -469,6 +655,14 @@ export class SessionHandle {
 
   closeConnection(connectionId: bigint, metadata: Metadata = []): Promise<void> {
     return this.core.closeConnection(connectionId, metadata);
+  }
+
+  resume(conduit: Conduit<Message>): Promise<void> {
+    return this.core.resume(conduit);
+  }
+
+  shutdown(): void {
+    this.core.shutdown();
   }
 
   closed(): Promise<void> {
@@ -759,11 +953,17 @@ export class Session {
       messageHello(helloV7(localSettings.parity, localSettings.max_concurrent_requests, helloMetadata)),
     );
     const helloYourself = await waitForHelloYourself(conduit);
+    const sessionResumeKey = metadataSessionResumeKey(helloYourself.metadata);
+    if (options.resumable && !sessionResumeKey) {
+      throw SessionError.protocol("peer did not advertise session resumption");
+    }
     const core = new SessionCore(
       conduit,
       localSettings,
       helloYourself.connection_settings,
       metadataSupportsRetry(helloYourself.metadata),
+      options.resumable ?? false,
+      sessionResumeKey,
       options.onConnection,
     );
     core.rootConnection();
@@ -783,7 +983,12 @@ export class Session {
       parity: parityEven(),
       max_concurrent_requests: options.maxConcurrentRequests ?? 64,
     };
-    const helloMetadata = appendRetrySupportMetadata(options.metadata ?? []);
+    let helloMetadata = appendRetrySupportMetadata(options.metadata ?? []);
+    let sessionResumeKey: Uint8Array | null = null;
+    if (options.resumable) {
+      sessionResumeKey = randomSessionResumeKey();
+      helloMetadata = appendSessionResumeKeyMetadata(helloMetadata, sessionResumeKey);
+    }
     const response: HelloYourself = {
       connection_settings: localSettings,
       metadata: helloMetadata,
@@ -794,6 +999,8 @@ export class Session {
       localSettings,
       hello.connection_settings,
       metadataSupportsRetry(hello.metadata),
+      options.resumable ?? false,
+      sessionResumeKey,
       options.onConnection,
     );
     core.rootConnection();
@@ -834,6 +1041,16 @@ async function waitForHelloYourself(conduit: Conduit<Message>): Promise<HelloYou
     throw SessionError.protocol("expected HelloYourself during session establishment");
   }
   return message.payload.value;
+}
+
+function randomSessionResumeKey(): Uint8Array {
+  const bytes = new Uint8Array(16);
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi) {
+    throw SessionError.protocol("crypto.getRandomValues is unavailable");
+  }
+  cryptoApi.getRandomValues(bytes);
+  return bytes;
 }
 
 export const session = {

--- a/typescript/packages/roam-core/src/session_resume.ts
+++ b/typescript/packages/roam-core/src/session_resume.ts
@@ -1,0 +1,28 @@
+import type { Metadata } from "@bearcove/roam-wire";
+
+export const SESSION_RESUME_KEY_METADATA_KEY = "roam-session-key";
+
+export function appendSessionResumeKeyMetadata(metadata: Metadata, key: Uint8Array): Metadata {
+  return [
+    ...metadata,
+    {
+      key: SESSION_RESUME_KEY_METADATA_KEY,
+      value: { tag: "Bytes", value: key.slice() },
+      flags: 0n,
+    },
+  ];
+}
+
+export function metadataSessionResumeKey(
+  metadata: Metadata,
+): Uint8Array | null {
+  for (const entry of metadata) {
+    if (entry.key !== SESSION_RESUME_KEY_METADATA_KEY) {
+      continue;
+    }
+    if (entry.value.tag === "Bytes" && entry.value.value.length === 16) {
+      return entry.value.value.slice();
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
This adds manual session resumption on a new conduit in both Rust and TypeScript. Resumable sessions now negotiate a session resume key during handshake, keep session/connection state alive across a conduit break, and allow an explicit `resume(...)` call to bind a fresh conduit onto the existing session.

This slice does not add automatic resend or client retry policy yet. It is the session-resumption substrate only: operation identity and retry semantics from the previous slice remain in place, but callers must still decide when to retry.

## Changes
- Add resumable session builder opt-in and manual `SessionHandle::resume(...)` support on the Rust side.
- Add session-resume key metadata helpers and wire types for handshake/resume negotiation.
- Add matching resumable-session support in the TypeScript runtime, including `SessionHandle.resume(...)` and `SessionHandle.shutdown()`.
- Preserve existing session / connection state across a manual conduit swap instead of tearing everything down on the first conduit break.
- Add end-to-end Rust and TypeScript tests proving an in-flight call can complete after a manual resume on a new conduit.

## Testing
- `cargo nextest run -p roam-core`
- `cargo check -p roam-core`
- `pnpm --filter @bearcove/roam-core check`
- `pnpm --filter @bearcove/roam-core test`
