### PR TITLE
fix: publish facet-cbor 0.3.2 with facet-core = "0.45"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "facet-cbor"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "facet",
  "facet-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ vox-ffi = { path = "rust/vox-ffi", version = "0.3.1" }
 subject-rust = { path = "rust/subject-rust", version = "0.2.2" }
 spec-proto = { path = "spec/spec-proto", version = "0.2.2" }
 vox-postcard = { path = "rust/vox-postcard", version = "0.3.1" }
-facet-cbor = { path = "rust/facet-cbor", version = "0.3.1" }
+facet-cbor = { path = "rust/facet-cbor", version = "0.3.2" }
 ur-taking-me-with-you = { path = "rust/ur-taking-me-with-you", version = "8.0.0" }
 
 # Not internal crates

--- a/rust/facet-cbor/Cargo.toml
+++ b/rust/facet-cbor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-cbor"
-version.workspace = true
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Problem

Every push to main fires the release-plz **Publish** job, which tries to
publish `vox-ffi 0.3.1` (not yet on crates.io). During `cargo publish
--verify`, cargo builds `vox-ffi` in a clean sandbox and resolves its deps
from crates.io:

```
vox-ffi 0.3.1
  └── vox-types 0.3.1      (crates.io)
        └── facet-cbor 0.3.1  (crates.io, facet-core = "^0.44.3")
              ├── facet-core "^0.44.3" → resolves to 0.44.4
              └── facet-reflect "^0.44.3" → 0.44.6 → needs facet-core 0.45.x
```

Two incompatible `facet_core` versions → type mismatch → build failure.

## Fix

Bump `facet-cbor` to `0.3.2`. When the Publish job runs after this lands,
it will publish `facet-cbor 0.3.2` with `facet-core = "^0.45"` (from the
workspace dep). After that:

- `vox-types 0.3.1` has `facet-cbor = "^0.3.1"` → resolves to `0.3.2`
- `facet-cbor 0.3.2` has `facet-core = "^0.45"` → `0.45.x` only
- `facet-reflect 0.44.6` also uses `facet-core 0.45.x`
- No split, verify succeeds
