### PR TITLE
Add resumable acceptor registry and browser reconnect coverage

### DIFF
--- a/rust/roam-core/src/driver.rs
+++ b/rust/roam-core/src/driver.rs
@@ -22,6 +22,7 @@ use roam_types::{
 use crate::session::{
     ConnectionHandle, ConnectionMessage, ConnectionSender, DropControlRequest, FailureDisposition,
 };
+use crate::{InMemoryOperationStore, OperationAdmit, OperationCancel, OperationStore};
 use moire::sync::mpsc;
 
 type ResponseSlot = moire::sync::oneshot::Sender<SelfRef<RequestMessage<'static>>>;
@@ -31,256 +32,12 @@ struct InFlightHandler {
     retry: roam_types::RetryPolicy,
 }
 
-#[derive(Clone, PartialEq, Eq)]
-struct OperationSignature {
-    method_id: roam_types::MethodId,
-    args: Arc<[u8]>,
-}
-
-impl OperationSignature {
-    fn matches_call(&self, method_id: roam_types::MethodId, args: &[u8]) -> bool {
-        self.method_id == method_id && self.args.as_ref() == args
-    }
-}
-
-struct StoredOperation {
-    signature: OperationSignature,
-    retry: roam_types::RetryPolicy,
-}
-
-struct LiveOperation {
-    stored: StoredOperation,
-    owner_request_id: RequestId,
-    waiters: Vec<RequestId>,
-}
-
-struct SealedOperation {
-    stored: StoredOperation,
-    encoded_response: Arc<[u8]>,
-}
-
-enum OperationState {
-    Live(LiveOperation),
-    Released(StoredOperation),
-    Sealed(SealedOperation),
-    Indeterminate(StoredOperation),
-}
-
-enum OperationAdmit {
-    Start,
-    Attached,
-    Replay(Arc<[u8]>),
-    Conflict,
-    Indeterminate,
-}
-
-enum OperationCancel {
-    None,
-    DetachOnly,
-    Release {
-        owner_request_id: RequestId,
-        waiters: Vec<RequestId>,
-    },
-}
-
-#[derive(Default)]
-struct OperationRegistry {
-    states: BTreeMap<u64, OperationState>,
-    request_to_operation: BTreeMap<RequestId, u64>,
-}
-
-impl OperationRegistry {
-    fn admit(
-        &mut self,
-        operation_id: u64,
-        method_id: roam_types::MethodId,
-        args: &[u8],
-        retry: roam_types::RetryPolicy,
-        request_id: RequestId,
-    ) -> OperationAdmit {
-        let signature = OperationSignature {
-            method_id,
-            args: Arc::<[u8]>::from(args.to_vec()),
-        };
-        let Some(existing) = self.states.remove(&operation_id) else {
-            self.request_to_operation.insert(request_id, operation_id);
-            self.states.insert(
-                operation_id,
-                OperationState::Live(LiveOperation {
-                    stored: StoredOperation { signature, retry },
-                    owner_request_id: request_id,
-                    waiters: vec![request_id],
-                }),
-            );
-            return OperationAdmit::Start;
-        };
-
-        match existing {
-            OperationState::Live(mut live) => {
-                if !live.stored.signature.matches_call(method_id, args) {
-                    self.states.insert(operation_id, OperationState::Live(live));
-                    return OperationAdmit::Conflict;
-                }
-                live.waiters.push(request_id);
-                self.request_to_operation.insert(request_id, operation_id);
-                self.states.insert(operation_id, OperationState::Live(live));
-                OperationAdmit::Attached
-            }
-            OperationState::Sealed(sealed) => {
-                let replay = if sealed.stored.signature.matches_call(method_id, args) {
-                    OperationAdmit::Replay(Arc::clone(&sealed.encoded_response))
-                } else {
-                    OperationAdmit::Conflict
-                };
-                self.states
-                    .insert(operation_id, OperationState::Sealed(sealed));
-                replay
-            }
-            OperationState::Released(stored) => {
-                if !stored.signature.matches_call(method_id, args) || !stored.retry.idem {
-                    let admit = if stored.signature.matches_call(method_id, args) {
-                        OperationAdmit::Indeterminate
-                    } else {
-                        OperationAdmit::Conflict
-                    };
-                    self.states
-                        .insert(operation_id, OperationState::Released(stored));
-                    return admit;
-                }
-                self.request_to_operation.insert(request_id, operation_id);
-                self.states.insert(
-                    operation_id,
-                    OperationState::Live(LiveOperation {
-                        stored: StoredOperation {
-                            signature,
-                            retry: stored.retry,
-                        },
-                        owner_request_id: request_id,
-                        waiters: vec![request_id],
-                    }),
-                );
-                OperationAdmit::Start
-            }
-            OperationState::Indeterminate(stored) => {
-                if !stored.signature.matches_call(method_id, args) || !stored.retry.idem {
-                    let admit = if stored.signature.matches_call(method_id, args) {
-                        OperationAdmit::Indeterminate
-                    } else {
-                        OperationAdmit::Conflict
-                    };
-                    self.states
-                        .insert(operation_id, OperationState::Indeterminate(stored));
-                    return admit;
-                }
-                self.request_to_operation.insert(request_id, operation_id);
-                self.states.insert(
-                    operation_id,
-                    OperationState::Live(LiveOperation {
-                        stored: StoredOperation {
-                            signature,
-                            retry: stored.retry,
-                        },
-                        owner_request_id: request_id,
-                        waiters: vec![request_id],
-                    }),
-                );
-                OperationAdmit::Start
-            }
-        }
-    }
-
-    fn seal(
-        &mut self,
-        operation_id: u64,
-        owner_request_id: RequestId,
-        encoded_response: Arc<[u8]>,
-    ) -> Vec<RequestId> {
-        let Some(OperationState::Live(live)) = self.states.remove(&operation_id) else {
-            return vec![];
-        };
-        if live.owner_request_id != owner_request_id {
-            self.states.insert(operation_id, OperationState::Live(live));
-            return vec![];
-        }
-        for waiter in &live.waiters {
-            self.request_to_operation.remove(waiter);
-        }
-        let waiters = live.waiters.clone();
-        self.states.insert(
-            operation_id,
-            OperationState::Sealed(SealedOperation {
-                stored: live.stored,
-                encoded_response,
-            }),
-        );
-        waiters
-    }
-
-    fn fail_without_reply(
-        &mut self,
-        operation_id: u64,
-        owner_request_id: RequestId,
-    ) -> Vec<RequestId> {
-        let Some(OperationState::Live(live)) = self.states.remove(&operation_id) else {
-            return vec![];
-        };
-        if live.owner_request_id != owner_request_id {
-            self.states.insert(operation_id, OperationState::Live(live));
-            return vec![];
-        }
-        for waiter in &live.waiters {
-            self.request_to_operation.remove(waiter);
-        }
-        let waiters = live.waiters.clone();
-        let next = if live.stored.retry.persist {
-            OperationState::Indeterminate(live.stored)
-        } else {
-            OperationState::Released(live.stored)
-        };
-        self.states.insert(operation_id, next);
-        waiters
-    }
-
-    fn cancel(&mut self, request_id: RequestId) -> OperationCancel {
-        let Some(operation_id) = self.request_to_operation.get(&request_id).copied() else {
-            return OperationCancel::None;
-        };
-        let Some(OperationState::Live(live)) = self.states.get_mut(&operation_id) else {
-            self.request_to_operation.remove(&request_id);
-            return OperationCancel::None;
-        };
-
-        if live.stored.retry.persist {
-            if live.owner_request_id == request_id {
-                return OperationCancel::None;
-            }
-            live.waiters.retain(|candidate| *candidate != request_id);
-            self.request_to_operation.remove(&request_id);
-            return OperationCancel::DetachOnly;
-        }
-
-        let Some(OperationState::Live(live)) = self.states.remove(&operation_id) else {
-            return OperationCancel::None;
-        };
-        for waiter in &live.waiters {
-            self.request_to_operation.remove(waiter);
-        }
-        let waiters = live.waiters.clone();
-        self.states
-            .insert(operation_id, OperationState::Released(live.stored));
-        OperationCancel::Release {
-            owner_request_id: live.owner_request_id,
-            waiters,
-        }
-    }
-}
-
 /// State shared between the driver loop and any DriverCaller/DriverChannelSink handles.
 struct DriverShared {
     pending_responses: SyncMutex<BTreeMap<RequestId, ResponseSlot>>,
     request_ids: SyncMutex<IdAllocator<RequestId>>,
     next_operation_id: AtomicU64,
-    operations: Arc<SyncMutex<OperationRegistry>>,
+    operations: Arc<dyn OperationStore>,
     channel_ids: SyncMutex<IdAllocator<ChannelId>>,
     /// Registry mapping inbound channel IDs to the sender that feeds the Rx handle.
     channel_senders:
@@ -368,7 +125,7 @@ pub struct DriverReplySink {
     request_id: RequestId,
     retry: roam_types::RetryPolicy,
     operation_id: Option<u64>,
-    operations: Option<Arc<SyncMutex<OperationRegistry>>>,
+    operations: Option<Arc<dyn OperationStore>>,
     binder: DriverChannelBinder,
 }
 
@@ -404,11 +161,8 @@ impl ReplySink for DriverReplySink {
             let encoded_response: Arc<[u8]> = facet_postcard::to_vec(&response)
                 .expect("serialize operation response")
                 .into();
-            let waiters = operations.lock().seal(
-                operation_id,
-                self.request_id,
-                Arc::clone(&encoded_response),
-            );
+            let waiters =
+                operations.seal(operation_id, self.request_id, Arc::clone(&encoded_response));
             for waiter in waiters {
                 if send_encoded_response(sender.clone(), waiter, Arc::clone(&encoded_response))
                     .await
@@ -434,9 +188,7 @@ impl Drop for DriverReplySink {
             if let (Some(operation_id), Some(operations)) =
                 (self.operation_id, self.operations.take())
             {
-                let waiters = operations
-                    .lock()
-                    .fail_without_reply(operation_id, self.request_id);
+                let waiters = operations.fail_without_reply(operation_id, self.request_id);
                 let disposition = if self.retry.persist {
                     FailureDisposition::Indeterminate
                 } else {
@@ -968,6 +720,14 @@ impl ChannelCreditReplenisher for DriverChannelCreditReplenisher {
 
 impl<H: Handler<DriverReplySink>> Driver<H> {
     pub fn new(handle: ConnectionHandle, handler: H) -> Self {
+        Self::with_operation_store(handle, handler, Arc::new(InMemoryOperationStore::default()))
+    }
+
+    pub fn with_operation_store(
+        handle: ConnectionHandle,
+        handler: H,
+        operation_store: Arc<dyn OperationStore>,
+    ) -> Self {
         let conn_id = handle.connection_id();
         let ConnectionHandle {
             sender,
@@ -994,10 +754,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
                 pending_responses: SyncMutex::new("driver.pending_responses", BTreeMap::new()),
                 request_ids: SyncMutex::new("driver.request_ids", IdAllocator::new(parity)),
                 next_operation_id: AtomicU64::new(1),
-                operations: Arc::new(SyncMutex::new(
-                    "driver.operations",
-                    OperationRegistry::default(),
-                )),
+                operations: operation_store,
                 channel_ids: SyncMutex::new("driver.channel_ids", IdAllocator::new(parity)),
                 channel_senders: SyncMutex::new("driver.channel_senders", BTreeMap::new()),
                 channel_buffers: SyncMutex::new("driver.channel_buffers", BTreeMap::new()),
@@ -1181,7 +938,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
             let operation_id = metadata_operation_id(&call.metadata);
 
             if let Some(operation_id) = operation_id {
-                let admit = self.shared.operations.lock().admit(
+                let admit = self.shared.operations.admit(
                     operation_id,
                     call.method_id,
                     incoming_args_bytes(&call),
@@ -1279,7 +1036,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
         } else if is_cancel {
             // r[impl rpc.cancel]
             // r[impl rpc.cancel.channels]
-            match self.shared.operations.lock().cancel(req_id) {
+            match self.shared.operations.cancel(req_id) {
                 OperationCancel::None => {
                     let should_abort = self
                         .in_flight_handlers

--- a/rust/roam-core/src/lib.rs
+++ b/rust/roam-core/src/lib.rs
@@ -14,6 +14,9 @@ pub use bare_conduit::*;
 mod into_conduit;
 pub use into_conduit::*;
 
+mod operation_store;
+pub use operation_store::*;
+
 mod transport_prologue;
 pub use transport_prologue::*;
 

--- a/rust/roam-core/src/operation_store.rs
+++ b/rust/roam-core/src/operation_store.rs
@@ -1,0 +1,335 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use moire::sync::SyncMutex;
+use roam_types::{MaybeSend, MaybeSync, MethodId, RequestId, RetryPolicy};
+
+#[derive(Clone, PartialEq, Eq)]
+struct OperationSignature {
+    method_id: MethodId,
+    args: Arc<[u8]>,
+}
+
+impl OperationSignature {
+    fn from_args(method_id: MethodId, args: &[u8]) -> Self {
+        Self {
+            method_id,
+            args: Arc::<[u8]>::from(args.to_vec()),
+        }
+    }
+
+    fn matches_call(&self, method_id: MethodId, args: &[u8]) -> bool {
+        self.method_id == method_id && self.args.as_ref() == args
+    }
+}
+
+struct StoredOperation {
+    signature: OperationSignature,
+    retry: RetryPolicy,
+}
+
+struct LiveOperation {
+    stored: StoredOperation,
+    owner_request_id: RequestId,
+    waiters: Vec<RequestId>,
+}
+
+struct SealedOperation {
+    stored: StoredOperation,
+    encoded_response: Arc<[u8]>,
+}
+
+enum OperationState {
+    Live(LiveOperation),
+    Released(StoredOperation),
+    Sealed(SealedOperation),
+    Indeterminate(StoredOperation),
+}
+
+/// Result of admitting an operation ID against the current store state.
+pub enum OperationAdmit {
+    Start,
+    Attached,
+    Replay(Arc<[u8]>),
+    Conflict,
+    Indeterminate,
+}
+
+/// Effect of cancelling one waiter or owner request.
+pub enum OperationCancel {
+    None,
+    DetachOnly,
+    Release {
+        owner_request_id: RequestId,
+        waiters: Vec<RequestId>,
+    },
+}
+
+/// Connection-scoped operation state backing for retry/session recovery.
+///
+/// The default implementation is in-memory. Applications that want stronger
+/// retention or durability can provide their own implementation.
+pub trait OperationStore: MaybeSend + MaybeSync + 'static {
+    fn admit(
+        &self,
+        operation_id: u64,
+        method_id: MethodId,
+        args: &[u8],
+        retry: RetryPolicy,
+        request_id: RequestId,
+    ) -> OperationAdmit;
+
+    fn seal(
+        &self,
+        operation_id: u64,
+        owner_request_id: RequestId,
+        encoded_response: Arc<[u8]>,
+    ) -> Vec<RequestId>;
+
+    fn fail_without_reply(&self, operation_id: u64, owner_request_id: RequestId) -> Vec<RequestId>;
+
+    fn cancel(&self, request_id: RequestId) -> OperationCancel;
+}
+
+#[derive(Default)]
+struct OperationRegistry {
+    states: BTreeMap<u64, OperationState>,
+    request_to_operation: BTreeMap<RequestId, u64>,
+}
+
+impl OperationRegistry {
+    fn admit(
+        &mut self,
+        operation_id: u64,
+        method_id: MethodId,
+        args: &[u8],
+        retry: RetryPolicy,
+        request_id: RequestId,
+    ) -> OperationAdmit {
+        let signature = OperationSignature::from_args(method_id, args);
+        let Some(existing) = self.states.remove(&operation_id) else {
+            self.request_to_operation.insert(request_id, operation_id);
+            self.states.insert(
+                operation_id,
+                OperationState::Live(LiveOperation {
+                    stored: StoredOperation { signature, retry },
+                    owner_request_id: request_id,
+                    waiters: vec![request_id],
+                }),
+            );
+            return OperationAdmit::Start;
+        };
+
+        match existing {
+            OperationState::Live(mut live) => {
+                if !live.stored.signature.matches_call(method_id, args) {
+                    self.states.insert(operation_id, OperationState::Live(live));
+                    return OperationAdmit::Conflict;
+                }
+                live.waiters.push(request_id);
+                self.request_to_operation.insert(request_id, operation_id);
+                self.states.insert(operation_id, OperationState::Live(live));
+                OperationAdmit::Attached
+            }
+            OperationState::Sealed(sealed) => {
+                let replay = if sealed.stored.signature.matches_call(method_id, args) {
+                    OperationAdmit::Replay(Arc::clone(&sealed.encoded_response))
+                } else {
+                    OperationAdmit::Conflict
+                };
+                self.states
+                    .insert(operation_id, OperationState::Sealed(sealed));
+                replay
+            }
+            OperationState::Released(stored) => {
+                if !stored.signature.matches_call(method_id, args) || !stored.retry.idem {
+                    let admit = if stored.signature.matches_call(method_id, args) {
+                        OperationAdmit::Indeterminate
+                    } else {
+                        OperationAdmit::Conflict
+                    };
+                    self.states
+                        .insert(operation_id, OperationState::Released(stored));
+                    return admit;
+                }
+                self.request_to_operation.insert(request_id, operation_id);
+                self.states.insert(
+                    operation_id,
+                    OperationState::Live(LiveOperation {
+                        stored: StoredOperation {
+                            signature,
+                            retry: stored.retry,
+                        },
+                        owner_request_id: request_id,
+                        waiters: vec![request_id],
+                    }),
+                );
+                OperationAdmit::Start
+            }
+            OperationState::Indeterminate(stored) => {
+                if !stored.signature.matches_call(method_id, args) || !stored.retry.idem {
+                    let admit = if stored.signature.matches_call(method_id, args) {
+                        OperationAdmit::Indeterminate
+                    } else {
+                        OperationAdmit::Conflict
+                    };
+                    self.states
+                        .insert(operation_id, OperationState::Indeterminate(stored));
+                    return admit;
+                }
+                self.request_to_operation.insert(request_id, operation_id);
+                self.states.insert(
+                    operation_id,
+                    OperationState::Live(LiveOperation {
+                        stored: StoredOperation {
+                            signature,
+                            retry: stored.retry,
+                        },
+                        owner_request_id: request_id,
+                        waiters: vec![request_id],
+                    }),
+                );
+                OperationAdmit::Start
+            }
+        }
+    }
+
+    fn seal(
+        &mut self,
+        operation_id: u64,
+        owner_request_id: RequestId,
+        encoded_response: Arc<[u8]>,
+    ) -> Vec<RequestId> {
+        let Some(OperationState::Live(live)) = self.states.remove(&operation_id) else {
+            return vec![];
+        };
+        if live.owner_request_id != owner_request_id {
+            self.states.insert(operation_id, OperationState::Live(live));
+            return vec![];
+        }
+        for waiter in &live.waiters {
+            self.request_to_operation.remove(waiter);
+        }
+        let waiters = live.waiters.clone();
+        self.states.insert(
+            operation_id,
+            OperationState::Sealed(SealedOperation {
+                stored: live.stored,
+                encoded_response,
+            }),
+        );
+        waiters
+    }
+
+    fn fail_without_reply(
+        &mut self,
+        operation_id: u64,
+        owner_request_id: RequestId,
+    ) -> Vec<RequestId> {
+        let Some(OperationState::Live(live)) = self.states.remove(&operation_id) else {
+            return vec![];
+        };
+        if live.owner_request_id != owner_request_id {
+            self.states.insert(operation_id, OperationState::Live(live));
+            return vec![];
+        }
+        for waiter in &live.waiters {
+            self.request_to_operation.remove(waiter);
+        }
+        let waiters = live.waiters.clone();
+        let next = if live.stored.retry.persist {
+            OperationState::Indeterminate(live.stored)
+        } else {
+            OperationState::Released(live.stored)
+        };
+        self.states.insert(operation_id, next);
+        waiters
+    }
+
+    fn cancel(&mut self, request_id: RequestId) -> OperationCancel {
+        let Some(operation_id) = self.request_to_operation.get(&request_id).copied() else {
+            return OperationCancel::None;
+        };
+        let Some(OperationState::Live(live)) = self.states.get_mut(&operation_id) else {
+            self.request_to_operation.remove(&request_id);
+            return OperationCancel::None;
+        };
+
+        if live.stored.retry.persist {
+            if live.owner_request_id == request_id {
+                return OperationCancel::None;
+            }
+            live.waiters.retain(|candidate| *candidate != request_id);
+            self.request_to_operation.remove(&request_id);
+            return OperationCancel::DetachOnly;
+        }
+
+        let Some(OperationState::Live(live)) = self.states.remove(&operation_id) else {
+            return OperationCancel::None;
+        };
+        for waiter in &live.waiters {
+            self.request_to_operation.remove(waiter);
+        }
+        let waiters = live.waiters.clone();
+        self.states
+            .insert(operation_id, OperationState::Released(live.stored));
+        OperationCancel::Release {
+            owner_request_id: live.owner_request_id,
+            waiters,
+        }
+    }
+}
+
+/// Default in-memory operation store.
+pub struct InMemoryOperationStore {
+    inner: SyncMutex<OperationRegistry>,
+}
+
+impl InMemoryOperationStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for InMemoryOperationStore {
+    fn default() -> Self {
+        Self {
+            inner: SyncMutex::new("driver.operations", OperationRegistry::default()),
+        }
+    }
+}
+
+impl OperationStore for InMemoryOperationStore {
+    fn admit(
+        &self,
+        operation_id: u64,
+        method_id: MethodId,
+        args: &[u8],
+        retry: RetryPolicy,
+        request_id: RequestId,
+    ) -> OperationAdmit {
+        self.inner
+            .lock()
+            .admit(operation_id, method_id, args, retry, request_id)
+    }
+
+    fn seal(
+        &self,
+        operation_id: u64,
+        owner_request_id: RequestId,
+        encoded_response: Arc<[u8]>,
+    ) -> Vec<RequestId> {
+        self.inner
+            .lock()
+            .seal(operation_id, owner_request_id, encoded_response)
+    }
+
+    fn fail_without_reply(&self, operation_id: u64, owner_request_id: RequestId) -> Vec<RequestId> {
+        self.inner
+            .lock()
+            .fail_without_reply(operation_id, owner_request_id)
+    }
+
+    fn cancel(&self, request_id: RequestId) -> OperationCancel {
+        self.inner.lock().cancel(request_id)
+    }
+}

--- a/rust/roam-core/src/session/builders.rs
+++ b/rust/roam-core/src/session/builders.rs
@@ -1,9 +1,15 @@
-use std::{future::Future, pin::Pin};
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
 
 use moire::sync::mpsc;
 use roam_types::{
-    Conduit, ConduitTx, ConnectionSettings, Handler, Link, MaybeSend, MaybeSync, MessageFamily,
-    Metadata, Parity, SplitLink,
+    Conduit, ConduitRx, ConduitTx, ConnectionSettings, Handler, Link, MaybeSend, MaybeSync,
+    Message, MessageFamily, MessagePayload, Metadata, Parity, SelfRef, SessionResumeKey, SplitLink,
+    metadata_session_resume_key,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -11,7 +17,9 @@ use crate::{
     Attachment, LinkSource, StableConduit, prepare_acceptor_attachment, single_attachment_source,
     single_link_source,
 };
-use crate::{BareConduit, IntoConduit, TransportMode, accept_transport, initiate_transport};
+use crate::{
+    BareConduit, IntoConduit, OperationStore, TransportMode, accept_transport, initiate_transport,
+};
 
 use super::{
     CloseRequest, ConduitRecoverer, ConnectionAcceptor, OpenRequest, Session, SessionError,
@@ -94,6 +102,86 @@ pub fn acceptor_transport<L: Link>(link: L) -> SessionTransportAcceptorBuilder<'
     acceptor_on(link)
 }
 
+#[derive(Clone, Default)]
+pub struct SessionRegistry {
+    inner: Arc<Mutex<HashMap<SessionResumeKey, SessionHandle>>>,
+}
+
+impl SessionRegistry {
+    fn get(&self, key: &SessionResumeKey) -> Option<SessionHandle> {
+        self.inner
+            .lock()
+            .expect("session registry poisoned")
+            .get(key)
+            .cloned()
+    }
+
+    fn insert(&self, key: SessionResumeKey, handle: SessionHandle) {
+        self.inner
+            .lock()
+            .expect("session registry poisoned")
+            .insert(key, handle);
+    }
+
+    fn remove(&self, key: &SessionResumeKey) {
+        self.inner
+            .lock()
+            .expect("session registry poisoned")
+            .remove(key);
+    }
+}
+
+pub enum SessionAcceptOutcome<Client> {
+    Established(Client, SessionHandle),
+    Resumed,
+}
+
+struct PrefetchedConduitRx<Rx> {
+    first: Option<SelfRef<Message<'static>>>,
+    inner: Rx,
+}
+
+impl<Rx> PrefetchedConduitRx<Rx> {
+    fn new(first: SelfRef<Message<'static>>, inner: Rx) -> Self {
+        Self {
+            first: Some(first),
+            inner,
+        }
+    }
+}
+
+impl<Rx> ConduitRx for PrefetchedConduitRx<Rx>
+where
+    Rx: ConduitRx<Msg = MessageFamily> + MaybeSend,
+{
+    type Msg = MessageFamily;
+    type Error = Rx::Error;
+
+    fn recv(
+        &mut self,
+    ) -> impl Future<Output = Result<Option<SelfRef<Message<'static>>>, Self::Error>> + MaybeSend + '_
+    {
+        async move {
+            if let Some(first) = self.first.take() {
+                return Ok(Some(first));
+            }
+            self.inner.recv().await
+        }
+    }
+}
+
+fn resume_key_from_first_message(
+    first: &SelfRef<Message<'static>>,
+) -> Result<Option<SessionResumeKey>, SessionError> {
+    match &first.payload {
+        MessagePayload::Hello(hello) => Ok(metadata_session_resume_key(&hello.metadata)),
+        MessagePayload::ProtocolError(error) => {
+            Err(SessionError::Protocol(error.description.to_owned()))
+        }
+        _ => Err(SessionError::Protocol("expected Hello".into())),
+    }
+}
+
 pub struct SessionInitiatorBuilder<'a, C> {
     conduit: C,
     root_settings: ConnectionSettings,
@@ -102,6 +190,7 @@ pub struct SessionInitiatorBuilder<'a, C> {
     keepalive: Option<SessionKeepaliveConfig>,
     resumable: bool,
     recoverer: Option<Box<dyn ConduitRecoverer>>,
+    operation_store: Option<Arc<dyn OperationStore>>,
     spawn_fn: SpawnFn,
 }
 
@@ -118,6 +207,7 @@ impl<'a, C> SessionInitiatorBuilder<'a, C> {
             keepalive: None,
             resumable: false,
             recoverer: None,
+            operation_store: None,
             spawn_fn: default_spawn_fn(),
         }
     }
@@ -154,6 +244,11 @@ impl<'a, C> SessionInitiatorBuilder<'a, C> {
 
     pub fn resumable(mut self) -> Self {
         self.resumable = true;
+        self
+    }
+
+    pub fn operation_store(mut self, operation_store: Arc<dyn OperationStore>) -> Self {
+        self.operation_store = Some(operation_store);
         self
     }
 
@@ -210,7 +305,10 @@ impl<'a, C> SessionInitiatorBuilder<'a, C> {
             resume_tx,
             control_tx,
         };
-        let mut driver = Driver::new(handle, handler);
+        let mut driver = match self.operation_store {
+            Some(operation_store) => Driver::with_operation_store(handle, handler, operation_store),
+            None => Driver::new(handle, handler),
+        };
         let client = Client::from(driver.caller());
         (self.spawn_fn)(Box::pin(async move { session.run().await }));
         #[cfg(not(target_arch = "wasm32"))]
@@ -230,6 +328,7 @@ pub struct SessionSourceInitiatorBuilder<'a, S> {
     on_connection: Option<Box<dyn ConnectionAcceptor>>,
     keepalive: Option<SessionKeepaliveConfig>,
     resumable: bool,
+    operation_store: Option<Arc<dyn OperationStore>>,
     spawn_fn: SpawnFn,
 }
 
@@ -247,6 +346,7 @@ impl<'a, S> SessionSourceInitiatorBuilder<'a, S> {
             on_connection: None,
             keepalive: None,
             resumable: true,
+            operation_store: None,
             spawn_fn: default_spawn_fn(),
         }
     }
@@ -283,6 +383,11 @@ impl<'a, S> SessionSourceInitiatorBuilder<'a, S> {
 
     pub fn resumable(mut self) -> Self {
         self.resumable = true;
+        self
+    }
+
+    pub fn operation_store(mut self, operation_store: Arc<dyn OperationStore>) -> Self {
+        self.operation_store = Some(operation_store);
         self
     }
 
@@ -317,6 +422,7 @@ impl<'a, S> SessionSourceInitiatorBuilder<'a, S> {
             on_connection,
             keepalive,
             resumable,
+            operation_store,
             spawn_fn,
         } = self;
 
@@ -337,6 +443,7 @@ impl<'a, S> SessionSourceInitiatorBuilder<'a, S> {
                     keepalive,
                     resumable,
                     Some(recoverer),
+                    operation_store,
                     spawn_fn,
                 )
                 .establish(handler)
@@ -360,6 +467,7 @@ impl<'a, S> SessionSourceInitiatorBuilder<'a, S> {
                     keepalive,
                     resumable,
                     None,
+                    operation_store,
                     spawn_fn,
                 )
                 .establish(handler)
@@ -377,6 +485,7 @@ pub struct SessionTransportInitiatorBuilder<'a, L> {
     on_connection: Option<Box<dyn ConnectionAcceptor>>,
     keepalive: Option<SessionKeepaliveConfig>,
     resumable: bool,
+    operation_store: Option<Arc<dyn OperationStore>>,
     spawn_fn: SpawnFn,
 }
 
@@ -393,6 +502,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
             on_connection: None,
             keepalive: None,
             resumable: false,
+            operation_store: None,
             spawn_fn: default_spawn_fn(),
         }
     }
@@ -432,6 +542,11 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
         self
     }
 
+    pub fn operation_store(mut self, operation_store: Arc<dyn OperationStore>) -> Self {
+        self.operation_store = Some(operation_store);
+        self
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     pub fn spawn_fn(mut self, f: impl FnOnce(BoxSessionFuture) + Send + 'static) -> Self {
         self.spawn_fn = Box::new(f);
@@ -463,6 +578,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
             on_connection,
             keepalive,
             resumable,
+            operation_store,
             spawn_fn,
         } = self;
         match mode {
@@ -477,6 +593,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
                     on_connection,
                     keepalive,
                     resumable,
+                    operation_store,
                     spawn_fn,
                     handler,
                 )
@@ -490,6 +607,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
                     on_connection,
                     keepalive,
                     resumable,
+                    operation_store,
                     spawn_fn,
                     handler,
                 )
@@ -517,6 +635,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
             on_connection,
             keepalive,
             resumable,
+            operation_store,
             spawn_fn,
         } = self;
         match mode {
@@ -531,6 +650,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
                     on_connection,
                     keepalive,
                     resumable,
+                    operation_store,
                     spawn_fn,
                     handler,
                 )
@@ -549,6 +669,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
         on_connection: Option<Box<dyn ConnectionAcceptor>>,
         keepalive: Option<SessionKeepaliveConfig>,
         resumable: bool,
+        operation_store: Option<Arc<dyn OperationStore>>,
         spawn_fn: SpawnFn,
         handler: impl Handler<DriverReplySink> + 'static,
     ) -> Result<(Client, SessionHandle), SessionError>
@@ -567,6 +688,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
             keepalive,
             resumable,
             None,
+            operation_store,
             spawn_fn,
         )
         .establish(handler)
@@ -581,6 +703,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
         on_connection: Option<Box<dyn ConnectionAcceptor>>,
         keepalive: Option<SessionKeepaliveConfig>,
         resumable: bool,
+        operation_store: Option<Arc<dyn OperationStore>>,
         spawn_fn: SpawnFn,
         handler: impl Handler<DriverReplySink> + 'static,
     ) -> Result<(Client, SessionHandle), SessionError>
@@ -607,6 +730,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
             keepalive,
             resumable,
             None,
+            operation_store,
             spawn_fn,
         )
         .establish(handler)
@@ -621,6 +745,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
         keepalive: Option<SessionKeepaliveConfig>,
         resumable: bool,
         recoverer: Option<Box<dyn ConduitRecoverer>>,
+        operation_store: Option<Arc<dyn OperationStore>>,
         spawn_fn: SpawnFn,
     ) -> SessionInitiatorBuilder<'a, C> {
         builder.root_settings = root_settings;
@@ -629,6 +754,7 @@ impl<'a, L> SessionTransportInitiatorBuilder<'a, L> {
         builder.keepalive = keepalive;
         builder.resumable = resumable;
         builder.recoverer = recoverer;
+        builder.operation_store = operation_store;
         builder.spawn_fn = spawn_fn;
         builder
     }
@@ -708,6 +834,8 @@ pub struct SessionAcceptorBuilder<'a, C> {
     on_connection: Option<Box<dyn ConnectionAcceptor>>,
     keepalive: Option<SessionKeepaliveConfig>,
     resumable: bool,
+    session_registry: Option<SessionRegistry>,
+    operation_store: Option<Arc<dyn OperationStore>>,
     spawn_fn: SpawnFn,
 }
 
@@ -723,6 +851,8 @@ impl<'a, C> SessionAcceptorBuilder<'a, C> {
             on_connection: None,
             keepalive: None,
             resumable: false,
+            session_registry: None,
+            operation_store: None,
             spawn_fn: default_spawn_fn(),
         }
     }
@@ -754,6 +884,16 @@ impl<'a, C> SessionAcceptorBuilder<'a, C> {
 
     pub fn resumable(mut self) -> Self {
         self.resumable = true;
+        self
+    }
+
+    pub fn session_registry(mut self, session_registry: SessionRegistry) -> Self {
+        self.session_registry = Some(session_registry);
+        self
+    }
+
+    pub fn operation_store(mut self, operation_store: Arc<dyn OperationStore>) -> Self {
+        self.operation_store = Some(operation_store);
         self
     }
 
@@ -784,7 +924,164 @@ impl<'a, C> SessionAcceptorBuilder<'a, C> {
         for<'p> <C::Tx as ConduitTx>::Permit<'p>: MaybeSend,
         C::Rx: MaybeSend + 'static,
     {
-        let (tx, rx) = self.conduit.split();
+        let Self {
+            conduit,
+            root_settings,
+            metadata,
+            on_connection,
+            keepalive,
+            resumable,
+            session_registry: _session_registry,
+            operation_store,
+            spawn_fn,
+        } = self;
+        Self::establish_from_parts(
+            conduit,
+            root_settings,
+            metadata,
+            on_connection,
+            keepalive,
+            resumable,
+            operation_store,
+            spawn_fn,
+            handler,
+        )
+        .await
+    }
+
+    #[moire::instrument]
+    pub async fn establish_or_resume<Client: From<DriverCaller>>(
+        self,
+        handler: impl Handler<DriverReplySink> + 'static,
+    ) -> Result<SessionAcceptOutcome<Client>, SessionError>
+    where
+        C: Conduit<Msg = MessageFamily> + 'static,
+        C::Tx: MaybeSend + MaybeSync + 'static,
+        for<'p> <C::Tx as ConduitTx>::Permit<'p>: MaybeSend,
+        C::Rx: MaybeSend + 'static,
+    {
+        let Self {
+            conduit,
+            root_settings,
+            metadata,
+            on_connection,
+            keepalive,
+            resumable,
+            session_registry,
+            operation_store,
+            spawn_fn,
+        } = self;
+
+        let Some(session_registry) = session_registry else {
+            let (client, handle) = Self::establish_from_parts(
+                conduit,
+                root_settings,
+                metadata,
+                on_connection,
+                keepalive,
+                resumable,
+                operation_store,
+                spawn_fn,
+                handler,
+            )
+            .await?;
+            return Ok(SessionAcceptOutcome::Established(client, handle));
+        };
+
+        let (tx, mut rx) = conduit.split();
+        let Some(first) = rx
+            .recv()
+            .await
+            .map_err(|error| SessionError::Protocol(error.to_string()))?
+        else {
+            return Err(SessionError::Protocol(
+                "peer closed during handshake".into(),
+            ));
+        };
+
+        if let Some(resume_key) = resume_key_from_first_message(&first)? {
+            if let Some(handle) = session_registry.get(&resume_key) {
+                if let Err(error) = handle
+                    .resume_parts(Arc::new(tx), Box::new(PrefetchedConduitRx::new(first, rx)))
+                    .await
+                {
+                    session_registry.remove(&resume_key);
+                    return Err(error);
+                }
+                return Ok(SessionAcceptOutcome::Resumed);
+            }
+            return Err(SessionError::Protocol("unknown session resume key".into()));
+        }
+
+        let (client, handle, resume_key) = Self::establish_from_parts_with_prefetched_hello(
+            tx,
+            PrefetchedConduitRx::new(first, rx),
+            root_settings,
+            metadata,
+            on_connection,
+            keepalive,
+            resumable,
+            operation_store,
+            spawn_fn,
+            handler,
+        )
+        .await?;
+        if let Some(resume_key) = resume_key {
+            session_registry.insert(resume_key, handle.clone());
+        }
+        Ok(SessionAcceptOutcome::Established(client, handle))
+    }
+
+    async fn establish_from_parts<Client: From<DriverCaller>, Tx, Rx>(
+        conduit: impl Conduit<Msg = MessageFamily, Tx = Tx, Rx = Rx> + 'static,
+        root_settings: ConnectionSettings,
+        metadata: Metadata<'a>,
+        on_connection: Option<Box<dyn ConnectionAcceptor>>,
+        keepalive: Option<SessionKeepaliveConfig>,
+        resumable: bool,
+        operation_store: Option<Arc<dyn OperationStore>>,
+        spawn_fn: SpawnFn,
+        handler: impl Handler<DriverReplySink> + 'static,
+    ) -> Result<(Client, SessionHandle), SessionError>
+    where
+        Tx: ConduitTx<Msg = MessageFamily> + MaybeSend + MaybeSync + 'static,
+        for<'p> <Tx as ConduitTx>::Permit<'p>: MaybeSend,
+        Rx: ConduitRx<Msg = MessageFamily> + MaybeSend + 'static,
+    {
+        let (tx, rx) = conduit.split();
+        let (client, handle, _resume_key) = Self::establish_from_parts_with_prefetched_hello(
+            tx,
+            rx,
+            root_settings,
+            metadata,
+            on_connection,
+            keepalive,
+            resumable,
+            operation_store,
+            spawn_fn,
+            handler,
+        )
+        .await?;
+        Ok((client, handle))
+    }
+
+    async fn establish_from_parts_with_prefetched_hello<Client: From<DriverCaller>, Tx, Rx>(
+        tx: Tx,
+        rx: Rx,
+        root_settings: ConnectionSettings,
+        metadata: Metadata<'a>,
+        on_connection: Option<Box<dyn ConnectionAcceptor>>,
+        keepalive: Option<SessionKeepaliveConfig>,
+        resumable: bool,
+        operation_store: Option<Arc<dyn OperationStore>>,
+        spawn_fn: SpawnFn,
+        handler: impl Handler<DriverReplySink> + 'static,
+    ) -> Result<(Client, SessionHandle, Option<SessionResumeKey>), SessionError>
+    where
+        Tx: ConduitTx<Msg = MessageFamily> + MaybeSend + MaybeSync + 'static,
+        for<'p> <Tx as ConduitTx>::Permit<'p>: MaybeSend,
+        Rx: ConduitRx<Msg = MessageFamily> + MaybeSend + 'static,
+    {
         let (open_tx, open_rx) = mpsc::channel::<OpenRequest>("session.open", 4);
         let (close_tx, close_rx) = mpsc::channel::<CloseRequest>("session.close", 4);
         let (resume_tx, resume_rx) = mpsc::channel::<super::ResumeRequest>("session.resume", 1);
@@ -792,33 +1089,37 @@ impl<'a, C> SessionAcceptorBuilder<'a, C> {
         let mut session = Session::pre_handshake(
             tx,
             rx,
-            self.on_connection,
+            on_connection,
             open_rx,
             close_rx,
             resume_rx,
             control_tx.clone(),
             control_rx,
-            self.keepalive,
-            self.resumable,
+            keepalive,
+            resumable,
             None,
         );
         let handle = session
-            .establish_as_acceptor(self.root_settings, self.metadata)
+            .establish_as_acceptor(root_settings, metadata)
             .await?;
+        let resume_key = session.resume_key();
         let session_handle = SessionHandle {
             open_tx,
             close_tx,
             resume_tx,
             control_tx,
         };
-        let mut driver = Driver::new(handle, handler);
+        let mut driver = match operation_store {
+            Some(operation_store) => Driver::with_operation_store(handle, handler, operation_store),
+            None => Driver::new(handle, handler),
+        };
         let client = Client::from(driver.caller());
-        (self.spawn_fn)(Box::pin(async move { session.run().await }));
+        (spawn_fn)(Box::pin(async move { session.run().await }));
         #[cfg(not(target_arch = "wasm32"))]
         tokio::spawn(async move { driver.run().await });
         #[cfg(target_arch = "wasm32")]
         wasm_bindgen_futures::spawn_local(async move { driver.run().await });
-        Ok((client, session_handle))
+        Ok((client, session_handle, resume_key))
     }
 }
 
@@ -829,6 +1130,8 @@ pub struct SessionTransportAcceptorBuilder<'a, L: Link> {
     on_connection: Option<Box<dyn ConnectionAcceptor>>,
     keepalive: Option<SessionKeepaliveConfig>,
     resumable: bool,
+    session_registry: Option<SessionRegistry>,
+    operation_store: Option<Arc<dyn OperationStore>>,
     spawn_fn: SpawnFn,
 }
 
@@ -844,6 +1147,8 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
             on_connection: None,
             keepalive: None,
             resumable: true,
+            session_registry: None,
+            operation_store: None,
             spawn_fn: default_spawn_fn(),
         }
     }
@@ -878,6 +1183,16 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
         self
     }
 
+    pub fn session_registry(mut self, session_registry: SessionRegistry) -> Self {
+        self.session_registry = Some(session_registry);
+        self
+    }
+
+    pub fn operation_store(mut self, operation_store: Arc<dyn OperationStore>) -> Self {
+        self.operation_store = Some(operation_store);
+        self
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     pub fn spawn_fn(mut self, f: impl FnOnce(BoxSessionFuture) + Send + 'static) -> Self {
         self.spawn_fn = Box::new(f);
@@ -909,6 +1224,8 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
             on_connection,
             keepalive,
             resumable,
+            session_registry,
+            operation_store,
             spawn_fn,
         } = self;
         let (mode, link) = accept_transport(link)
@@ -925,6 +1242,8 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
                     on_connection,
                     keepalive,
                     resumable,
+                    session_registry,
+                    operation_store,
                     spawn_fn,
                 )
                 .establish(handler)
@@ -938,11 +1257,74 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
                     on_connection,
                     keepalive,
                     resumable,
+                    session_registry,
+                    operation_store,
                     spawn_fn,
                     handler,
                 )
                 .await
             }
+        }
+    }
+
+    #[moire::instrument]
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn establish_or_resume<Client: From<DriverCaller>>(
+        self,
+        handler: impl Handler<DriverReplySink> + 'static,
+    ) -> Result<SessionAcceptOutcome<Client>, SessionError>
+    where
+        L: Link + Send + 'static,
+        L::Tx: MaybeSend + MaybeSync + 'static,
+        <L::Tx as roam_types::LinkTx>::Permit: MaybeSend,
+        L::Rx: MaybeSend + 'static,
+    {
+        let Self {
+            link,
+            root_settings,
+            metadata,
+            on_connection,
+            keepalive,
+            resumable,
+            session_registry,
+            operation_store,
+            spawn_fn,
+        } = self;
+        let (mode, link) = accept_transport(link)
+            .await
+            .map_err(session_error_from_transport)?;
+        match mode {
+            TransportMode::Bare => {
+                let builder =
+                    SessionAcceptorBuilder::new(BareConduit::<MessageFamily, _>::new(link));
+                Self::apply_common_parts(
+                    builder,
+                    root_settings,
+                    metadata,
+                    on_connection,
+                    keepalive,
+                    resumable,
+                    session_registry,
+                    operation_store,
+                    spawn_fn,
+                )
+                .establish_or_resume(handler)
+                .await
+            }
+            TransportMode::Stable => Self::finish_with_stable_parts(
+                link,
+                root_settings,
+                metadata,
+                on_connection,
+                keepalive,
+                resumable,
+                session_registry,
+                operation_store,
+                spawn_fn,
+                handler,
+            )
+            .await
+            .map(|(client, handle)| SessionAcceptOutcome::Established(client, handle)),
         }
     }
 
@@ -964,6 +1346,8 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
             on_connection,
             keepalive,
             resumable,
+            session_registry,
+            operation_store,
             spawn_fn,
         } = self;
         let (mode, link) = accept_transport(link)
@@ -980,9 +1364,60 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
                     on_connection,
                     keepalive,
                     resumable,
+                    session_registry,
+                    operation_store,
                     spawn_fn,
                 )
                 .establish(handler)
+                .await
+            }
+            TransportMode::Stable => Err(SessionError::Protocol(
+                "stable conduit transport selection is unsupported on wasm".into(),
+            )),
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn establish_or_resume<Client: From<DriverCaller>>(
+        self,
+        handler: impl Handler<DriverReplySink> + 'static,
+    ) -> Result<SessionAcceptOutcome<Client>, SessionError>
+    where
+        L: Link + 'static,
+        L::Tx: MaybeSend + MaybeSync + 'static,
+        <L::Tx as roam_types::LinkTx>::Permit: MaybeSend,
+        L::Rx: MaybeSend + 'static,
+    {
+        let Self {
+            link,
+            root_settings,
+            metadata,
+            on_connection,
+            keepalive,
+            resumable,
+            session_registry,
+            operation_store,
+            spawn_fn,
+        } = self;
+        let (mode, link) = accept_transport(link)
+            .await
+            .map_err(session_error_from_transport)?;
+        match mode {
+            TransportMode::Bare => {
+                let builder =
+                    SessionAcceptorBuilder::new(BareConduit::<MessageFamily, _>::new(link));
+                Self::apply_common_parts(
+                    builder,
+                    root_settings,
+                    metadata,
+                    on_connection,
+                    keepalive,
+                    resumable,
+                    session_registry,
+                    operation_store,
+                    spawn_fn,
+                )
+                .establish_or_resume(handler)
                 .await
             }
             TransportMode::Stable => Err(SessionError::Protocol(
@@ -999,6 +1434,8 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
         on_connection: Option<Box<dyn ConnectionAcceptor>>,
         keepalive: Option<SessionKeepaliveConfig>,
         resumable: bool,
+        session_registry: Option<SessionRegistry>,
+        operation_store: Option<Arc<dyn OperationStore>>,
         spawn_fn: SpawnFn,
         handler: impl Handler<DriverReplySink> + 'static,
     ) -> Result<(Client, SessionHandle), SessionError>
@@ -1024,6 +1461,8 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
             on_connection,
             keepalive,
             resumable,
+            session_registry,
+            operation_store,
             spawn_fn,
         )
         .establish(handler)
@@ -1037,6 +1476,8 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
         on_connection: Option<Box<dyn ConnectionAcceptor>>,
         keepalive: Option<SessionKeepaliveConfig>,
         resumable: bool,
+        session_registry: Option<SessionRegistry>,
+        operation_store: Option<Arc<dyn OperationStore>>,
         spawn_fn: SpawnFn,
     ) -> SessionAcceptorBuilder<'a, C> {
         builder.root_settings = root_settings;
@@ -1044,6 +1485,8 @@ impl<'a, L: Link> SessionTransportAcceptorBuilder<'a, L> {
         builder.on_connection = on_connection;
         builder.keepalive = keepalive;
         builder.resumable = resumable;
+        builder.session_registry = session_registry;
+        builder.operation_store = operation_store;
         builder.spawn_fn = spawn_fn;
         builder
     }

--- a/rust/roam-core/src/session/mod.rs
+++ b/rust/roam-core/src/session/mod.rs
@@ -184,13 +184,17 @@ impl SessionHandle {
         <I::Conduit as Conduit>::Rx: MaybeSend + 'static,
     {
         let (tx, rx) = into_conduit.into_conduit().split();
+        self.resume_parts(Arc::new(tx), Box::new(rx)).await
+    }
+
+    pub(crate) async fn resume_parts(
+        &self,
+        tx: Arc<dyn DynConduitTx>,
+        rx: Box<dyn DynConduitRx>,
+    ) -> Result<(), SessionError> {
         let (result_tx, result_rx) = moire::sync::oneshot::channel("session.resume_result");
         self.resume_tx
-            .send(ResumeRequest {
-                tx: Arc::new(tx),
-                rx: Box::new(rx),
-                result_tx,
-            })
+            .send(ResumeRequest { tx, rx, result_tx })
             .await
             .map_err(|_| SessionError::Protocol("session closed".into()))?;
         result_rx
@@ -620,6 +624,10 @@ impl Session {
             resume_notifier,
             recoverer,
         }
+    }
+
+    pub(crate) fn resume_key(&self) -> Option<SessionResumeKey> {
+        self.session_resume_key
     }
 
     // r[impl session.handshake]

--- a/rust/roam-core/src/tests/driver_tests.rs
+++ b/rust/roam-core/src/tests/driver_tests.rs
@@ -10,15 +10,20 @@ use roam_types::{
     ChannelItem, ChannelMessage, ChannelSink, Conduit, ConduitRx, ConnectionSettings, Handler,
     IncomingChannelMessage, Link, LinkRx, LinkTx, LinkTxPermit, Message, MessageFamily,
     MessagePayload, Metadata, MethodId, Parity, Payload, ReplySink, RequestBody, RequestCall,
-    RequestCancel, RequestMessage, RequestResponse, RetryPolicy, RoamError, RpcPlan, SelfRef, Tx,
-    WriteSlot, bind_channels_caller_args, channel, ensure_operation_id, metadata_operation_id,
+    RequestCancel, RequestId, RequestMessage, RequestResponse, RetryPolicy, RoamError, RpcPlan,
+    SelfRef, Tx, WriteSlot, bind_channels_caller_args, channel, ensure_operation_id,
+    metadata_operation_id,
 };
 
 use crate::session::{
-    AcceptedConnection, ConnectionAcceptor, ConnectionMessage, SessionError, SessionHandle,
-    SessionKeepaliveConfig, acceptor, initiator_conduit, proxy_connections,
+    AcceptedConnection, ConnectionAcceptor, ConnectionMessage, SessionAcceptOutcome, SessionError,
+    SessionHandle, SessionKeepaliveConfig, SessionRegistry, acceptor, acceptor_on,
+    initiator_conduit, initiator_on, proxy_connections,
 };
-use crate::{BareConduit, Driver, DriverCaller, DriverReplySink, memory_link_pair};
+use crate::{
+    BareConduit, Driver, DriverCaller, DriverReplySink, InMemoryOperationStore, OperationAdmit,
+    OperationCancel, OperationStore, TransportMode, initiate_transport, memory_link_pair,
+};
 
 type MessageConduit = BareConduit<MessageFamily, crate::MemoryLink>;
 
@@ -294,6 +299,54 @@ impl Handler<DriverReplySink> for OperationIdHandler {
 struct ReplayHandler {
     runs: Arc<std::sync::atomic::AtomicUsize>,
     release: Arc<tokio::sync::Notify>,
+}
+
+struct CountingOperationStore {
+    inner: InMemoryOperationStore,
+    admits: AtomicUsize,
+}
+
+impl CountingOperationStore {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryOperationStore::default(),
+            admits: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl OperationStore for CountingOperationStore {
+    fn admit(
+        &self,
+        operation_id: u64,
+        method_id: MethodId,
+        args: &[u8],
+        retry: RetryPolicy,
+        request_id: RequestId,
+    ) -> OperationAdmit {
+        self.admits.fetch_add(1, Ordering::SeqCst);
+        self.inner
+            .admit(operation_id, method_id, args, retry, request_id)
+    }
+
+    fn seal(
+        &self,
+        operation_id: u64,
+        owner_request_id: RequestId,
+        encoded_response: Arc<[u8]>,
+    ) -> Vec<RequestId> {
+        self.inner
+            .seal(operation_id, owner_request_id, encoded_response)
+    }
+
+    fn fail_without_reply(&self, operation_id: u64, owner_request_id: RequestId) -> Vec<RequestId> {
+        self.inner
+            .fail_without_reply(operation_id, owner_request_id)
+    }
+
+    fn cancel(&self, request_id: RequestId) -> OperationCancel {
+        self.inner.cancel(request_id)
+    }
 }
 
 impl Handler<DriverReplySink> for ReplayHandler {
@@ -905,6 +958,44 @@ async fn caller_injects_operation_id_when_peer_supports_retry() {
 }
 
 #[tokio::test]
+async fn builder_uses_custom_operation_store() {
+    let (client_conduit, server_conduit) = message_conduit_pair();
+    let store = Arc::new(CountingOperationStore::new());
+    let store_check = Arc::clone(&store);
+
+    let server_task = moire::task::spawn(
+        async move {
+            let (server_caller, _sh) = acceptor(server_conduit)
+                .operation_store(store)
+                .establish::<DriverCaller>(OperationIdHandler)
+                .await
+                .expect("server handshake failed");
+            server_caller
+        }
+        .named("server_setup"),
+    );
+
+    let (caller, _sh) = initiator_conduit(client_conduit)
+        .establish::<DriverCaller>(())
+        .await
+        .expect("client handshake failed");
+
+    let _server_caller_guard = server_task.await.expect("server setup failed");
+
+    let _response = caller
+        .call(RequestCall {
+            method_id: MethodId(1),
+            args: Payload::outgoing(&7_u32),
+            channels: vec![],
+            metadata: Default::default(),
+        })
+        .await
+        .expect("call should succeed");
+
+    assert_ne!(store_check.admits.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn duplicate_operation_id_attaches_live_and_replays_sealed_outcome() {
     let (client_conduit, server_conduit) = message_conduit_pair();
 
@@ -1087,6 +1178,106 @@ async fn resumable_session_keeps_pending_call_alive_across_manual_resume() {
 
     let _ = client_session_handle.shutdown();
     let _ = server_session_handle.shutdown();
+    client_break2.close().await;
+    server_break2.close().await;
+}
+
+#[tokio::test]
+async fn resumable_acceptor_registry_keeps_pending_call_alive_across_auto_resume() {
+    let registry = SessionRegistry::default();
+    let (client_link1, client_break1, server_link1, server_break1) = breakable_link_pair(64);
+    let started = Arc::new(tokio::sync::Notify::new());
+    let started_for_wait = Arc::clone(&started);
+    let started_wait = started_for_wait.notified();
+    let release = Arc::new(tokio::sync::Notify::new());
+
+    let (server_established, client_established) = tokio::try_join!(
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            acceptor_on(server_link1)
+                .session_registry(registry.clone())
+                .establish_or_resume::<DriverCaller>(ResumableReplyingHandler {
+                    started,
+                    release: Arc::clone(&release),
+                }),
+        ),
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            initiator_on(client_link1, TransportMode::Bare)
+                .resumable()
+                .establish::<DriverCaller>(()),
+        ),
+    )
+    .expect("initial session establishment timed out");
+    let (server_caller, _server_session_handle) =
+        match server_established.expect("server handshake failed") {
+            SessionAcceptOutcome::Established(client, handle) => (client, handle),
+            SessionAcceptOutcome::Resumed => panic!("first accept should establish a new session"),
+        };
+    let (caller, client_session_handle) = client_established.expect("client handshake failed");
+
+    let call_task = moire::task::spawn(
+        async move {
+            caller
+                .call(RequestCall {
+                    method_id: MethodId(1),
+                    args: Payload::outgoing(&66_u32),
+                    channels: vec![],
+                    metadata: Default::default(),
+                })
+                .await
+        }
+        .named("registry_resume_pending_call"),
+    );
+
+    tokio::time::timeout(Duration::from_secs(1), started_wait)
+        .await
+        .expect("timed out waiting for handler start");
+
+    client_break1.close().await;
+    server_break1.close().await;
+    tokio::time::sleep(Duration::from_millis(25)).await;
+
+    let (client_link2, client_break2, server_link2, server_break2) = breakable_link_pair(64);
+    let (resume_result, server_accept_result) = tokio::join!(
+        async {
+            let resumed_link = initiate_transport(client_link2, TransportMode::Bare)
+                .await
+                .expect("client transport prologue should succeed");
+            client_session_handle
+                .resume(BareConduit::new(resumed_link))
+                .await
+        },
+        acceptor_on(server_link2)
+            .session_registry(registry.clone())
+            .establish_or_resume::<DriverCaller>(ResumableReplyingHandler {
+                started: Arc::new(tokio::sync::Notify::new()),
+                release: Arc::clone(&release),
+            }),
+    );
+    resume_result.expect("client session resume should succeed");
+    match server_accept_result.expect("server accept should succeed") {
+        SessionAcceptOutcome::Resumed => {}
+        SessionAcceptOutcome::Established(_, _) => {
+            panic!("registry accept should have resumed the existing session")
+        }
+    }
+
+    release.notify_waiters();
+
+    let response = call_task
+        .await
+        .expect("call task join")
+        .expect("call should succeed after registry-driven session resume");
+    let ret_bytes = match &response.ret {
+        Payload::Incoming(bytes) => *bytes,
+        _ => panic!("expected incoming payload in response"),
+    };
+    let value: u32 = facet_postcard::from_slice(ret_bytes).expect("deserialize response");
+    assert_eq!(value, 66);
+
+    drop(server_caller);
+    let _ = client_session_handle.shutdown();
     client_break2.close().await;
     server_break2.close().await;
 }

--- a/rust/roam-core/src/wasm_driver.rs
+++ b/rust/roam-core/src/wasm_driver.rs
@@ -23,255 +23,15 @@ use tokio::sync::watch;
 use crate::session::{
     ConnectionHandle, ConnectionMessage, ConnectionSender, DropControlRequest, FailureDisposition,
 };
+use crate::{InMemoryOperationStore, OperationAdmit, OperationCancel, OperationStore};
 
 type ResponseSlot = moire::sync::oneshot::Sender<SelfRef<RequestMessage<'static>>>;
-
-#[derive(Clone, PartialEq, Eq)]
-struct OperationSignature {
-    method_id: roam_types::MethodId,
-    args: Arc<[u8]>,
-}
-
-impl OperationSignature {
-    fn matches_call(&self, method_id: roam_types::MethodId, args: &[u8]) -> bool {
-        self.method_id == method_id && self.args.as_ref() == args
-    }
-}
-
-struct StoredOperation {
-    signature: OperationSignature,
-    retry: roam_types::RetryPolicy,
-}
-
-struct LiveOperation {
-    stored: StoredOperation,
-    owner_request_id: RequestId,
-    waiters: Vec<RequestId>,
-}
-
-struct SealedOperation {
-    stored: StoredOperation,
-    encoded_response: Arc<[u8]>,
-}
-
-enum OperationState {
-    Live(LiveOperation),
-    Released(StoredOperation),
-    Sealed(SealedOperation),
-    Indeterminate(StoredOperation),
-}
-
-enum OperationAdmit {
-    Start,
-    Attached,
-    Replay(Arc<[u8]>),
-    Conflict,
-    Indeterminate,
-}
-
-enum OperationCancel {
-    None,
-    DetachOnly,
-    Release {
-        owner_request_id: RequestId,
-        waiters: Vec<RequestId>,
-    },
-}
-
-#[derive(Default)]
-struct OperationRegistry {
-    states: BTreeMap<u64, OperationState>,
-    request_to_operation: BTreeMap<RequestId, u64>,
-}
-
-impl OperationRegistry {
-    fn admit(
-        &mut self,
-        operation_id: u64,
-        method_id: roam_types::MethodId,
-        args: &[u8],
-        retry: roam_types::RetryPolicy,
-        request_id: RequestId,
-    ) -> OperationAdmit {
-        let signature = OperationSignature {
-            method_id,
-            args: Arc::<[u8]>::from(args.to_vec()),
-        };
-        let Some(existing) = self.states.remove(&operation_id) else {
-            self.request_to_operation.insert(request_id, operation_id);
-            self.states.insert(
-                operation_id,
-                OperationState::Live(LiveOperation {
-                    stored: StoredOperation { signature, retry },
-                    owner_request_id: request_id,
-                    waiters: vec![request_id],
-                }),
-            );
-            return OperationAdmit::Start;
-        };
-
-        match existing {
-            OperationState::Live(mut live) => {
-                if !live.stored.signature.matches_call(method_id, args) {
-                    self.states.insert(operation_id, OperationState::Live(live));
-                    return OperationAdmit::Conflict;
-                }
-                live.waiters.push(request_id);
-                self.request_to_operation.insert(request_id, operation_id);
-                self.states.insert(operation_id, OperationState::Live(live));
-                OperationAdmit::Attached
-            }
-            OperationState::Sealed(sealed) => {
-                let replay = if sealed.stored.signature.matches_call(method_id, args) {
-                    OperationAdmit::Replay(Arc::clone(&sealed.encoded_response))
-                } else {
-                    OperationAdmit::Conflict
-                };
-                self.states
-                    .insert(operation_id, OperationState::Sealed(sealed));
-                replay
-            }
-            OperationState::Released(stored) => {
-                let matches_call = stored.signature.matches_call(method_id, args);
-                if !matches_call || !stored.retry.idem {
-                    self.states
-                        .insert(operation_id, OperationState::Released(stored));
-                    return if matches_call {
-                        OperationAdmit::Indeterminate
-                    } else {
-                        OperationAdmit::Conflict
-                    };
-                }
-                self.request_to_operation.insert(request_id, operation_id);
-                self.states.insert(
-                    operation_id,
-                    OperationState::Live(LiveOperation {
-                        stored: StoredOperation {
-                            signature,
-                            retry: stored.retry,
-                        },
-                        owner_request_id: request_id,
-                        waiters: vec![request_id],
-                    }),
-                );
-                OperationAdmit::Start
-            }
-            OperationState::Indeterminate(stored) => {
-                let matches_call = stored.signature.matches_call(method_id, args);
-                if !matches_call || !stored.retry.idem {
-                    self.states
-                        .insert(operation_id, OperationState::Indeterminate(stored));
-                    return if matches_call {
-                        OperationAdmit::Indeterminate
-                    } else {
-                        OperationAdmit::Conflict
-                    };
-                }
-                self.request_to_operation.insert(request_id, operation_id);
-                self.states.insert(
-                    operation_id,
-                    OperationState::Live(LiveOperation {
-                        stored: StoredOperation {
-                            signature,
-                            retry: stored.retry,
-                        },
-                        owner_request_id: request_id,
-                        waiters: vec![request_id],
-                    }),
-                );
-                OperationAdmit::Start
-            }
-        }
-    }
-
-    fn seal(
-        &mut self,
-        operation_id: u64,
-        owner_request_id: RequestId,
-        encoded_response: Arc<[u8]>,
-    ) -> Vec<RequestId> {
-        let Some(OperationState::Live(live)) = self.states.remove(&operation_id) else {
-            return vec![];
-        };
-        if live.owner_request_id != owner_request_id {
-            self.states.insert(operation_id, OperationState::Live(live));
-            return vec![];
-        }
-        for waiter in &live.waiters {
-            self.request_to_operation.remove(waiter);
-        }
-        let waiters = live.waiters.clone();
-        self.states.insert(
-            operation_id,
-            OperationState::Sealed(SealedOperation {
-                stored: live.stored,
-                encoded_response,
-            }),
-        );
-        waiters
-    }
-
-    fn fail_without_reply(
-        &mut self,
-        operation_id: u64,
-        owner_request_id: RequestId,
-    ) -> Vec<RequestId> {
-        let Some(OperationState::Live(live)) = self.states.remove(&operation_id) else {
-            return vec![];
-        };
-        if live.owner_request_id != owner_request_id {
-            self.states.insert(operation_id, OperationState::Live(live));
-            return vec![];
-        }
-        for waiter in &live.waiters {
-            self.request_to_operation.remove(waiter);
-        }
-        let waiters = live.waiters.clone();
-        let next = if live.stored.retry.persist {
-            OperationState::Indeterminate(live.stored)
-        } else {
-            OperationState::Released(live.stored)
-        };
-        self.states.insert(operation_id, next);
-        waiters
-    }
-
-    fn cancel(&mut self, request_id: RequestId) -> OperationCancel {
-        let Some(operation_id) = self.request_to_operation.get(&request_id).copied() else {
-            return OperationCancel::None;
-        };
-        let Some(OperationState::Live(live)) = self.states.get_mut(&operation_id) else {
-            self.request_to_operation.remove(&request_id);
-            return OperationCancel::None;
-        };
-
-        if live.stored.retry.persist {
-            live.waiters.retain(|candidate| *candidate != request_id);
-            self.request_to_operation.remove(&request_id);
-            return OperationCancel::DetachOnly;
-        }
-
-        let Some(OperationState::Live(live)) = self.states.remove(&operation_id) else {
-            return OperationCancel::None;
-        };
-        for waiter in &live.waiters {
-            self.request_to_operation.remove(waiter);
-        }
-        let waiters = live.waiters.clone();
-        self.states
-            .insert(operation_id, OperationState::Released(live.stored));
-        OperationCancel::Release {
-            owner_request_id: live.owner_request_id,
-            waiters,
-        }
-    }
-}
 
 struct DriverShared {
     pending_responses: SyncMutex<BTreeMap<RequestId, ResponseSlot>>,
     request_ids: SyncMutex<IdAllocator<RequestId>>,
     next_operation_id: AtomicU64,
-    operations: Arc<SyncMutex<OperationRegistry>>,
+    operations: Arc<dyn OperationStore>,
 }
 
 struct CallerDropGuard {
@@ -291,7 +51,7 @@ pub struct DriverReplySink {
     request_id: RequestId,
     retry: roam_types::RetryPolicy,
     operation_id: Option<u64>,
-    operations: Option<Arc<SyncMutex<OperationRegistry>>>,
+    operations: Option<Arc<dyn OperationStore>>,
 }
 
 fn send_encoded_response(
@@ -317,11 +77,8 @@ impl ReplySink for DriverReplySink {
             let encoded_response: Arc<[u8]> = facet_postcard::to_vec(&response)
                 .expect("serialize operation response")
                 .into();
-            let waiters = operations.lock().seal(
-                operation_id,
-                self.request_id,
-                Arc::clone(&encoded_response),
-            );
+            let waiters =
+                operations.seal(operation_id, self.request_id, Arc::clone(&encoded_response));
             for waiter in waiters {
                 if send_encoded_response(sender.clone(), waiter, Arc::clone(&encoded_response))
                     .await
@@ -342,9 +99,7 @@ impl Drop for DriverReplySink {
             if let (Some(operation_id), Some(operations)) =
                 (self.operation_id, self.operations.take())
             {
-                let waiters = operations
-                    .lock()
-                    .fail_without_reply(operation_id, self.request_id);
+                let waiters = operations.fail_without_reply(operation_id, self.request_id);
                 let disposition = if self.retry.persist {
                     FailureDisposition::Indeterminate
                 } else {
@@ -518,6 +273,14 @@ pub struct Driver<H: Handler<DriverReplySink>> {
 
 impl<H: Handler<DriverReplySink>> Driver<H> {
     pub fn new(handle: ConnectionHandle, handler: H) -> Self {
+        Self::with_operation_store(handle, handler, Arc::new(InMemoryOperationStore::default()))
+    }
+
+    pub fn with_operation_store(
+        handle: ConnectionHandle,
+        handler: H,
+        operation_store: Arc<dyn OperationStore>,
+    ) -> Self {
         let conn_id = handle.connection_id();
         let ConnectionHandle {
             sender,
@@ -541,10 +304,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
                 pending_responses: SyncMutex::new("driver.pending_responses", BTreeMap::new()),
                 request_ids: SyncMutex::new("driver.request_ids", IdAllocator::new(parity)),
                 next_operation_id: AtomicU64::new(1),
-                operations: Arc::new(SyncMutex::new(
-                    "driver.operations",
-                    OperationRegistry::default(),
-                )),
+                operations: operation_store,
             }),
             peer_supports_retry,
             in_flight_handlers: BTreeMap::new(),
@@ -646,7 +406,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
                         panic!("incoming request payload should always be incoming bytes")
                     }
                 };
-                match self.shared.operations.lock().admit(
+                match self.shared.operations.admit(
                     operation_id,
                     call.method_id,
                     args,
@@ -727,7 +487,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
                 let _: Result<(), _> = tx.send(msg);
             }
         } else if is_cancel {
-            match self.shared.operations.lock().cancel(req_id) {
+            match self.shared.operations.cancel(req_id) {
                 OperationCancel::None => {
                     let should_abort = self
                         .in_flight_handlers

--- a/rust/roam/src/lib.rs
+++ b/rust/roam/src/lib.rs
@@ -91,6 +91,9 @@ pub use roam_types::{
 #[cfg(feature = "runtime")]
 pub use roam_core::*;
 
+#[cfg(feature = "runtime")]
+pub use roam_core::{InMemoryOperationStore, OperationAdmit, OperationCancel, OperationStore};
+
 // Channel binding is only available on non-wasm32 targets
 #[cfg(not(target_arch = "wasm32"))]
 pub use roam_types::{bind_channels_callee_args, bind_channels_caller_args};

--- a/typescript/peer-server/src/main.rs
+++ b/typescript/peer-server/src/main.rs
@@ -5,11 +5,13 @@
 //! provide a real roam peer for the TypeScript client to talk to.
 
 use roam::{Rx, Tx};
-use roam_core::acceptor_transport;
+use roam_core::{SessionAcceptOutcome, SessionRegistry, acceptor_transport};
 use roam_websocket::WsLink;
 use spec_proto::{Canvas, Color, LookupError, MathError, Message, Person, Point, Rectangle, Shape};
 use spec_proto::{Testbed, TestbedClient, TestbedDispatcher};
 use std::env;
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::TcpListener;
 
 #[derive(Clone)]
@@ -17,6 +19,9 @@ struct TestbedService;
 
 impl Testbed for TestbedService {
     async fn echo(&self, message: String) -> String {
+        if message == "__roam_reconnect__" {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
         message
     }
 
@@ -144,6 +149,8 @@ async fn main() {
     // Print port on stdout for Playwright to parse
     println!("{}", port);
 
+    let registry = Arc::new(SessionRegistry::default());
+
     loop {
         let (stream, peer) = match listener.accept().await {
             Ok(conn) => conn,
@@ -154,6 +161,7 @@ async fn main() {
         };
 
         eprintln!("New connection from {}", peer);
+        let registry = Arc::clone(&registry);
 
         tokio::spawn(async move {
             let ws_link = match WsLink::server(stream).await {
@@ -164,8 +172,9 @@ async fn main() {
                 }
             };
 
-            let (root_caller_guard, _sh) = match acceptor_transport(ws_link)
-                .establish::<TestbedClient>(TestbedDispatcher::new(TestbedService))
+            let accepted = match acceptor_transport(ws_link)
+                .session_registry((*registry).clone())
+                .establish_or_resume::<TestbedClient>(TestbedDispatcher::new(TestbedService))
                 .await
             {
                 Ok(v) => v,
@@ -175,9 +184,16 @@ async fn main() {
                 }
             };
 
-            eprintln!("Connection established with {}", peer);
-            let _root_caller_guard = root_caller_guard;
-            std::future::pending::<()>().await;
+            match accepted {
+                SessionAcceptOutcome::Established(root_caller_guard, _sh) => {
+                    eprintln!("Connection established with {}", peer);
+                    let _root_caller_guard = root_caller_guard;
+                    std::future::pending::<()>().await;
+                }
+                SessionAcceptOutcome::Resumed => {
+                    eprintln!("Connection resumed with {}", peer);
+                }
+            }
         });
     }
 }

--- a/typescript/tests/browser/src/main.ts
+++ b/typescript/tests/browser/src/main.ts
@@ -3,14 +3,16 @@
 // This test connects to a Rust WebSocket server and makes RPC calls
 // using generated client code for the Testbed service.
 
-import { channel } from "@bearcove/roam-core";
+import { channel, session, type LinkAttachment, type LinkSource } from "@bearcove/roam-core";
 import { connectTestbed, TestbedClient } from "@bearcove/roam-generated/testbed.ts";
+import { WsLink, WsLinkSource } from "@bearcove/roam-ws";
 
 // Make test results available to Playwright
 declare global {
   interface Window {
     testResults: TestResult[];
     runTests: (wsUrl: string) => Promise<void>;
+    runReconnectTest: (wsUrl: string) => Promise<void>;
     testsComplete: boolean;
   }
 }
@@ -41,6 +43,25 @@ function addResult(name: string, passed: boolean, error?: string) {
     div.className = passed ? "pass" : "fail";
     div.textContent = `${passed ? "PASS" : "FAIL"}: ${name}${error ? ` - ${error}` : ""}`;
     resultsDiv.appendChild(div);
+  }
+}
+
+class TrackingWsLinkSource implements LinkSource<WsLink> {
+  private readonly inner: WsLinkSource;
+  currentLink: WsLink | null = null;
+
+  constructor(url: string) {
+    this.inner = new WsLinkSource(url);
+  }
+
+  async nextLink(): Promise<LinkAttachment<WsLink>> {
+    const attachment = await this.inner.nextLink();
+    this.currentLink = attachment.link;
+    return attachment;
+  }
+
+  closeCurrentLink(): void {
+    this.currentLink?.close();
   }
 }
 
@@ -486,9 +507,46 @@ async function runTests(wsUrl: string): Promise<void> {
 
 window.runTests = runTests;
 
+async function runReconnectTest(wsUrl: string): Promise<void> {
+  log(`Connecting to ${wsUrl} with reconnect test...`);
+
+  try {
+    const source = new TrackingWsLinkSource(wsUrl);
+    const established = await session.initiator(source, { transport: "bare" });
+    const client = new TestbedClient(established.rootConnection().caller());
+
+    log("Starting delayed echo call...");
+    const delayedEcho = client.echo("__roam_reconnect__");
+
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 50));
+    log("Dropping active WebSocket during in-flight call...");
+    source.closeCurrentLink();
+
+    const result = await delayedEcho;
+    if (result !== "__roam_reconnect__") {
+      throw new Error(`Reconnect echo mismatch: expected __roam_reconnect__, got ${result}`);
+    }
+    addResult("reconnects and resumes in-flight echo", true);
+    log("Reconnect test passed!");
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e);
+    log(`Error: ${error}`);
+    addResult("reconnect", false, error);
+  }
+
+  window.testsComplete = true;
+}
+
+window.runReconnectTest = runReconnectTest;
+
 // Auto-run if WS_URL is in the URL hash
 const urlParams = new URLSearchParams(window.location.search);
 const wsUrl = urlParams.get("ws");
+const scenario = urlParams.get("scenario");
 if (wsUrl) {
-  runTests(wsUrl);
+  if (scenario === "reconnect") {
+    runReconnectTest(wsUrl);
+  } else {
+    runTests(wsUrl);
+  }
 }

--- a/typescript/tests/playwright/ws-ts.spec.ts
+++ b/typescript/tests/playwright/ws-ts.spec.ts
@@ -114,3 +114,37 @@ test("browser can connect to Rust WebSocket server and call echo methods", async
     expect(result.passed, `Test "${result.name}" failed: ${result.error}`).toBe(true);
   }
 });
+
+test("browser reconnects and resumes an in-flight WebSocket call", async ({ page }) => {
+  page.on("console", (msg) => {
+    console.log(`[browser ${msg.type()}] ${msg.text()}`);
+  });
+
+  page.on("pageerror", (err) => {
+    console.log(`[browser pageerror] ${err.message}`);
+  });
+
+  page.on("requestfailed", (req) => {
+    console.log(`[browser requestfailed] ${req.url()} - ${req.failure()?.errorText}`);
+  });
+
+  console.log(`Navigating to reconnect test page (vite=${vitePort}, ws=${wsPort})...`);
+  await page.goto(
+    `http://127.0.0.1:${vitePort}/?ws=ws://127.0.0.1:${wsPort}&scenario=reconnect`,
+    { waitUntil: "networkidle" },
+  );
+  console.log("Navigation complete, waiting for reconnect testsComplete...");
+
+  await page.waitForFunction(() => (window as any).testsComplete === true, { timeout: 10000 });
+  console.log("reconnect testsComplete is true");
+
+  const results = await page.evaluate(() => (window as any).testResults);
+  console.log("Reconnect test results:", results);
+
+  expect(results).toBeInstanceOf(Array);
+  expect(results.length).toBeGreaterThan(0);
+
+  for (const result of results) {
+    expect(result.passed, `Test "${result.name}" failed: ${result.error}`).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary
- add a pluggable Rust operation store seam with an in-memory default
- add acceptor-side session registry routing so resumed inbound transports can reattach to existing sessions
- cover browser WebSocket reconnect/resume end to end with a Playwright test against the Rust peer server

## Validation
- cargo check -p peer-server
- cargo nextest run -p roam-core resumable_acceptor_registry_keeps_pending_call_alive_across_auto_resume
- pnpm --filter @bearcove/roam-browser-tests build
- cd typescript/tests/playwright && pnpm exec playwright test ws-ts.spec.ts
- cargo nextest run -p roam-core builder_uses_custom_operation_store caller_injects_operation_id_when_peer_supports_retry duplicate_operation_id_attaches_live_and_replays_sealed_outcome
- cargo check -p roam-core -p roam --all-targets
- cargo check -p roam-core --target wasm32-unknown-unknown