### PR TITLE
Specify v9 transport prologue

### DIFF
--- a/docs/content/spec/_index.md
+++ b/docs/content/spec/_index.md
@@ -8,6 +8,7 @@ The Roam specification defines the protocol and runtime model across layers:
 
 - Requests and channels
 - Connections and sessions
+- Transport prologue and conduit selection
 - Conduit behavior
 - Retry semantics and operation continuity
 - Link transports (stream, WebSocket, shared memory)

--- a/docs/content/spec/conn.md
+++ b/docs/content/spec/conn.md
@@ -152,6 +152,58 @@ weight = 11
 > When the peer has closed the link, `recv` MUST return `Ok(None)`. After `Ok(None)`
 > is returned once, all subsequent `recv` calls MUST return `Ok(None)` as well.
 
+# Transport prologue
+
+> r[transport.prologue]
+>
+> Every fresh link attachment begins with a **transport prologue** before any
+> conduit-specific traffic is sent.
+
+> r[transport.prologue.first-payload]
+>
+> The transport prologue MUST be the first payload observed on a fresh link in
+> each direction. Session `Hello` / `HelloYourself` messages MUST NOT appear
+> before the transport prologue has completed successfully.
+
+> r[transport.prologue.request]
+>
+> The initiator sends a `TransportHello` that includes:
+>
+>   * a transport-prologue magic number
+>   * a transport-prologue version
+>   * the requested conduit mode
+
+> r[transport.prologue.requested-mode]
+>
+> The requested conduit mode is an exact request, not a preference list. This
+> spec defines two conduit modes:
+>
+>   * `bare`
+>   * `stable`
+
+> r[transport.prologue.accept]
+>
+> The acceptor MUST reply with either:
+>
+>   * `TransportAccept`, acknowledging the requested conduit mode, or
+>   * `TransportReject`, refusing the request
+
+> r[transport.prologue.no-fallback]
+>
+> If the acceptor does not support the requested conduit mode, it MUST reject
+> the transport prologue. It MUST NOT silently fall back to a different conduit
+> mode.
+
+> r[transport.prologue.post-accept]
+>
+> After `TransportAccept`, all subsequent payloads on that link attachment are
+> interpreted according to the selected conduit mode.
+
+> r[transport.prologue.reject-close]
+>
+> After `TransportReject`, the link attachment is unusable for roam traffic and
+> MUST be closed or abandoned by the peers.
+
 # Conduits
 
 > r[conduit]
@@ -167,12 +219,18 @@ weight = 11
 
 > r[conduit.bare]
 >
-> `BareConduit` does not provide any feature on top of serialization/deserialization.
+> `BareConduit` does not provide any feature on top of
+> serialization/deserialization. It begins immediately after the transport
+> prologue has accepted `bare`.
 
 > r[conduit.stable]
 >
 > `StableConduit` provides automatic reconnection (over fresh links) and replay of
 > missed messages. It comes with its own Packet framing.
+
+`StableConduit` begins only after the transport prologue has accepted `stable`.
+Its own stable-conduit handshake is separate from, and ordered after, the
+transport prologue.
 
 `StableConduit` continuity does not, by itself, answer what happens to an RPC
 whose outcome is now ambiguous. Operation-level retry and session resumption
@@ -212,6 +270,9 @@ documentation for more information.
 > Sessions are established between two peers on top of a conduit. They keep track of
 > any number of connections, on which calls (requests) can be made, and data can be
 > exchanged over channels.
+
+The transport prologue selects the conduit mode first. Session establishment
+starts only after that conduit has been selected and initialized.
 
 > r[session.outlives-conduit]
 >

--- a/docs/content/spec/intro.md
+++ b/docs/content/spec/intro.md
@@ -13,6 +13,10 @@ weight = 10
 If you're upgrading an existing codebase, read the
 [v6 -> v7 migration guide](../v6-to-v7/).
 
+This specification describes the current roam v9 protocol model. The v9 line
+introduces a transport prologue below the conduit/session layers so conduit
+mode is selected on the wire before session establishment.
+
 ## Defining a service
 
 An application named `fantastic` would typically define services in `*-proto`
@@ -80,7 +84,9 @@ shared memory; but a roam connection sits several layers above a "TCP connection
 +------------------------+
 | Session                |  set of connections over a conduit
 +------------------------+
-| Conduit                |  serialization, reconnection
+| Conduit                |  serialization, replay, session-facing continuity
++------------------------+
+| Transport Prologue     |  conduit mode request / accept / reject
 +------------------------+
 | Link                   |  TCP, SHM, WebSocket, etc.
 +------------------------+
@@ -89,6 +95,8 @@ shared memory; but a roam connection sits several layers above a "TCP connection
 The layers have distinct continuity boundaries:
 
 - A **Link** is one concrete transport attachment.
+- A **Transport Prologue** selects which conduit protocol, if any, will run on
+  that link attachment.
 - A **Conduit** may hide some link failures and replacement internally.
 - A **Session** is above any one conduit instance and may survive conduit
   replacement.

--- a/docs/content/spec/stable.md
+++ b/docs/content/spec/stable.md
@@ -11,6 +11,10 @@ weight = 14
 > layer above it sees a reliable, ordered stream of items, even when the
 > underlying link fails and is replaced.
 
+StableConduit is entered only after the transport prologue has accepted the
+`stable` conduit mode. The stable-conduit handshake specified on this page is
+therefore not the first exchange on a fresh link attachment.
+
 StableConduit continuity is below the RPC retry layer. It preserves conduit
 items; it does not by itself define when an RPC should be retried, resumed, or
 replayed as the same logical operation. See [Retry](./retry/).
@@ -25,9 +29,10 @@ replayed as the same logical operation. See [Retry](./retry/).
 
 > r[stable.handshake]
 >
-> Every link begins with a handshake. The client sends a `ClientHello`,
-> the server responds with a `ServerHello`. These messages are
-> postcard-encoded and sent as raw link payloads (not wrapped in frames).
+> Every stable-conduit attachment begins with a stable handshake after the
+> transport prologue has accepted `stable`. The client sends a `ClientHello`,
+> the server responds with a `ServerHello`. These messages are postcard-encoded
+> and sent as raw link payloads (not wrapped in stable frames).
 
 > r[stable.handshake.client-hello]
 >


### PR DESCRIPTION
## Summary
- define a v9 transport prologue below conduit and session
- make conduit mode an initiator request with accept-or-reject semantics
- clarify that stable-conduit handshake begins only after the transport prologue accepts `stable`

## Notes
- this does not implement the transport redesign yet
- it only establishes the new spec root for the upcoming connector/reconnect work

## Validation
- `tracey_reload`
- `tracey_validate`