### PR TITLE
chore: bump facet and facet-core to 0.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -247,22 +247,22 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "color-backtrace"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308329d5d62e877ba02943db3a8e8c052de9fde7ab48283395ba0e6494efbabd"
+checksum = "83c39683d44e712e45134c852c21c2f60139c3846047c9dde39cddf7066c78c6"
 dependencies = [
  "backtrace",
  "btparse",
@@ -463,6 +463,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -762,13 +771,24 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.44.3"
+version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa60b7d3d49d30f477f9490b7fc3ce42009b5b626b625b0356742884c493a11"
+checksum = "c78066af2cc259674a54fef24323f6081ae54a5f3a3fb53b995af7a867041c81"
 dependencies = [
  "autocfg",
- "facet-core",
- "facet-macros",
+ "facet-core 0.44.4",
+ "facet-macros 0.44.4",
+]
+
+[[package]]
+name = "facet"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46910314e20bd63a1da33c9bfcf7c0890f0d4f0991cd36dd2e092c315d0d4fc5"
+dependencies = [
+ "autocfg",
+ "facet-core 0.45.0",
+ "facet-macros 0.45.0",
  "facet-reflect",
 ]
 
@@ -779,7 +799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1dfe5ee67dafa3ee39af19b47e0da41337f72e7e0e841f4400dec966b8cafa8"
 dependencies = [
  "camino",
- "facet",
+ "facet 0.44.5",
  "facet-error",
  "facet-format",
  "facet-reflect",
@@ -791,16 +811,16 @@ dependencies = [
 name = "facet-cbor"
 version = "0.3.1"
 dependencies = [
- "facet",
- "facet-core",
+ "facet 0.45.0",
+ "facet-core 0.45.0",
  "facet-reflect",
 ]
 
 [[package]]
 name = "facet-core"
-version = "0.44.3"
+version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f9ee47507f15c18243a8cba3b2a85b71176173f0097e9164a54dd4e4e3e4ce"
+checksum = "04625a816bc27bb757b5f62ec17a228b90c08631f579ee0b36eccd6c426df207"
 dependencies = [
  "autocfg",
  "camino",
@@ -811,31 +831,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "facet-dessert"
-version = "0.44.5"
+name = "facet-core"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb18a3e7ee90139051f679390662ae158439c1564b73b482676b9a3862d13c0"
+checksum = "b2db98936341a13f724a39d7084d4c4e424f7aa292ba33d3d42075515b539a02"
 dependencies = [
- "facet-core",
+ "autocfg",
+ "camino",
+ "const-fnv1a-hash",
+ "iddqd",
+ "impls",
+]
+
+[[package]]
+name = "facet-dessert"
+version = "0.44.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "166863742c9c15ebab407e9dc0a03a92bf162434e39b36c1a7359dcdea1826ba"
+dependencies = [
+ "facet-core 0.45.0",
  "facet-reflect",
 ]
 
 [[package]]
 name = "facet-error"
-version = "0.44.3"
+version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ad09f4efc4d87eaa1122dbd194caac256ce0c4002b799ffe3f346cdc1ad01"
+checksum = "afd603e1fb7e6100d33e8f774f7b385c6c50ef9473e754192d592caed7db953e"
 dependencies = [
- "facet",
+ "facet 0.45.0",
 ]
 
 [[package]]
 name = "facet-format"
-version = "0.44.5"
+version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87b44b7183a982f8c9889b7ec50bf8f1a38318a77069084436cc908bb1e5e96"
+checksum = "67f3c5491b2b781f9ec7fb36ab9a41783b7bd35b60adbf9ab2de41ca52c7412f"
 dependencies = [
- "facet-core",
+ "facet-core 0.45.0",
  "facet-dessert",
  "facet-path",
  "facet-reflect",
@@ -844,12 +877,12 @@ dependencies = [
 
 [[package]]
 name = "facet-json"
-version = "0.44.5"
+version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81791a228a3d57e2e982430f92ad2a219feaca8f21234316a830246594f64e84"
+checksum = "a17eaa68efb270cd7d687cf2695c8ba4c509c495fa8456473d65b535a5a6bd22"
 dependencies = [
- "facet",
- "facet-core",
+ "facet 0.45.0",
+ "facet-core 0.45.0",
  "facet-format",
  "facet-reflect",
  "memchr",
@@ -857,20 +890,42 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.44.3"
+version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77becc35b3b3008e7b3ef23356954e46561177316aff0a92c73fc6ddb2a15a0"
+checksum = "a288cd230608b4d7e89b307f85be2029f265e27dcdc565a2ae5358d0c4e53f57"
 dependencies = [
- "facet-macro-types",
+ "facet-macro-types 0.44.4",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "facet-macro-parse"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0bc71a940273cdd2c49b7edfcd8d3c7533626564191040e499c3f3281fb501"
+dependencies = [
+ "facet-macro-types 0.45.0",
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
 name = "facet-macro-types"
-version = "0.44.3"
+version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e600db5983cdad99db3b34adfa20b546d80f21ab8feecd35d40bbbfbcf53b5c"
+checksum = "9c805b7f1ad4bba14e1dba5c67ef810bf9eef2373364fe3916af1d08a5411296"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unsynn",
+]
+
+[[package]]
+name = "facet-macro-types"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e57f79de57ee5c62a9ca30b29af692a5f895b417abdd07a4f232ca3fd245ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -879,21 +934,44 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.44.3"
+version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a7015e119aa043740dc8aee6b1b70e26b6616e1701b329496bf04990f44133"
+checksum = "e0cc46a94a2725e82f2c0095bac16665057c24d7f4f11169a7a879dbcba81d8f"
 dependencies = [
- "facet-macros-impl",
+ "facet-macros-impl 0.44.4",
+]
+
+[[package]]
+name = "facet-macros"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ad6e39347d3fb386c383602789eab42c45a73bce69af7033b2177c0124e58"
+dependencies = [
+ "facet-macros-impl 0.45.0",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.44.3"
+version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb5e6f6cc64210ab12aa625b014db78d34d6a3b63d1011382c141518a1e1f78"
+checksum = "1af13fd5dfa728cc48418cf33cbcfc0d5cfdbaaf22a3d0f5229da4b1e5669fa5"
 dependencies = [
- "facet-macro-parse",
- "facet-macro-types",
+ "facet-macro-parse 0.44.4",
+ "facet-macro-types 0.44.4",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "unsynn",
+]
+
+[[package]]
+name = "facet-macros-impl"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbc1ff57009b55acadad1fbb9d7c601b6215188f2e892f5d7fa1528f12b320"
+dependencies = [
+ "facet-macro-parse 0.45.0",
+ "facet-macro-types 0.45.0",
  "proc-macro2",
  "quote",
  "strsim",
@@ -902,21 +980,21 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.44.3"
+version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e7b83cb0de7c00d6e76f08d36b047d6cb9efc39e10744dbcf7a4a5a19c4903"
+checksum = "8985e3025f0d03eb3cdfaca8dd9eb002c64ff775c273666dfb98c88ba39b541d"
 dependencies = [
- "facet-core",
+ "facet-core 0.45.0",
 ]
 
 [[package]]
 name = "facet-postcard"
-version = "0.44.5"
+version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7578186a9babca46fe08118e9a856b1ef158ae24b3a7a551926273ad1ad5e52a"
+checksum = "a4b1c04b07a2b9ceaf68cbc39937a6f80713eb7c90515995b720031afa023c65"
 dependencies = [
  "camino",
- "facet-core",
+ "facet-core 0.45.0",
  "facet-format",
  "facet-path",
  "facet-reflect",
@@ -926,35 +1004,35 @@ dependencies = [
 
 [[package]]
 name = "facet-pretty"
-version = "0.44.4"
+version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b93416595a402722978717593f38b3d51ab17b5cc1d914305b1758f02651ead"
+checksum = "a0643d9635979d589ad7a2ca6f02ee67287638ff66d0345fca6410c7c65f489c"
 dependencies = [
- "facet-core",
+ "facet-core 0.45.0",
  "facet-reflect",
  "owo-colors",
 ]
 
 [[package]]
 name = "facet-reflect"
-version = "0.44.3"
+version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cc255bd928399489868fdddec09e69073d622432cc2b52cfa3c3a5d811305c"
+checksum = "f4dbe613d1597c4875c5920d09acff9f2b0f53ca05c9260e4169adccc64edee8"
 dependencies = [
- "facet-core",
+ "facet-core 0.45.0",
  "facet-path",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "regex",
  "smallvec 2.0.0-alpha.12",
 ]
 
 [[package]]
 name = "facet-solver"
-version = "0.44.3"
+version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d2427360875510d60267f4bb132f47aa4f5714896be9ca11c516f14542118d"
+checksum = "bfd6d0a78d837f78c0c896577ac75ffc2efa39a5ce858782f84e23efb585077f"
 dependencies = [
- "facet-core",
+ "facet-core 0.45.0",
  "facet-reflect",
  "strsim",
 ]
@@ -984,11 +1062,11 @@ dependencies = [
 
 [[package]]
 name = "facet-toml"
-version = "0.44.5"
+version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9e781ae29e06f148fafa48c418c12666736bb5538246b4a7682431c0fe17c9"
+checksum = "d678c47260c93fcbf8adc69de7f91686227a41818a4a2826be1b5271840281a7"
 dependencies = [
- "facet-core",
+ "facet-core 0.45.0",
  "facet-format",
  "facet-reflect",
  "toml_parser",
@@ -996,11 +1074,11 @@ dependencies = [
 
 [[package]]
 name = "facet-value"
-version = "0.44.5"
+version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edd5a4a2cb835ea6e0fc5a896a105505ddbde1bc1fa1e7e7f38bcc639eec5d8"
+checksum = "98ff71b0d84ea0acd6fc2cc0a10931284d354100fb513e4fc8f5abf1127a5ff2"
 dependencies = [
- "facet-core",
+ "facet-core 0.45.0",
  "facet-format",
  "facet-reflect",
  "indexmap",
@@ -1008,20 +1086,20 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "figue"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33f286df173a047e864b39279b14de5e08dc5c7c5c719f81e96a8602049d4dd"
+checksum = "b0ffdb761cf6aa5298efdef8ae22dac4057d492f85e1e7434864eb1ccbcfeae5"
 dependencies = [
  "ariadne",
  "camino",
- "facet",
- "facet-core",
+ "facet 0.44.5",
+ "facet-core 0.44.4",
  "facet-error",
  "facet-format",
  "facet-json",
@@ -1040,11 +1118,11 @@ dependencies = [
 
 [[package]]
 name = "figue-attrs"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09be1cd2a5c7295aa5dae9dd5585db38b3ab59c751336ebd4d692b867415703"
+checksum = "a95509cd6139af9c281d9e4f163db7fce0da7101102ac555e677937248437e58"
 dependencies = [
- "facet",
+ "facet 0.44.5",
 ]
 
 [[package]]
@@ -1313,6 +1391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
@@ -1410,9 +1497,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1425,7 +1512,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec 1.15.1",
  "tokio",
  "want",
@@ -1466,12 +1552,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1479,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1492,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1506,15 +1593,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1526,15 +1613,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1599,12 +1686,12 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1624,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.1"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99322078b2c076829a1db959d49da554fabc4342257fc0ba5a070a1eb3a01cd8"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console 0.16.3",
  "once_cell",
@@ -1690,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1714,9 +1801,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1726,9 +1813,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1831,7 +1918,7 @@ version = "1.0.0"
 source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
  "ctor",
- "facet",
+ "facet 0.44.5",
  "facet-json",
  "facet-value",
  "moire-trace-capture",
@@ -1866,7 +1953,7 @@ name = "moire-trace-types"
 version = "1.0.0"
 source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
- "facet",
+ "facet 0.44.5",
 ]
 
 [[package]]
@@ -1874,7 +1961,7 @@ name = "moire-types"
 version = "1.0.0"
 source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
- "facet",
+ "facet 0.44.5",
  "facet-value",
  "moire-trace-types",
 ]
@@ -1899,7 +1986,7 @@ name = "moire-wire"
 version = "1.0.0"
 source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
 dependencies = [
- "facet",
+ "facet 0.44.5",
  "facet-json",
  "moire-trace-types",
  "moire-types",
@@ -2032,7 +2119,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror",
 ]
 
@@ -2182,12 +2269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,9 +2276,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2347,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2456,7 +2537,7 @@ name = "rust-examples"
 version = "0.3.1"
 dependencies = [
  "eyre",
- "facet",
+ "facet 0.45.0",
  "hdrhistogram",
  "indicatif",
  "serde",
@@ -2498,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2531,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2561,9 +2642,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -2621,7 +2702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2717,7 +2798,7 @@ dependencies = [
 name = "spec-proto"
 version = "0.2.2"
 dependencies = [
- "facet",
+ "facet 0.45.0",
  "vox",
 ]
 
@@ -3134,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3144,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -3161,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3219,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -3430,7 +3511,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror",
  "utf-8",
@@ -3549,7 +3630,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vox"
 version = "0.3.1"
 dependencies = [
- "facet",
+ "facet 0.45.0",
  "facet-pretty",
  "facet-reflect",
  "moire",
@@ -3574,7 +3655,7 @@ name = "vox-bench"
 version = "0.3.1"
 dependencies = [
  "divan",
- "facet",
+ "facet 0.45.0",
  "futures-util",
  "hyper-util",
  "moire",
@@ -3599,9 +3680,9 @@ dependencies = [
 name = "vox-codegen"
 version = "0.3.1"
 dependencies = [
- "facet",
+ "facet 0.45.0",
  "facet-cbor",
- "facet-core",
+ "facet-core 0.45.0",
  "heck",
  "vox",
  "vox-types",
@@ -3611,9 +3692,9 @@ dependencies = [
 name = "vox-core"
 version = "0.3.1"
 dependencies = [
- "facet",
+ "facet 0.45.0",
  "facet-cbor",
- "facet-core",
+ "facet-core 0.45.0",
  "facet-error",
  "facet-reflect",
  "facet-testhelpers",
@@ -3691,8 +3772,8 @@ dependencies = [
 name = "vox-postcard"
 version = "0.3.1"
 dependencies = [
- "facet",
- "facet-core",
+ "facet 0.45.0",
+ "facet-core 0.45.0",
  "facet-postcard",
  "facet-reflect",
  "vox-schema",
@@ -3704,9 +3785,9 @@ name = "vox-schema"
 version = "0.3.1"
 dependencies = [
  "blake3",
- "facet",
+ "facet 0.45.0",
  "facet-cbor",
- "facet-core",
+ "facet-core 0.45.0",
  "indexmap",
 ]
 
@@ -3736,9 +3817,9 @@ version = "0.3.1"
 dependencies = [
  "bitflags",
  "blake3",
- "facet",
+ "facet 0.45.0",
  "facet-cbor",
- "facet-core",
+ "facet-core 0.45.0",
  "facet-path",
  "facet-reflect",
  "futures-channel",
@@ -3812,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3825,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3835,9 +3916,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3845,9 +3926,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3858,9 +3939,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3926,9 +4007,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4127,9 +4208,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
@@ -4221,9 +4302,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xshell"
@@ -4245,7 +4326,7 @@ name = "xtask"
 version = "0.2.2"
 dependencies = [
  "dprint-plugin-typescript",
- "facet",
+ "facet 0.45.0",
  "facet-cbor",
  "figue",
  "prettyplease",
@@ -4266,9 +4347,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4277,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4309,18 +4390,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4336,9 +4417,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4347,9 +4428,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4358,9 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,35 +771,24 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.44.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78066af2cc259674a54fef24323f6081ae54a5f3a3fb53b995af7a867041c81"
-dependencies = [
- "autocfg",
- "facet-core 0.44.4",
- "facet-macros 0.44.4",
-]
-
-[[package]]
-name = "facet"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46910314e20bd63a1da33c9bfcf7c0890f0d4f0991cd36dd2e092c315d0d4fc5"
 dependencies = [
  "autocfg",
- "facet-core 0.45.0",
- "facet-macros 0.45.0",
+ "facet-core",
+ "facet-macros",
  "facet-reflect",
 ]
 
 [[package]]
 name = "facet-cargo-toml"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dfe5ee67dafa3ee39af19b47e0da41337f72e7e0e841f4400dec966b8cafa8"
+checksum = "e7ce9a6b794ea45ff379071e48b0f1825793fc2b140fa49d79cc3364d9371793"
 dependencies = [
  "camino",
- "facet 0.44.5",
+ "facet",
  "facet-error",
  "facet-format",
  "facet-reflect",
@@ -811,23 +800,9 @@ dependencies = [
 name = "facet-cbor"
 version = "0.3.1"
 dependencies = [
- "facet 0.45.0",
- "facet-core 0.45.0",
+ "facet",
+ "facet-core",
  "facet-reflect",
-]
-
-[[package]]
-name = "facet-core"
-version = "0.44.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04625a816bc27bb757b5f62ec17a228b90c08631f579ee0b36eccd6c426df207"
-dependencies = [
- "autocfg",
- "camino",
- "const-fnv1a-hash",
- "iddqd",
- "impls",
- "indexmap",
 ]
 
 [[package]]
@@ -841,6 +816,7 @@ dependencies = [
  "const-fnv1a-hash",
  "iddqd",
  "impls",
+ "indexmap",
 ]
 
 [[package]]
@@ -849,7 +825,7 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "166863742c9c15ebab407e9dc0a03a92bf162434e39b36c1a7359dcdea1826ba"
 dependencies = [
- "facet-core 0.45.0",
+ "facet-core",
  "facet-reflect",
 ]
 
@@ -859,7 +835,7 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afd603e1fb7e6100d33e8f774f7b385c6c50ef9473e754192d592caed7db953e"
 dependencies = [
- "facet 0.45.0",
+ "facet",
 ]
 
 [[package]]
@@ -868,7 +844,7 @@ version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67f3c5491b2b781f9ec7fb36ab9a41783b7bd35b60adbf9ab2de41ca52c7412f"
 dependencies = [
- "facet-core 0.45.0",
+ "facet-core",
  "facet-dessert",
  "facet-path",
  "facet-reflect",
@@ -881,22 +857,11 @@ version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17eaa68efb270cd7d687cf2695c8ba4c509c495fa8456473d65b535a5a6bd22"
 dependencies = [
- "facet 0.45.0",
- "facet-core 0.45.0",
+ "facet",
+ "facet-core",
  "facet-format",
  "facet-reflect",
  "memchr",
-]
-
-[[package]]
-name = "facet-macro-parse"
-version = "0.44.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a288cd230608b4d7e89b307f85be2029f265e27dcdc565a2ae5358d0c4e53f57"
-dependencies = [
- "facet-macro-types 0.44.4",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -905,20 +870,9 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0bc71a940273cdd2c49b7edfcd8d3c7533626564191040e499c3f3281fb501"
 dependencies = [
- "facet-macro-types 0.45.0",
+ "facet-macro-types",
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "facet-macro-types"
-version = "0.44.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c805b7f1ad4bba14e1dba5c67ef810bf9eef2373364fe3916af1d08a5411296"
-dependencies = [
- "proc-macro2",
- "quote",
- "unsynn",
 ]
 
 [[package]]
@@ -934,34 +888,11 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.44.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cc46a94a2725e82f2c0095bac16665057c24d7f4f11169a7a879dbcba81d8f"
-dependencies = [
- "facet-macros-impl 0.44.4",
-]
-
-[[package]]
-name = "facet-macros"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ad6e39347d3fb386c383602789eab42c45a73bce69af7033b2177c0124e58"
 dependencies = [
- "facet-macros-impl 0.45.0",
-]
-
-[[package]]
-name = "facet-macros-impl"
-version = "0.44.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1af13fd5dfa728cc48418cf33cbcfc0d5cfdbaaf22a3d0f5229da4b1e5669fa5"
-dependencies = [
- "facet-macro-parse 0.44.4",
- "facet-macro-types 0.44.4",
- "proc-macro2",
- "quote",
- "strsim",
- "unsynn",
+ "facet-macros-impl",
 ]
 
 [[package]]
@@ -970,8 +901,8 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbc1ff57009b55acadad1fbb9d7c601b6215188f2e892f5d7fa1528f12b320"
 dependencies = [
- "facet-macro-parse 0.45.0",
- "facet-macro-types 0.45.0",
+ "facet-macro-parse",
+ "facet-macro-types",
  "proc-macro2",
  "quote",
  "strsim",
@@ -984,7 +915,7 @@ version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8985e3025f0d03eb3cdfaca8dd9eb002c64ff775c273666dfb98c88ba39b541d"
 dependencies = [
- "facet-core 0.45.0",
+ "facet-core",
 ]
 
 [[package]]
@@ -994,7 +925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b1c04b07a2b9ceaf68cbc39937a6f80713eb7c90515995b720031afa023c65"
 dependencies = [
  "camino",
- "facet-core 0.45.0",
+ "facet-core",
  "facet-format",
  "facet-path",
  "facet-reflect",
@@ -1008,7 +939,7 @@ version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0643d9635979d589ad7a2ca6f02ee67287638ff66d0345fca6410c7c65f489c"
 dependencies = [
- "facet-core 0.45.0",
+ "facet-core",
  "facet-reflect",
  "owo-colors",
 ]
@@ -1019,7 +950,7 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4dbe613d1597c4875c5920d09acff9f2b0f53ca05c9260e4169adccc64edee8"
 dependencies = [
- "facet-core 0.45.0",
+ "facet-core",
  "facet-path",
  "hashbrown 0.17.0",
  "regex",
@@ -1032,7 +963,7 @@ version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd6d0a78d837f78c0c896577ac75ffc2efa39a5ce858782f84e23efb585077f"
 dependencies = [
- "facet-core 0.45.0",
+ "facet-core",
  "facet-reflect",
  "strsim",
 ]
@@ -1066,7 +997,7 @@ version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d678c47260c93fcbf8adc69de7f91686227a41818a4a2826be1b5271840281a7"
 dependencies = [
- "facet-core 0.45.0",
+ "facet-core",
  "facet-format",
  "facet-reflect",
  "toml_parser",
@@ -1078,7 +1009,7 @@ version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff71b0d84ea0acd6fc2cc0a10931284d354100fb513e4fc8f5abf1127a5ff2"
 dependencies = [
- "facet-core 0.45.0",
+ "facet-core",
  "facet-format",
  "facet-reflect",
  "indexmap",
@@ -1092,14 +1023,14 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "figue"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ffdb761cf6aa5298efdef8ae22dac4057d492f85e1e7434864eb1ccbcfeae5"
+checksum = "1f5806cb9b80e1a41a43c6c01da5c9e7213105a93cc9781b88206c42070499d3"
 dependencies = [
  "ariadne",
  "camino",
- "facet 0.44.5",
- "facet-core 0.44.4",
+ "facet",
+ "facet-core",
  "facet-error",
  "facet-format",
  "facet-json",
@@ -1118,11 +1049,11 @@ dependencies = [
 
 [[package]]
 name = "figue-attrs"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95509cd6139af9c281d9e4f163db7fce0da7101102ac555e677937248437e58"
+checksum = "2c36c03791c4eddba0b7e6126d48c7c5fdb38b1d616e8943e4d9ddb6e8001400"
 dependencies = [
- "facet 0.44.5",
+ "facet",
 ]
 
 [[package]]
@@ -1889,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "moire"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 dependencies = [
  "moire-macros",
  "moire-macros-noop",
@@ -1900,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "moire-macros"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1910,15 +1841,15 @@ dependencies = [
 [[package]]
 name = "moire-macros-noop"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 
 [[package]]
 name = "moire-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 dependencies = [
  "ctor",
- "facet 0.44.5",
+ "facet",
  "facet-json",
  "facet-value",
  "moire-trace-capture",
@@ -1931,7 +1862,7 @@ dependencies = [
 [[package]]
 name = "moire-tokio"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 dependencies = [
  "moire-runtime",
  "moire-types",
@@ -1942,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "moire-trace-capture"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 dependencies = [
  "libc",
  "moire-trace-types",
@@ -1951,17 +1882,17 @@ dependencies = [
 [[package]]
 name = "moire-trace-types"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 dependencies = [
- "facet 0.44.5",
+ "facet",
 ]
 
 [[package]]
 name = "moire-types"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 dependencies = [
- "facet 0.44.5",
+ "facet",
  "facet-value",
  "moire-trace-types",
 ]
@@ -1969,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "moire-wasm"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1984,9 +1915,9 @@ dependencies = [
 [[package]]
 name = "moire-wire"
 version = "1.0.0"
-source = "git+https://github.com/bearcove/moire?rev=13eac79#13eac79c1b128282dd792a611319d0a1016ad15d"
+source = "git+https://github.com/bearcove/moire?rev=e58c3dd#e58c3dd30bd5f0ab505aecc159e39d5ea158b764"
 dependencies = [
- "facet 0.44.5",
+ "facet",
  "facet-json",
  "moire-trace-types",
  "moire-types",
@@ -2537,7 +2468,7 @@ name = "rust-examples"
 version = "0.3.1"
 dependencies = [
  "eyre",
- "facet 0.45.0",
+ "facet",
  "hdrhistogram",
  "indicatif",
  "serde",
@@ -2798,7 +2729,7 @@ dependencies = [
 name = "spec-proto"
 version = "0.2.2"
 dependencies = [
- "facet 0.45.0",
+ "facet",
  "vox",
 ]
 
@@ -3630,7 +3561,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vox"
 version = "0.3.1"
 dependencies = [
- "facet 0.45.0",
+ "facet",
  "facet-pretty",
  "facet-reflect",
  "moire",
@@ -3655,7 +3586,7 @@ name = "vox-bench"
 version = "0.3.1"
 dependencies = [
  "divan",
- "facet 0.45.0",
+ "facet",
  "futures-util",
  "hyper-util",
  "moire",
@@ -3680,9 +3611,9 @@ dependencies = [
 name = "vox-codegen"
 version = "0.3.1"
 dependencies = [
- "facet 0.45.0",
+ "facet",
  "facet-cbor",
- "facet-core 0.45.0",
+ "facet-core",
  "heck",
  "vox",
  "vox-types",
@@ -3692,9 +3623,9 @@ dependencies = [
 name = "vox-core"
 version = "0.3.1"
 dependencies = [
- "facet 0.45.0",
+ "facet",
  "facet-cbor",
- "facet-core 0.45.0",
+ "facet-core",
  "facet-error",
  "facet-reflect",
  "facet-testhelpers",
@@ -3772,8 +3703,8 @@ dependencies = [
 name = "vox-postcard"
 version = "0.3.1"
 dependencies = [
- "facet 0.45.0",
- "facet-core 0.45.0",
+ "facet",
+ "facet-core",
  "facet-postcard",
  "facet-reflect",
  "vox-schema",
@@ -3785,9 +3716,9 @@ name = "vox-schema"
 version = "0.3.1"
 dependencies = [
  "blake3",
- "facet 0.45.0",
+ "facet",
  "facet-cbor",
- "facet-core 0.45.0",
+ "facet-core",
  "indexmap",
 ]
 
@@ -3817,9 +3748,9 @@ version = "0.3.1"
 dependencies = [
  "bitflags",
  "blake3",
- "facet 0.45.0",
+ "facet",
  "facet-cbor",
- "facet-core 0.45.0",
+ "facet-core",
  "facet-path",
  "facet-reflect",
  "futures-channel",
@@ -4326,7 +4257,7 @@ name = "xtask"
 version = "0.2.2"
 dependencies = [
  "dprint-plugin-typescript",
- "facet 0.45.0",
+ "facet",
  "facet-cbor",
  "figue",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ xshell = "0.2"
 passfd = "0.1"
 
 # facet ecosystem
-facet = { version = "0.44.3", features = ["camino", "reflect"] }
-facet-core = { version = "0.44.3" }
+facet = { version = "0.45", features = ["camino", "reflect"] }
+facet-core = { version = "0.45" }
 facet-postcard = { version = "0.44.3", features = ["camino"] }
 facet-path = { version = "0.44.3" }
 facet-reflect = { version = "0.44.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ facet-cbor = { path = "rust/facet-cbor", version = "0.3.1" }
 ur-taking-me-with-you = { path = "rust/ur-taking-me-with-you", version = "8.0.0" }
 
 # Not internal crates
-moire = { version = "1.0.0", git = "https://github.com/bearcove/moire", rev = "13eac79" }
-moire-types = { version = "1.0.0", git = "https://github.com/bearcove/moire", rev = "13eac79" }
+moire = { version = "1.0.0", git = "https://github.com/bearcove/moire", rev = "e58c3dd" }
+moire-types = { version = "1.0.0", git = "https://github.com/bearcove/moire", rev = "e58c3dd" }
 
 bitflags = "2.11.0"
 structstruck = "0.5.1"
@@ -96,7 +96,7 @@ facet-pretty = { version = "0.44.4" }
 facet-json = { version = "0.44.3" }
 facet-value = { version = "0.44.3" }
 facet-testhelpers = { version = "0.44.3" }
-facet-cargo-toml = { version = "0.44.0" }
+facet-cargo-toml = { version = "0.45" }
 facet-error = { version = "0.44.3" }
 
 # Futures utilities

--- a/rust/vox-core/src/session/mod.rs
+++ b/rust/vox-core/src/session/mod.rs
@@ -1131,6 +1131,13 @@ impl Session {
 
         loop {
             tokio::select! {
+                // biased: ensure conduit EOF is processed before any resume
+                // request. Without this, tokio's random branch selection can
+                // pick resume_rx when BOTH branches are simultaneously ready
+                // (fast client reconnect on Linux), causing the session to
+                // reject a valid resume while still in CONNECTED state.
+                biased;
+
                 msg = self.rx.recv_msg() => {
                     vox_types::dlog!("[session {:?}] recv_msg returned", self.role);
                     match msg {

--- a/swift/subject/Sources/subject-swift/Testbed.swift
+++ b/swift/subject/Sources/subject-swift/Testbed.swift
@@ -1913,13 +1913,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -1947,13 +1949,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -1993,13 +1997,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2038,13 +2044,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2079,13 +2087,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2116,13 +2126,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2153,13 +2165,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2190,13 +2204,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2235,13 +2251,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2270,13 +2288,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2306,13 +2326,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2348,13 +2370,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2385,13 +2409,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2432,13 +2458,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2499,13 +2527,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2604,13 +2634,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2653,13 +2685,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2690,13 +2724,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2730,13 +2766,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2765,13 +2803,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2798,13 +2838,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2832,13 +2874,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2869,13 +2913,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2910,13 +2956,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2947,13 +2995,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -2983,13 +3033,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3020,13 +3072,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3067,13 +3121,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3110,13 +3166,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3146,13 +3204,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3182,13 +3242,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3219,13 +3281,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3262,13 +3326,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3298,13 +3364,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3334,13 +3402,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }
@@ -3370,13 +3440,15 @@ public final class TestbedDispatcher: ServiceDispatcher {
       } catch {
         taskSender(
           .response(
-            requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
-            schemaPayload: responseSchemaPayload))
+            requestId: requestId,
+            payload: encodeInvalidPayloadError(reason: String(describing: error)),
+            methodId: methodId, schemaPayload: responseSchemaPayload))
       }
     } catch {
       taskSender(
         .response(
-          requestId: requestId, payload: encodeInvalidPayloadError(), methodId: methodId,
+          requestId: requestId,
+          payload: encodeInvalidPayloadError(reason: String(describing: error)), methodId: methodId,
           schemaPayload: responseSchemaPayload))
     }
   }


### PR DESCRIPTION
Follows upstream facet-rs/facet#2167 which bumped `facet` and `facet-core` to 0.45.

## Changes

- `facet` workspace dep: `0.44.3` → `0.45`
- `facet-core` workspace dep: `0.44.3` → `0.45`
- All other `facet-*` deps remain at their current `0.44.x` versions
- `Cargo.lock` updated (`cargo update`)

## Notes

`facet-cargo-toml` is still at `0.44.0` on crates.io and does not yet support `facet-core 0.45`, so CI will fail on crates that use it until a new version is published.