### PR TITLE
feat: vox::Fd — SCM_RIGHTS file-descriptor passing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4201,6 +4201,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "vox-core",
+ "vox-fdpass",
+ "vox-postcard",
  "vox-types",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ vox-macros-core = { path = "rust/vox-macros-core", version = "0.5.1" }
 vox-service-macros = { path = "rust/vox-macros", version = "0.5.1" }
 vox-core = { path = "rust/vox-core", version = "0.5.1" }
 vox-stream = { path = "rust/vox-stream", version = "0.5.1" }
+vox-fdpass = { path = "rust/vox-fdpass", version = "0.5.1" }
 vox-codegen = { path = "rust/vox-codegen", version = "0.5.1" }
 vox-websocket = { path = "rust/vox-websocket", version = "0.5.1" }
 vox-inprocess = { path = "rust/vox-inprocess", version = "0.5.1" }

--- a/rust/vox-core/src/bare_conduit/mod.rs
+++ b/rust/vox-core/src/bare_conduit/mod.rs
@@ -133,6 +133,7 @@ where
             },
             BareConduitRx {
                 link_rx: rx,
+                pending_fds: vox_types::FrameFds::default(),
                 #[cfg(not(target_arch = "wasm32"))]
                 decoder: self.decoder,
                 #[cfg(target_arch = "wasm32")]
@@ -154,9 +155,17 @@ pub struct BareConduitTx<F: MsgFamily, LTx: LinkTx> {
     _phantom: PhantomData<fn(F)>,
 }
 
+/// A serialized message plus the file descriptors collected while encoding
+/// it. The descriptors travel out-of-band via `SCM_RIGHTS`; off-Unix
+/// [`FrameFds`](vox_types::FrameFds) is `()`.
+pub struct PreparedFrame {
+    pub bytes: Vec<u8>,
+    pub fds: vox_types::FrameFds,
+}
+
 impl<F: MsgFamily, LTx: LinkTx + MaybeSend + 'static> ConduitTx for BareConduitTx<F, LTx> {
     type Msg = F;
-    type Prepared = Vec<u8>;
+    type Prepared = PreparedFrame;
     type Error = BareConduitError;
 
     // r[impl zerocopy.framing.single-pass]
@@ -167,20 +176,38 @@ impl<F: MsgFamily, LTx: LinkTx + MaybeSend + 'static> ConduitTx for BareConduitT
     // r[impl zerocopy.scatter.write]
     // r[impl zerocopy.scatter.lifetime]
     fn prepare_send(&self, item: F::Msg<'_>) -> Result<Self::Prepared, Self::Error> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let ptr = PtrConst::new((&raw const item).cast::<u8>());
-            vox_jit::encode_with(self.encoder, ptr).map_err(BareConduitError::Encode)
-        }
-        #[cfg(target_arch = "wasm32")]
-        {
-            vox_postcard::to_vec(&item).map_err(BareConduitError::Encode)
-        }
+        let encode = || -> Result<Vec<u8>, BareConduitError> {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let ptr = PtrConst::new((&raw const item).cast::<u8>());
+                vox_jit::encode_with(self.encoder, ptr).map_err(BareConduitError::Encode)
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                vox_postcard::to_vec(&item).map_err(BareConduitError::Encode)
+            }
+        };
+        // Collect any `Fd`s the encoder funnels into the thread-local
+        // collector — same install-around-encode shape as the channel
+        // binder (`with_channel_binder`). Off-Unix this is a pass-through
+        // and `fds` is `()`.
+        let (encoded, fds) = vox_types::collect_fds(encode);
+        Ok(PreparedFrame {
+            bytes: encoded?,
+            fds,
+        })
     }
 
     async fn send_prepared(&self, prepared: Self::Prepared) -> Result<(), Self::Error> {
+        let PreparedFrame { bytes, fds } = prepared;
+        if vox_types::frame_fds_len(&fds) > 0 && !self.link_tx.supports_fd_passing() {
+            return Err(BareConduitError::Io(std::io::Error::other(
+                "message carries file descriptors but the transport \
+                 cannot pass them",
+            )));
+        }
         self.link_tx
-            .send(prepared)
+            .send_with_fds(bytes, fds)
             .await
             .map_err(BareConduitError::Io)
     }
@@ -196,6 +223,9 @@ impl<F: MsgFamily, LTx: LinkTx + MaybeSend + 'static> ConduitTx for BareConduitT
 
 pub struct BareConduitRx<F: MsgFamily, LRx> {
     link_rx: LRx,
+    /// Descriptors that arrived with the most recently `recv`'d frame,
+    /// awaiting [`take_frame_fds`](vox_types::ConduitRx::take_frame_fds).
+    pending_fds: vox_types::FrameFds,
     #[cfg(not(target_arch = "wasm32"))]
     decoder: &'static CompiledDecoder,
     #[cfg(target_arch = "wasm32")]
@@ -220,6 +250,13 @@ where
             None => return Ok(None),
         };
 
+        // Capture this frame's descriptors. `Payload` only *borrows* its
+        // bytes during Message decode — the typed `Fd` is decoded later by
+        // the generated stub — so the fds are threaded out via
+        // `take_frame_fds` (the same rail as the schema tracker) and
+        // installed at that decode site, not here.
+        self.pending_fds = self.link_rx.take_frame_fds();
+
         #[cfg(not(target_arch = "wasm32"))]
         {
             crate::deserialize_postcard_with_decoder::<F::Msg<'static>>(backing, self.decoder)
@@ -236,6 +273,10 @@ where
             .map_err(BareConduitError::Decode)
             .map(Some)
         }
+    }
+
+    fn take_frame_fds(&mut self) -> vox_types::FrameFds {
+        std::mem::take(&mut self.pending_fds)
     }
 }
 

--- a/rust/vox-core/src/driver.rs
+++ b/rust/vox-core/src/driver.rs
@@ -50,6 +50,10 @@ use vox_types::{OperationId, PostcardPayload};
 struct PendingResponse {
     msg: SelfRef<RequestMessage<'static>>,
     schemas: Arc<vox_types::SchemaRecvTracker>,
+    /// Descriptors that arrived with the response frame, surfaced to the
+    /// caller via [`WithTracker::fds`](vox_types::WithTracker) and installed
+    /// at the typed-return decode site. `()` off-Unix.
+    fds: vox_types::FrameFds,
 }
 
 type ResponseSlot = moire::sync::oneshot::Sender<PendingResponse>;
@@ -2153,6 +2157,7 @@ impl DriverCaller {
         let PendingResponse {
             msg: response_msg,
             schemas: response_schemas,
+            fds: response_fds,
         } = pending;
         let response = response_msg.map(|m| match m.body {
             RequestBody::Response(r) => r,
@@ -2163,6 +2168,7 @@ impl DriverCaller {
         Ok(vox_types::WithTracker {
             value: response,
             tracker: response_schemas,
+            fds: response_fds,
         })
     }
 }
@@ -2725,7 +2731,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
 
     async fn handle_recv(&mut self, recv: crate::session::RecvMessage) {
         self.shared.mark_inbound_progress();
-        let crate::session::RecvMessage { schemas, msg } = recv;
+        let crate::session::RecvMessage { schemas, msg, fds } = recv;
         let msg_ref = msg.get();
         let is_request = matches!(msg_ref, ConnectionMessage::Request(_));
         if is_request {
@@ -2767,7 +2773,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
                 ConnectionMessage::Request(r) => r,
                 _ => unreachable!(),
             });
-            self.handle_request(msg, schemas);
+            self.handle_request(msg, schemas, fds);
         } else {
             let msg = msg.map(|m| match m {
                 ConnectionMessage::Channel(c) => c,
@@ -2781,6 +2787,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
         &mut self,
         msg: SelfRef<RequestMessage<'static>>,
         schemas: Arc<vox_types::SchemaRecvTracker>,
+        fds: vox_types::FrameFds,
     ) {
         let msg_ref = msg.get();
         let req_id = msg_ref.id;
@@ -2966,7 +2973,7 @@ impl<H: Handler<DriverReplySink>> Driver<H> {
             if let Some(tx) = self.shared.pending_responses.lock().remove(&req_id) {
                 vox_types::dlog!("[driver] routing response to waiter: req={:?}", req_id);
                 tracing::trace!(%req_id, "routing response to pending oneshot");
-                let _: Result<(), _> = tx.send(PendingResponse { msg, schemas });
+                let _: Result<(), _> = tx.send(PendingResponse { msg, schemas, fds });
             } else {
                 vox_types::dlog!("[driver] dropped unmatched response: req={:?}", req_id);
                 tracing::trace!(%req_id, "no pending response slot for this req_id");

--- a/rust/vox-core/src/memory_link.rs
+++ b/rust/vox-core/src/memory_link.rs
@@ -1,16 +1,27 @@
 use moire::sync::mpsc;
 use vox_types::{Backing, Link, LinkRx, LinkTx};
 
+/// One in-process frame: bytes, plus any descriptors moving with it.
+///
+/// In-process fd "passing" is just an ownership move through the same
+/// channel as the bytes — no `SCM_RIGHTS`, and no separate stream that
+/// could desync.
+#[cfg(unix)]
+type MemItem = (Vec<u8>, Vec<std::os::fd::OwnedFd>);
+#[cfg(not(unix))]
+type MemItem = Vec<u8>;
+
 /// In-process [`Link`] backed by tokio mpsc channels.
 ///
-/// Each direction is an unbounded channel carrying `Vec<u8>` — raw bytes,
-/// no serialization, no IO. Useful for testing Conduits, Session, and
-/// anything above the transport layer without real networking.
+/// Each direction is an unbounded channel carrying raw bytes (and, on Unix,
+/// any `Fd`s travelling with them) — no serialization, no IO. Useful for
+/// testing Conduits, Session, and anything above the transport layer
+/// without real networking.
 // r[impl transport.memory]
 // r[impl zerocopy.framing.link.memory]
 pub struct MemoryLink {
-    tx: mpsc::Sender<Vec<u8>>,
-    rx: mpsc::Receiver<Vec<u8>>,
+    tx: mpsc::Sender<MemItem>,
+    rx: mpsc::Receiver<MemItem>,
 }
 
 /// Create a pair of connected [`MemoryLink`]s.
@@ -31,7 +42,14 @@ impl Link for MemoryLink {
     type Rx = MemoryLinkRx;
 
     fn split(self) -> (Self::Tx, Self::Rx) {
-        (MemoryLinkTx { tx: self.tx }, MemoryLinkRx { rx: self.rx })
+        (
+            MemoryLinkTx { tx: self.tx },
+            MemoryLinkRx {
+                rx: self.rx,
+                #[cfg(unix)]
+                last_fds: Vec::new(),
+            },
+        )
     }
 }
 
@@ -42,21 +60,48 @@ impl Link for MemoryLink {
 /// Sending half of a [`MemoryLink`].
 #[derive(Clone)]
 pub struct MemoryLinkTx {
-    tx: mpsc::Sender<Vec<u8>>,
+    tx: mpsc::Sender<MemItem>,
+}
+
+impl MemoryLinkTx {
+    async fn send_item(&self, item: MemItem) -> std::io::Result<()> {
+        let permit = self.tx.clone().reserve_owned().await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::ConnectionReset, "receiver dropped")
+        })?;
+        drop(permit.send(item));
+        Ok(())
+    }
 }
 
 impl LinkTx for MemoryLinkTx {
     async fn send(&self, bytes: Vec<u8>) -> std::io::Result<()> {
-        let permit = self.tx.clone().reserve_owned().await.map_err(|_| {
-            std::io::Error::new(std::io::ErrorKind::ConnectionReset, "receiver dropped")
-        })?;
-        drop(permit.send(bytes));
-        Ok(())
+        #[cfg(unix)]
+        {
+            self.send_item((bytes, Vec::new())).await
+        }
+        #[cfg(not(unix))]
+        {
+            self.send_item(bytes).await
+        }
     }
 
     async fn close(self) -> std::io::Result<()> {
         drop(self.tx);
         Ok(())
+    }
+
+    #[cfg(unix)]
+    fn supports_fd_passing(&self) -> bool {
+        true
+    }
+
+    #[cfg(unix)]
+    async fn send_with_fds(
+        &self,
+        bytes: Vec<u8>,
+        fds: Vec<std::os::fd::OwnedFd>,
+    ) -> std::io::Result<()> {
+        self.send_item((bytes, fds)).await
     }
 }
 
@@ -66,7 +111,9 @@ impl LinkTx for MemoryLinkTx {
 
 /// Receiving half of a [`MemoryLink`].
 pub struct MemoryLinkRx {
-    rx: mpsc::Receiver<Vec<u8>>,
+    rx: mpsc::Receiver<MemItem>,
+    #[cfg(unix)]
+    last_fds: Vec<std::os::fd::OwnedFd>,
 }
 
 /// MemoryLink never fails on recv — the only "error" is channel closed (returns None).
@@ -86,8 +133,19 @@ impl LinkRx for MemoryLinkRx {
 
     async fn recv(&mut self) -> Result<Option<Backing>, Self::Error> {
         match self.rx.recv().await {
+            #[cfg(unix)]
+            Some((bytes, fds)) => {
+                self.last_fds = fds;
+                Ok(Some(Backing::Boxed(bytes.into_boxed_slice())))
+            }
+            #[cfg(not(unix))]
             Some(bytes) => Ok(Some(Backing::Boxed(bytes.into_boxed_slice()))),
             None => Ok(None),
         }
+    }
+
+    #[cfg(unix)]
+    fn take_frame_fds(&mut self) -> Vec<std::os::fd::OwnedFd> {
+        std::mem::take(&mut self.last_fds)
     }
 }

--- a/rust/vox-core/src/session/mod.rs
+++ b/rust/vox-core/src/session/mod.rs
@@ -828,6 +828,9 @@ vox_types::impl_reborrow!(ConnectionMessage);
 pub(crate) struct RecvMessage {
     pub schemas: Arc<vox_types::SchemaRecvTracker>,
     pub msg: SelfRef<ConnectionMessage<'static>>,
+    /// Descriptors that arrived with this frame (`SCM_RIGHTS`). Threaded to
+    /// the typed-decode site; `()` off-Unix.
+    pub fds: vox_types::FrameFds,
 }
 
 impl ConnectionHandle {
@@ -1267,7 +1270,10 @@ impl Session {
                     vox_types::dlog!("[session {:?}] recv_msg returned", self.role);
                     match msg {
                         Ok(Some(msg)) => {
-                            self.handle_message(msg, &mut keepalive_runtime).await;
+                            // Capture the frame's descriptors before the next
+                            // recv overwrites them; thread them with the msg.
+                            let fds = self.rx.take_frame_fds();
+                            self.handle_message(msg, fds, &mut keepalive_runtime).await;
                         }
                         Ok(None) => {
                             vox_types::dlog!("[session {:?}] recv loop: conduit returned EOF", self.role);
@@ -1445,6 +1451,7 @@ impl Session {
     async fn handle_message(
         &mut self,
         msg: SelfRef<Message<'static>>,
+        fds: vox_types::FrameFds,
         keepalive_runtime: &mut Option<KeepaliveRuntime>,
     ) {
         let msg_ref = msg.get();
@@ -1610,6 +1617,7 @@ impl Session {
                 let recv_msg = RecvMessage {
                     schemas: Arc::clone(&state.schema_recv_tracker),
                     msg: r.map(ConnectionMessage::Request),
+                    fds,
                 };
                 vox_types::dlog!(
                     "[session {:?}] dispatch request: conn={:?} req={:?} body={}",
@@ -1632,6 +1640,7 @@ impl Session {
                 let recv_msg = RecvMessage {
                     schemas: Arc::clone(&state.schema_recv_tracker),
                     msg: c.map(ConnectionMessage::Channel),
+                    fds,
                 };
                 if conn_tx.send(recv_msg).await.is_err() {
                     self.remove_connection_with_reason(&conn_id, ConnectionCloseReason::Unknown);
@@ -2773,6 +2782,10 @@ pub trait DynConduitTx: MaybeSend + MaybeSync {
 pub trait DynConduitRx: MaybeSend {
     fn recv_msg<'a>(&'a mut self)
     -> BoxFut<'a, std::io::Result<Option<SelfRef<Message<'static>>>>>;
+
+    /// Descriptors that arrived with the frame from the most recent
+    /// `recv_msg`. Threaded alongside the message to the typed-decode site.
+    fn take_frame_fds(&mut self) -> vox_types::FrameFds;
 }
 
 // r[impl zerocopy.send]
@@ -2812,6 +2825,10 @@ where
                 .await
                 .map_err(|error| std::io::Error::other(error.to_string()))
         })
+    }
+
+    fn take_frame_fds(&mut self) -> vox_types::FrameFds {
+        ConduitRx::take_frame_fds(self)
     }
 }
 

--- a/rust/vox-fdpass/src/unix.rs
+++ b/rust/vox-fdpass/src/unix.rs
@@ -69,6 +69,189 @@ pub async fn recv_fds(stream: &UnixStream, expected: usize) -> io::Result<Vec<Ra
     }
 }
 
+/// Maximum number of descriptors deliverable in one `SCM_RIGHTS` control
+/// message (kernel `SCM_MAX_FD`).
+pub const SCM_MAX_FD: usize = 253;
+
+/// Send `data` over a Unix stream, attaching `fds` as `SCM_RIGHTS`
+/// ancillary data to the first `sendmsg` that transfers any bytes.
+///
+/// Unlike [`send_fds`] (which sends a 1-byte sentinel), the caller's own
+/// bytes are the message payload, so descriptors are bound to exactly this
+/// frame — no separate fd-only message that could desync a framed byte
+/// stream. All of `data` is written before returning (the tail, if the
+/// first `sendmsg` was partial, is written plain — ancillary data is only
+/// ever delivered once).
+///
+/// `data` must be non-empty (`SCM_RIGHTS` requires ≥1 data byte) and `fds`
+/// must not exceed [`SCM_MAX_FD`].
+pub async fn send_msg_with_fds(
+    stream: &UnixStream,
+    data: &[u8],
+    fds: &[RawFd],
+) -> io::Result<()> {
+    if data.is_empty() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "send_msg_with_fds requires at least one data byte",
+        ));
+    }
+    if fds.len() > SCM_MAX_FD {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("too many fds: {} > SCM_MAX_FD ({SCM_MAX_FD})", fds.len()),
+        ));
+    }
+
+    // First sendmsg carries the ancillary data.
+    let mut sent = loop {
+        stream.writable().await?;
+        match stream.try_io(Interest::WRITABLE, || {
+            send_msg_now(stream.as_raw_fd(), data, fds)
+        }) {
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => continue,
+            other => break other?,
+        }
+    };
+
+    // Any remaining bytes go plain (fds already delivered).
+    while sent < data.len() {
+        stream.writable().await?;
+        match stream.try_io(Interest::WRITABLE, || {
+            send_msg_now(stream.as_raw_fd(), &data[sent..], &[])
+        }) {
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => continue,
+            Ok(n) => sent += n,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// Receive one `recvmsg` into `buf`, returning `(bytes_read, fds)`.
+///
+/// `bytes_read == 0` means clean EOF. Any `SCM_RIGHTS` descriptors on the
+/// message are returned (the caller owns and must close them). The control
+/// buffer is sized for [`SCM_MAX_FD`]; `MSG_CTRUNC` is a hard error.
+pub async fn recv_msg(stream: &UnixStream, buf: &mut [u8]) -> io::Result<(usize, Vec<RawFd>)> {
+    loop {
+        stream.readable().await?;
+        match stream.try_io(Interest::READABLE, || recv_msg_now(stream.as_raw_fd(), buf)) {
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => continue,
+            other => return other,
+        }
+    }
+}
+
+/// One `sendmsg`: `data` as the iovec, `fds` (if any) as `SCM_RIGHTS`.
+/// Returns the number of data bytes accepted by the kernel.
+fn send_msg_now(sock_fd: RawFd, data: &[u8], fds: &[RawFd]) -> io::Result<usize> {
+    let mut iov = libc::iovec {
+        iov_base: data.as_ptr() as *mut libc::c_void,
+        iov_len: data.len(),
+    };
+
+    // SAFETY: We initialize all fields before use.
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+
+    let mut control;
+    if !fds.is_empty() {
+        let data_len = std::mem::size_of_val(fds);
+        // SAFETY: libc macro-like function with valid integer argument.
+        let cmsg_space = unsafe { libc::CMSG_SPACE(data_len as u32) as usize };
+        control = vec![0u8; cmsg_space];
+        msg.msg_control = control.as_mut_ptr().cast();
+        msg.msg_controllen = control.len() as _;
+
+        // SAFETY: msg_control points to a valid writable buffer.
+        let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+        if cmsg.is_null() {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                "failed to build cmsg header",
+            ));
+        }
+        // SAFETY: cmsg is valid for writes in the control buffer.
+        unsafe {
+            (*cmsg).cmsg_level = libc::SOL_SOCKET;
+            (*cmsg).cmsg_type = libc::SCM_RIGHTS;
+            (*cmsg).cmsg_len = libc::CMSG_LEN(data_len as u32) as _;
+            let data_ptr = libc::CMSG_DATA(cmsg).cast::<RawFd>();
+            std::ptr::copy_nonoverlapping(fds.as_ptr(), data_ptr, fds.len());
+        }
+    }
+
+    // SAFETY: msg references valid iov/control buffers for the duration of call.
+    let n = unsafe { libc::sendmsg(sock_fd, &msg, 0) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if n == 0 {
+        return Err(io::Error::new(ErrorKind::WriteZero, "sendmsg wrote 0 bytes"));
+    }
+    Ok(n as usize)
+}
+
+/// One `recvmsg` into `buf`, harvesting any `SCM_RIGHTS` descriptors.
+fn recv_msg_now(sock_fd: RawFd, buf: &mut [u8]) -> io::Result<(usize, Vec<RawFd>)> {
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr().cast(),
+        iov_len: buf.len(),
+    };
+
+    let data_len = SCM_MAX_FD * std::mem::size_of::<RawFd>();
+    // SAFETY: libc macro-like function with valid integer argument.
+    let cmsg_space = unsafe { libc::CMSG_SPACE(data_len as u32) as usize };
+    let mut control = vec![0u8; cmsg_space];
+
+    // SAFETY: We initialize all fields before use.
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = control.as_mut_ptr().cast();
+    msg.msg_controllen = control.len() as _;
+
+    // SAFETY: msg references valid iov/control buffers for the duration of call.
+    let n = unsafe { libc::recvmsg(sock_fd, &mut msg, 0) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if n == 0 {
+        return Ok((0, Vec::new()));
+    }
+    if (msg.msg_flags & libc::MSG_CTRUNC) != 0 {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "control message truncated",
+        ));
+    }
+
+    let mut out = Vec::new();
+    // SAFETY: iterating cmsg headers as provided by kernel in `msg`.
+    unsafe {
+        let mut cmsg = libc::CMSG_FIRSTHDR(&msg);
+        while !cmsg.is_null() {
+            if (*cmsg).cmsg_level == libc::SOL_SOCKET && (*cmsg).cmsg_type == libc::SCM_RIGHTS {
+                let cmsg_len = (*cmsg).cmsg_len as usize;
+                let base_len = libc::CMSG_LEN(0) as usize;
+                if cmsg_len >= base_len {
+                    let bytes = cmsg_len - base_len;
+                    let count = bytes / std::mem::size_of::<RawFd>();
+                    let data_ptr = libc::CMSG_DATA(cmsg).cast::<RawFd>();
+                    for i in 0..count {
+                        out.push(*data_ptr.add(i));
+                    }
+                }
+            }
+            cmsg = libc::CMSG_NXTHDR(&msg, cmsg);
+        }
+    }
+
+    Ok((n as usize, out))
+}
+
 fn send_fds_now(sock_fd: RawFd, fds: &[RawFd]) -> io::Result<()> {
     let mut payload = [0xA5u8; 1];
     let mut iov = libc::iovec {
@@ -301,6 +484,44 @@ mod tests {
             .await
             .expect_err("closed peer should produce eof");
         assert_eq!(err.kind(), ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn send_msg_with_fds_carries_data_and_fd_atomically() {
+        let (a_std, b_std) = StdUnixStream::pair().expect("unix pair");
+        a_std.set_nonblocking(true).unwrap();
+        b_std.set_nonblocking(true).unwrap();
+        let a = UnixStream::from_std(a_std).unwrap();
+        let b = UnixStream::from_std(b_std).unwrap();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let fd = listener.into_raw_fd();
+
+        send_msg_with_fds(&a, b"FRAMEBYTES", &[fd]).await.expect("send");
+
+        let mut buf = [0u8; 64];
+        let (n, fds) = recv_msg(&b, &mut buf).await.expect("recv");
+        assert_eq!(&buf[..n], b"FRAMEBYTES");
+        assert_eq!(fds.len(), 1);
+
+        let recv_listener = unsafe { std::net::TcpListener::from_raw_fd(fds[0]) };
+        assert_eq!(recv_listener.local_addr().unwrap(), addr);
+        unsafe { libc::close(fd) };
+    }
+
+    #[tokio::test]
+    async fn recv_msg_zero_on_clean_eof() {
+        let (a_std, b_std) = StdUnixStream::pair().expect("unix pair");
+        a_std.set_nonblocking(true).unwrap();
+        b_std.set_nonblocking(true).unwrap();
+        let a = UnixStream::from_std(a_std).unwrap();
+        let b = UnixStream::from_std(b_std).unwrap();
+        drop(a);
+        let mut buf = [0u8; 16];
+        let (n, fds) = recv_msg(&b, &mut buf).await.expect("recv eof");
+        assert_eq!(n, 0);
+        assert!(fds.is_empty());
     }
 
     #[tokio::test]

--- a/rust/vox-macros-core/src/lib.rs
+++ b/rust/vox-macros-core/src/lib.rs
@@ -988,8 +988,11 @@ fn generate_client_method(
                         });
                     }
                 };
-                let #vox::WithTracker { value: response, tracker: schema_tracker } = with_tracker;
-                response.try_repack(|resp, _bytes| {
+                let #vox::WithTracker { value: response, tracker: schema_tracker, fds: __vox_frame_fds } = with_tracker;
+                // Install this response frame's descriptors as the fd source
+                // for the duration of the typed-return decode (any `vox::Fd`
+                // claims one). Pass-through off-Unix.
+                #vox::provide_fds(__vox_frame_fds, move || response.try_repack(|resp, _bytes| {
                     let ret_bytes = match &resp.ret {
                         #vox::Payload::PostcardBytes(bytes) => bytes,
                         _ => return Err(#vox::VoxError::<#err_ty>::InvalidPayload("response not PostcardBytes".into())),
@@ -1007,7 +1010,7 @@ fn generate_client_method(
                             Err(err)
                         }
                     }
-                })
+                }))
             }
         }
     } else {
@@ -1040,29 +1043,34 @@ fn generate_client_method(
                         });
                     }
                 };
-                let #vox::WithTracker { value: response, tracker: schema_tracker } = with_tracker;
-                let response = response.get();
-                let ret_bytes = match &response.ret {
-                    #vox::Payload::PostcardBytes(bytes) => bytes,
-                    _ => return Err(#vox::VoxError::<#err_ty>::InvalidPayload("response not PostcardBytes".into())),
-                };
-                let result: Result<#ok_ty_decode, #vox::VoxError<#err_ty>> =
-                    #vox::schema_deser::schema_deserialize_response::<Result<#ok_ty_decode, #vox::VoxError<#err_ty>>>(
-                        ret_bytes,
-                        method_id,
-                        &schema_tracker,
-                    )
-                    .map_err(|e| {
-                        #finish_retry_bindings
-                        #vox::VoxError::<#err_ty>::InvalidPayload(e.to_string())
-                    })?;
-                match result {
-                    Ok(ret) => Ok(ret),
-                    Err(err) => {
-                        #finish_retry_bindings
-                        Err(err)
+                let #vox::WithTracker { value: response, tracker: schema_tracker, fds: __vox_frame_fds } = with_tracker;
+                // Install this response frame's descriptors as the fd source
+                // for the typed-return decode (any `vox::Fd` claims one).
+                // Pass-through off-Unix.
+                #vox::provide_fds(__vox_frame_fds, move || {
+                    let response = response.get();
+                    let ret_bytes = match &response.ret {
+                        #vox::Payload::PostcardBytes(bytes) => bytes,
+                        _ => return Err(#vox::VoxError::<#err_ty>::InvalidPayload("response not PostcardBytes".into())),
+                    };
+                    let result: Result<#ok_ty_decode, #vox::VoxError<#err_ty>> =
+                        #vox::schema_deser::schema_deserialize_response::<Result<#ok_ty_decode, #vox::VoxError<#err_ty>>>(
+                            ret_bytes,
+                            method_id,
+                            &schema_tracker,
+                        )
+                        .map_err(|e| {
+                            #finish_retry_bindings
+                            #vox::VoxError::<#err_ty>::InvalidPayload(e.to_string())
+                        })?;
+                    match result {
+                        Ok(ret) => Ok(ret),
+                        Err(err) => {
+                            #finish_retry_bindings
+                            Err(err)
+                        }
                     }
-                }
+                })
             }
         }
     }

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__adder_infallible.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__adder_infallible.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/vox-macros-core/src/lib.rs
+assertion_line: 1121
 expression: "generate(quote!\n{ pub trait Adder { async fn add(&self, a: i32, b: i32) -> i32; } })"
 ---
 #[allow(non_snake_case, clippy::all)]
@@ -246,29 +247,32 @@ impl AdderClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                        "response not PostcardBytes".into(),
-                    ),
-                );
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(
+                        ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                            "response not PostcardBytes".into(),
+                        ),
+                    );
+                }
+            };
+            let result: Result<i32, ::vox::VoxError<::core::convert::Infallible>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<i32, ::vox::VoxError<::core::convert::Infallible>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| {
+                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                })?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => Err(err),
             }
-        };
-        let result: Result<i32, ::vox::VoxError<::core::convert::Infallible>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<i32, ::vox::VoxError<::core::convert::Infallible>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| {
-                ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-            })?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => Err(err),
-        }
+        })
     }
 }
 impl ::vox::FromVoxSession for AdderClient {

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/vox-macros-core/src/lib.rs
+assertion_line: 1347
 expression: "generate(quote!\n{\n    trait WordLab\n    {\n        async fn is_short(&self, word: &str) -> bool; async fn\n        classify(&self, word: String) -> &'vox str; async fn\n        transform(&self, prefix: &str, input: Rx<String>, output: Tx<String>)\n        -> u32;\n    }\n})"
 ---
 #[allow(non_snake_case, clippy::all)]
@@ -372,29 +373,32 @@ impl WordLabClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                        "response not PostcardBytes".into(),
-                    ),
-                );
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(
+                        ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                            "response not PostcardBytes".into(),
+                        ),
+                    );
+                }
+            };
+            let result: Result<bool, ::vox::VoxError<::core::convert::Infallible>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<bool, ::vox::VoxError<::core::convert::Infallible>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| {
+                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                })?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => Err(err),
             }
-        };
-        let result: Result<bool, ::vox::VoxError<::core::convert::Infallible>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<bool, ::vox::VoxError<::core::convert::Infallible>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| {
-                ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-            })?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => Err(err),
-        }
+        })
     }
     pub async fn classify(
         &self,
@@ -442,29 +446,34 @@ impl WordLabClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        response.try_repack(|resp, _bytes| {
-            let ret_bytes = match &resp.ret {
-                ::vox::Payload::PostcardBytes(bytes) => bytes,
-                _ => {
-                    return Err(
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            response.try_repack(|resp, _bytes| {
+                let ret_bytes = match &resp.ret {
+                    ::vox::Payload::PostcardBytes(bytes) => bytes,
+                    _ => {
+                        return Err(
+                            ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                                "response not PostcardBytes".into(),
+                            ),
+                        );
+                    }
+                };
+                let result: Result<&'static str, ::vox::VoxError<::core::convert::Infallible>> =
+                    ::vox::schema_deser::schema_deserialize_response_borrowed::<
+                        Result<&'static str, ::vox::VoxError<::core::convert::Infallible>>,
+                    >(ret_bytes, method_id, &schema_tracker)
+                    .map_err(|e| {
                         ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                            "response not PostcardBytes".into(),
-                        ),
-                    );
+                            e.to_string(),
+                        )
+                    })?;
+                match result {
+                    Ok(ret) => Ok(ret),
+                    Err(err) => Err(err),
                 }
-            };
-            let result: Result<&'static str, ::vox::VoxError<::core::convert::Infallible>> =
-                ::vox::schema_deser::schema_deserialize_response_borrowed::<
-                    Result<&'static str, ::vox::VoxError<::core::convert::Infallible>>,
-                >(ret_bytes, method_id, &schema_tracker)
-                .map_err(|e| {
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-                })?;
-            match result {
-                Ok(ret) => Ok(ret),
-                Err(err) => Err(err),
-            }
+            })
         })
     }
     pub async fn transform(
@@ -516,33 +525,36 @@ impl WordLabClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                        "response not PostcardBytes".into(),
-                    ),
-                );
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(
+                        ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                            "response not PostcardBytes".into(),
+                        ),
+                    );
+                }
+            };
+            let result: Result<u32, ::vox::VoxError<::core::convert::Infallible>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<u32, ::vox::VoxError<::core::convert::Infallible>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| {
+                    args.2.finish_retry_binding();
+                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                })?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => {
+                    args.2.finish_retry_binding();
+                    Err(err)
+                }
             }
-        };
-        let result: Result<u32, ::vox::VoxError<::core::convert::Infallible>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<u32, ::vox::VoxError<::core::convert::Infallible>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| {
-                args.2.finish_retry_binding();
-                ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-            })?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => {
-                args.2.finish_retry_binding();
-                Err(err)
-            }
-        }
+        })
     }
 }
 impl ::vox::FromVoxSession for WordLabClient {

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_vox_cow_return.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_vox_cow_return.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/vox-macros-core/src/lib.rs
+assertion_line: 1338
 expression: "generate(quote!\n{\n    trait TextSvc\n    {\n        async fn normalize(&self, input: String) -> ::std::borrow::Cow<'vox,\n        str>;\n    }\n})"
 ---
 #[allow(non_snake_case, clippy::all)]
@@ -253,34 +254,37 @@ impl TextSvcClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        response.try_repack(|resp, _bytes| {
-            let ret_bytes = match &resp.ret {
-                ::vox::Payload::PostcardBytes(bytes) => bytes,
-                _ => {
-                    return Err(
-                        ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                            "response not PostcardBytes".into(),
-                        ),
-                    );
-                }
-            };
-            let result: Result<
-                ::std::borrow::Cow<'static, str>,
-                ::vox::VoxError<::core::convert::Infallible>,
-            > = ::vox::schema_deser::schema_deserialize_response_borrowed::<
-                Result<
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            response.try_repack(|resp, _bytes| {
+                let ret_bytes = match &resp.ret {
+                    ::vox::Payload::PostcardBytes(bytes) => bytes,
+                    _ => {
+                        return Err(
+                            ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                                "response not PostcardBytes".into(),
+                            ),
+                        );
+                    }
+                };
+                let result: Result<
                     ::std::borrow::Cow<'static, str>,
                     ::vox::VoxError<::core::convert::Infallible>,
-                >,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| {
-                ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-            })?;
-            match result {
-                Ok(ret) => Ok(ret),
-                Err(err) => Err(err),
-            }
+                > = ::vox::schema_deser::schema_deserialize_response_borrowed::<
+                    Result<
+                        ::std::borrow::Cow<'static, str>,
+                        ::vox::VoxError<::core::convert::Infallible>,
+                    >,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| {
+                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                })?;
+                match result {
+                    Ok(ret) => Ok(ret),
+                    Err(err) => Err(err),
+                }
+            })
         })
     }
 }

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_vox_return.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_vox_return.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/vox-macros-core/src/lib.rs
+assertion_line: 1324
 expression: "generate(quote!\n{ trait Hasher { async fn hash(&self, payload: String) -> &'vox str; } })"
 ---
 #[allow(non_snake_case, clippy::all)]
@@ -254,29 +255,34 @@ impl HasherClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        response.try_repack(|resp, _bytes| {
-            let ret_bytes = match &resp.ret {
-                ::vox::Payload::PostcardBytes(bytes) => bytes,
-                _ => {
-                    return Err(
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            response.try_repack(|resp, _bytes| {
+                let ret_bytes = match &resp.ret {
+                    ::vox::Payload::PostcardBytes(bytes) => bytes,
+                    _ => {
+                        return Err(
+                            ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                                "response not PostcardBytes".into(),
+                            ),
+                        );
+                    }
+                };
+                let result: Result<&'static str, ::vox::VoxError<::core::convert::Infallible>> =
+                    ::vox::schema_deser::schema_deserialize_response_borrowed::<
+                        Result<&'static str, ::vox::VoxError<::core::convert::Infallible>>,
+                    >(ret_bytes, method_id, &schema_tracker)
+                    .map_err(|e| {
                         ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                            "response not PostcardBytes".into(),
-                        ),
-                    );
+                            e.to_string(),
+                        )
+                    })?;
+                match result {
+                    Ok(ret) => Ok(ret),
+                    Err(err) => Err(err),
                 }
-            };
-            let result: Result<&'static str, ::vox::VoxError<::core::convert::Infallible>> =
-                ::vox::schema_deser::schema_deserialize_response_borrowed::<
-                    Result<&'static str, ::vox::VoxError<::core::convert::Infallible>>,
-                >(ret_bytes, method_id, &schema_tracker)
-                .map_err(|e| {
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-                })?;
-            match result {
-                Ok(ret) => Ok(ret),
-                Err(err) => Err(err),
-            }
+            })
         })
     }
 }

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_vox_return_call_style.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_vox_return_call_style.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/vox-macros-core/src/lib.rs
+assertion_line: 1331
 expression: "generate(quote!\n{ trait Hasher { async fn hash(&self, payload: String) -> &'vox str; } })"
 ---
 #[allow(non_snake_case, clippy::all)]
@@ -254,29 +255,34 @@ impl HasherClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        response.try_repack(|resp, _bytes| {
-            let ret_bytes = match &resp.ret {
-                ::vox::Payload::PostcardBytes(bytes) => bytes,
-                _ => {
-                    return Err(
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            response.try_repack(|resp, _bytes| {
+                let ret_bytes = match &resp.ret {
+                    ::vox::Payload::PostcardBytes(bytes) => bytes,
+                    _ => {
+                        return Err(
+                            ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                                "response not PostcardBytes".into(),
+                            ),
+                        );
+                    }
+                };
+                let result: Result<&'static str, ::vox::VoxError<::core::convert::Infallible>> =
+                    ::vox::schema_deser::schema_deserialize_response_borrowed::<
+                        Result<&'static str, ::vox::VoxError<::core::convert::Infallible>>,
+                    >(ret_bytes, method_id, &schema_tracker)
+                    .map_err(|e| {
                         ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                            "response not PostcardBytes".into(),
-                        ),
-                    );
+                            e.to_string(),
+                        )
+                    })?;
+                match result {
+                    Ok(ret) => Ok(ret),
+                    Err(err) => Err(err),
                 }
-            };
-            let result: Result<&'static str, ::vox::VoxError<::core::convert::Infallible>> =
-                ::vox::schema_deser::schema_deserialize_response_borrowed::<
-                    Result<&'static str, ::vox::VoxError<::core::convert::Infallible>>,
-                >(ret_bytes, method_id, &schema_tracker)
-                .map_err(|e| {
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-                })?;
-            match result {
-                Ok(ret) => Ok(ret),
-                Err(err) => Err(err),
-            }
+            })
         })
     }
 }

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__explicit_request_context_opt_in.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__explicit_request_context_opt_in.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/vox-macros-core/src/lib.rs
+assertion_line: 1142
 expression: "generate(quote!\n{\n    trait Audit\n    {\n        #[vox::context] async fn record(&self, payload: String) -> &'vox str;\n        async fn ping(&self) -> u64;\n    }\n})"
 ---
 #[allow(non_snake_case, clippy::all)]
@@ -331,29 +332,34 @@ impl AuditClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        response.try_repack(|resp, _bytes| {
-            let ret_bytes = match &resp.ret {
-                ::vox::Payload::PostcardBytes(bytes) => bytes,
-                _ => {
-                    return Err(
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            response.try_repack(|resp, _bytes| {
+                let ret_bytes = match &resp.ret {
+                    ::vox::Payload::PostcardBytes(bytes) => bytes,
+                    _ => {
+                        return Err(
+                            ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                                "response not PostcardBytes".into(),
+                            ),
+                        );
+                    }
+                };
+                let result: Result<&'static str, ::vox::VoxError<::core::convert::Infallible>> =
+                    ::vox::schema_deser::schema_deserialize_response_borrowed::<
+                        Result<&'static str, ::vox::VoxError<::core::convert::Infallible>>,
+                    >(ret_bytes, method_id, &schema_tracker)
+                    .map_err(|e| {
                         ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                            "response not PostcardBytes".into(),
-                        ),
-                    );
+                            e.to_string(),
+                        )
+                    })?;
+                match result {
+                    Ok(ret) => Ok(ret),
+                    Err(err) => Err(err),
                 }
-            };
-            let result: Result<&'static str, ::vox::VoxError<::core::convert::Infallible>> =
-                ::vox::schema_deser::schema_deserialize_response_borrowed::<
-                    Result<&'static str, ::vox::VoxError<::core::convert::Infallible>>,
-                >(ret_bytes, method_id, &schema_tracker)
-                .map_err(|e| {
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-                })?;
-            match result {
-                Ok(ret) => Ok(ret),
-                Err(err) => Err(err),
-            }
+            })
         })
     }
     pub async fn ping(&self) -> Result<u64, ::vox::VoxError> {
@@ -399,29 +405,32 @@ impl AuditClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                        "response not PostcardBytes".into(),
-                    ),
-                );
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(
+                        ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                            "response not PostcardBytes".into(),
+                        ),
+                    );
+                }
+            };
+            let result: Result<u64, ::vox::VoxError<::core::convert::Infallible>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<u64, ::vox::VoxError<::core::convert::Infallible>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| {
+                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                })?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => Err(err),
             }
-        };
-        let result: Result<u64, ::vox::VoxError<::core::convert::Infallible>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<u64, ::vox::VoxError<::core::convert::Infallible>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| {
-                ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-            })?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => Err(err),
-        }
+        })
     }
 }
 impl ::vox::FromVoxSession for AuditClient {

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__fallible.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__fallible.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/vox-macros-core/src/lib.rs
+assertion_line: 1128
 expression: "generate(quote!\n{\n    trait Calc\n    { async fn div(&self, a: f64, b: f64) -> Result<f64, DivError>; }\n})"
 ---
 #[allow(non_snake_case, clippy::all)]
@@ -246,25 +247,28 @@ impl CalcClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(::vox::VoxError::<DivError>::InvalidPayload(
-                    "response not PostcardBytes".into(),
-                ));
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(::vox::VoxError::<DivError>::InvalidPayload(
+                        "response not PostcardBytes".into(),
+                    ));
+                }
+            };
+            let result: Result<f64, ::vox::VoxError<DivError>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<f64, ::vox::VoxError<DivError>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| ::vox::VoxError::<DivError>::InvalidPayload(e.to_string()))?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => Err(err),
             }
-        };
-        let result: Result<f64, ::vox::VoxError<DivError>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<f64, ::vox::VoxError<DivError>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| ::vox::VoxError::<DivError>::InvalidPayload(e.to_string()))?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => Err(err),
-        }
+        })
     }
 }
 impl ::vox::FromVoxSession for CalcClient {

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__method_retry_helper_attributes.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__method_retry_helper_attributes.snap
@@ -1,5 +1,6 @@
 ---
 source: rust/vox-macros-core/src/lib.rs
+assertion_line: 1154
 expression: "generate(quote!\n{\n    trait Billing\n    {\n        #[vox(idem)] async fn get_balance(&self, account: String) -> u64;\n        #[vox(persist)] async fn send_money(&self, from: String, to: String)\n        -> Result<u64, TransferError>;\n    }\n})"
 ---
 #[allow(non_snake_case, clippy::all)]
@@ -303,29 +304,32 @@ impl BillingClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                        "response not PostcardBytes".into(),
-                    ),
-                );
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(
+                        ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                            "response not PostcardBytes".into(),
+                        ),
+                    );
+                }
+            };
+            let result: Result<u64, ::vox::VoxError<::core::convert::Infallible>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<u64, ::vox::VoxError<::core::convert::Infallible>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| {
+                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                })?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => Err(err),
             }
-        };
-        let result: Result<u64, ::vox::VoxError<::core::convert::Infallible>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<u64, ::vox::VoxError<::core::convert::Infallible>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| {
-                ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-            })?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => Err(err),
-        }
+        })
     }
     pub async fn send_money(
         &self,
@@ -370,25 +374,28 @@ impl BillingClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(::vox::VoxError::<TransferError>::InvalidPayload(
-                    "response not PostcardBytes".into(),
-                ));
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(::vox::VoxError::<TransferError>::InvalidPayload(
+                        "response not PostcardBytes".into(),
+                    ));
+                }
+            };
+            let result: Result<u64, ::vox::VoxError<TransferError>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<u64, ::vox::VoxError<TransferError>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| ::vox::VoxError::<TransferError>::InvalidPayload(e.to_string()))?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => Err(err),
             }
-        };
-        let result: Result<u64, ::vox::VoxError<TransferError>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<u64, ::vox::VoxError<TransferError>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| ::vox::VoxError::<TransferError>::InvalidPayload(e.to_string()))?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => Err(err),
-        }
+        })
     }
 }
 impl ::vox::FromVoxSession for BillingClient {

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__no_args.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__no_args.snap
@@ -245,29 +245,32 @@ impl PingClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                        "response not PostcardBytes".into(),
-                    ),
-                );
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(
+                        ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                            "response not PostcardBytes".into(),
+                        ),
+                    );
+                }
+            };
+            let result: Result<u64, ::vox::VoxError<::core::convert::Infallible>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<u64, ::vox::VoxError<::core::convert::Infallible>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| {
+                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                })?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => Err(err),
             }
-        };
-        let result: Result<u64, ::vox::VoxError<::core::convert::Infallible>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<u64, ::vox::VoxError<::core::convert::Infallible>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| {
-                ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-            })?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => Err(err),
-        }
+        })
     }
 }
 impl ::vox::FromVoxSession for PingClient {

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__streaming_tx.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__streaming_tx.snap
@@ -253,33 +253,36 @@ impl StreamerClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                        "response not PostcardBytes".into(),
-                    ),
-                );
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(
+                        ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                            "response not PostcardBytes".into(),
+                        ),
+                    );
+                }
+            };
+            let result: Result<i32, ::vox::VoxError<::core::convert::Infallible>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<i32, ::vox::VoxError<::core::convert::Infallible>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| {
+                    args.1.finish_retry_binding();
+                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                })?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => {
+                    args.1.finish_retry_binding();
+                    Err(err)
+                }
             }
-        };
-        let result: Result<i32, ::vox::VoxError<::core::convert::Infallible>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<i32, ::vox::VoxError<::core::convert::Infallible>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| {
-                args.1.finish_retry_binding();
-                ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-            })?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => {
-                args.1.finish_retry_binding();
-                Err(err)
-            }
-        }
+        })
     }
 }
 impl ::vox::FromVoxSession for StreamerClient {

--- a/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__unit_return.snap
+++ b/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__unit_return.snap
@@ -249,29 +249,32 @@ impl NotifierClient {
         let ::vox::WithTracker {
             value: response,
             tracker: schema_tracker,
+            fds: __vox_frame_fds,
         } = with_tracker;
-        let response = response.get();
-        let ret_bytes = match &response.ret {
-            ::vox::Payload::PostcardBytes(bytes) => bytes,
-            _ => {
-                return Err(
-                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
-                        "response not PostcardBytes".into(),
-                    ),
-                );
+        ::vox::provide_fds(__vox_frame_fds, move || {
+            let response = response.get();
+            let ret_bytes = match &response.ret {
+                ::vox::Payload::PostcardBytes(bytes) => bytes,
+                _ => {
+                    return Err(
+                        ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(
+                            "response not PostcardBytes".into(),
+                        ),
+                    );
+                }
+            };
+            let result: Result<(), ::vox::VoxError<::core::convert::Infallible>> =
+                ::vox::schema_deser::schema_deserialize_response::<
+                    Result<(), ::vox::VoxError<::core::convert::Infallible>>,
+                >(ret_bytes, method_id, &schema_tracker)
+                .map_err(|e| {
+                    ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                })?;
+            match result {
+                Ok(ret) => Ok(ret),
+                Err(err) => Err(err),
             }
-        };
-        let result: Result<(), ::vox::VoxError<::core::convert::Infallible>> =
-            ::vox::schema_deser::schema_deserialize_response::<
-                Result<(), ::vox::VoxError<::core::convert::Infallible>>,
-            >(ret_bytes, method_id, &schema_tracker)
-            .map_err(|e| {
-                ::vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-            })?;
-        match result {
-            Ok(ret) => Ok(ret),
-            Err(err) => Err(err),
-        }
+        })
     }
 }
 impl ::vox::FromVoxSession for NotifierClient {

--- a/rust/vox-stream/Cargo.toml
+++ b/rust/vox-stream/Cargo.toml
@@ -28,7 +28,9 @@ tokio = { workspace = true, features = ["net", "io-util", "io-std", "rt", "sync"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+vox-fdpass.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+vox-postcard.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/rust/vox-stream/src/fd_link.rs
+++ b/rust/vox-stream/src/fd_link.rs
@@ -1,0 +1,306 @@
+//! Unix-domain [`Link`] that carries file descriptors via `SCM_RIGHTS`.
+//!
+//! Every frame is written with a single `sendmsg` (`vox-fdpass`) whose iovec
+//! *is* the framed bytes, so any descriptors are bound to exactly that
+//! frame — there is no separate fd-only message that could desync the byte
+//! stream. The reader does `recvmsg`, feeds bytes into the length-prefix
+//! framer, and attributes each `SCM_RIGHTS` batch to the frame whose bytes
+//! completed it. The conduit then installs those fds as the
+//! [`provide_fds`](vox_types::provide_fds) source around decoding.
+//!
+//! This is the only [`Link`] for which [`LinkTx::supports_fd_passing`]
+//! returns `true`.
+
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::sync::Arc;
+
+use tokio::net::UnixStream;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use vox_fdpass::{SCM_MAX_FD, recv_msg, send_msg_with_fds};
+use vox_types::{Backing, Link, LinkRx, LinkTx};
+
+/// A descriptor-passing [`Link`] over a `tokio` [`UnixStream`].
+pub struct FdStreamLink {
+    stream: UnixStream,
+}
+
+impl FdStreamLink {
+    /// Wrap an already-connected Unix stream.
+    pub fn new(stream: UnixStream) -> Self {
+        Self { stream }
+    }
+
+    /// Connect to a Unix socket path.
+    pub async fn connect(path: impl AsRef<std::path::Path>) -> io::Result<Self> {
+        Ok(Self::new(UnixStream::connect(path).await?))
+    }
+
+    /// A connected in-process pair (tests / same-process wiring).
+    pub fn pair() -> io::Result<(Self, Self)> {
+        let (a, b) = UnixStream::pair()?;
+        Ok((Self::new(a), Self::new(b)))
+    }
+}
+
+/// One queued outbound frame.
+enum Outgoing {
+    /// Frame body, plus descriptors to deliver out-of-band with it.
+    Frame(Vec<u8>, Vec<OwnedFd>),
+}
+
+impl Link for FdStreamLink {
+    type Tx = FdStreamLinkTx;
+    type Rx = FdStreamLinkRx;
+
+    fn split(self) -> (Self::Tx, Self::Rx) {
+        let sock = Arc::new(self.stream);
+        let (tx_chan, mut rx_chan) = mpsc::channel::<Outgoing>(128);
+        #[allow(clippy::type_complexity)]
+        let (read_tx, read_rx) =
+            mpsc::channel::<io::Result<Option<(Backing, Vec<OwnedFd>)>>>(128);
+
+        // Frame = [u32 body_len LE][u32 fd_count LE][body]. The explicit
+        // `fd_count` + an ordered receive FIFO makes fd→frame attribution
+        // deterministic regardless of how the kernel chunks bytes vs control
+        // messages across `recvmsg` (positional cmsg attribution is wrong
+        // when frames and sendmsg/recvmsg boundaries don't align).
+        let writer_sock = Arc::clone(&sock);
+        let writer_task = tokio::spawn(async move {
+            while let Some(Outgoing::Frame(body, fds)) = rx_chan.recv().await {
+                if body.len() > u32::MAX as usize {
+                    return Err(io::Error::other("frame exceeds 4GiB"));
+                }
+                let mut framed = Vec::with_capacity(8 + body.len());
+                framed.extend_from_slice(&(body.len() as u32).to_le_bytes());
+                framed.extend_from_slice(&(fds.len() as u32).to_le_bytes());
+                framed.extend_from_slice(&body);
+                let raw: Vec<RawFd> = fds.iter().map(|f| f.as_raw_fd()).collect();
+                send_msg_with_fds(&writer_sock, &framed, &raw).await?;
+                // `fds` drop here: closes our dups; the peer holds its own.
+                drop(fds);
+            }
+            Ok(())
+        });
+
+        let reader_sock = Arc::clone(&sock);
+        let reader_task = tokio::spawn(async move {
+            let mut buf = vec![0u8; 64 * 1024];
+            let mut acc: Vec<u8> = Vec::new();
+            // All descriptors received so far, in arrival order. SCM_RIGHTS
+            // preserves fd order across the socket, so popping `fd_count`
+            // per frame (in frame order) exactly reconstructs each frame's
+            // set — independent of recvmsg chunking.
+            let mut recv_fds: std::collections::VecDeque<OwnedFd> =
+                std::collections::VecDeque::new();
+            loop {
+                let (n, raw_fds) = match recv_msg(&reader_sock, &mut buf).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let _ = read_tx.send(Err(e)).await;
+                        break;
+                    }
+                };
+                if n == 0 {
+                    let _ = read_tx.send(Ok(None)).await;
+                    break;
+                }
+                for fd in raw_fds {
+                    // SAFETY: the kernel just handed us ownership of `fd`.
+                    recv_fds.push_back(unsafe { OwnedFd::from_raw_fd(fd) });
+                }
+                acc.extend_from_slice(&buf[..n]);
+
+                loop {
+                    if acc.len() < 8 {
+                        break;
+                    }
+                    let len =
+                        u32::from_le_bytes([acc[0], acc[1], acc[2], acc[3]]) as usize;
+                    let fd_count =
+                        u32::from_le_bytes([acc[4], acc[5], acc[6], acc[7]]) as usize;
+                    if acc.len() < 8 + len {
+                        break;
+                    }
+                    let body = acc[8..8 + len].to_vec();
+                    acc.drain(..8 + len);
+                    let mut fds = Vec::with_capacity(fd_count);
+                    for _ in 0..fd_count {
+                        match recv_fds.pop_front() {
+                            Some(fd) => fds.push(fd),
+                            None => break,
+                        }
+                    }
+                    if read_tx
+                        .send(Ok(Some((Backing::Boxed(body.into_boxed_slice()), fds))))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+        });
+
+        (
+            FdStreamLinkTx {
+                tx: tx_chan,
+                writer_task,
+            },
+            FdStreamLinkRx {
+                rx: read_rx,
+                last_fds: Vec::new(),
+                reader_task,
+            },
+        )
+    }
+}
+
+/// Sending half of an [`FdStreamLink`].
+pub struct FdStreamLinkTx {
+    tx: mpsc::Sender<Outgoing>,
+    writer_task: JoinHandle<io::Result<()>>,
+}
+
+impl LinkTx for FdStreamLinkTx {
+    async fn send(&self, bytes: Vec<u8>) -> io::Result<()> {
+        self.tx
+            .send(Outgoing::Frame(bytes, Vec::new()))
+            .await
+            .map_err(|_| {
+                io::Error::new(io::ErrorKind::ConnectionReset, "fd-stream writer stopped")
+            })
+    }
+
+    async fn close(self) -> io::Result<()> {
+        drop(self.tx);
+        self.writer_task.await.map_err(io::Error::other)?
+    }
+
+    fn supports_fd_passing(&self) -> bool {
+        true
+    }
+
+    async fn send_with_fds(&self, bytes: Vec<u8>, fds: Vec<OwnedFd>) -> io::Result<()> {
+        if fds.len() > SCM_MAX_FD {
+            return Err(io::Error::other(format!(
+                "too many fds in one message: {} > SCM_MAX_FD ({SCM_MAX_FD})",
+                fds.len()
+            )));
+        }
+        self.tx
+            .send(Outgoing::Frame(bytes, fds))
+            .await
+            .map_err(|_| {
+                io::Error::new(io::ErrorKind::ConnectionReset, "fd-stream writer stopped")
+            })
+    }
+}
+
+/// Receiving half of an [`FdStreamLink`].
+pub struct FdStreamLinkRx {
+    #[allow(clippy::type_complexity)]
+    rx: mpsc::Receiver<io::Result<Option<(Backing, Vec<OwnedFd>)>>>,
+    last_fds: Vec<OwnedFd>,
+    reader_task: JoinHandle<()>,
+}
+
+impl LinkRx for FdStreamLinkRx {
+    type Error = io::Error;
+
+    async fn recv(&mut self) -> io::Result<Option<Backing>> {
+        match self.rx.recv().await {
+            Some(Ok(Some((backing, fds)))) => {
+                self.last_fds = fds;
+                Ok(Some(backing))
+            }
+            Some(Ok(None)) | None => Ok(None),
+            Some(Err(e)) => Err(e),
+        }
+    }
+
+    fn take_frame_fds(&mut self) -> Vec<OwnedFd> {
+        std::mem::take(&mut self.last_fds)
+    }
+}
+
+impl Drop for FdStreamLinkRx {
+    fn drop(&mut self) {
+        self.reader_task.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Seek, Write};
+    use vox_types::{Fd, collect_fds, provide_fds};
+
+    fn temp_file_with(seed: &[u8]) -> std::fs::File {
+        let mut path = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("vox-fdlink-{}-{nanos}", std::process::id()));
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+        let _ = std::fs::remove_file(&path);
+        f.write_all(seed).unwrap();
+        f.rewind().unwrap();
+        f
+    }
+
+    /// Plain frames still work, and `supports_fd_passing` is advertised.
+    #[tokio::test]
+    async fn plain_frame_round_trip() {
+        let (a, b) = FdStreamLink::pair().unwrap();
+        let (tx, _rxa) = a.split();
+        let (_txb, mut rx) = b.split();
+        assert!(tx.supports_fd_passing());
+
+        tx.send(b"hello".to_vec()).await.unwrap();
+        let msg = rx.recv().await.unwrap().unwrap();
+        match msg {
+            Backing::Boxed(b) => assert_eq!(&*b, b"hello"),
+            Backing::Shared(s) => assert_eq!(s.as_bytes(), b"hello"),
+        }
+        assert!(rx.take_frame_fds().is_empty());
+    }
+
+    /// An `Fd` encoded into the frame body is delivered through the link and
+    /// re-materialises as a working descriptor on the far side.
+    #[tokio::test]
+    async fn fd_travels_with_its_frame() {
+        let (a, b) = FdStreamLink::pair().unwrap();
+        let (tx, _rxa) = a.split();
+        let (_txb, mut rx) = b.split();
+
+        let fd_msg = Fd::new(OwnedFd::from(temp_file_with(b"through-the-link")));
+        let (body, fds) = collect_fds(|| vox_postcard::to_vec(&fd_msg).unwrap());
+        assert_eq!(fds.len(), 1);
+        tx.send_with_fds(body, fds).await.unwrap();
+
+        let backing = rx.recv().await.unwrap().unwrap();
+        let frame_fds = rx.take_frame_fds();
+        assert_eq!(frame_fds.len(), 1, "one fd attributed to the frame");
+
+        let bytes = match &backing {
+            Backing::Boxed(b) => b.to_vec(),
+            Backing::Shared(s) => s.as_bytes().to_vec(),
+        };
+        let decoded: Fd =
+            provide_fds(frame_fds, || vox_postcard::from_slice(&bytes).unwrap());
+        let mut f = std::fs::File::from(decoded.into_owned_fd().unwrap());
+        let mut got = String::new();
+        f.read_to_string(&mut got).unwrap();
+        assert_eq!(got, "through-the-link");
+    }
+}

--- a/rust/vox-stream/src/lib.rs
+++ b/rust/vox-stream/src/lib.rs
@@ -15,6 +15,11 @@ use vox_types::{Backing, Link, LinkRx, LinkTx};
 #[cfg(not(target_arch = "wasm32"))]
 use vox_core::{Attachment, LinkSource};
 
+#[cfg(unix)]
+mod fd_link;
+#[cfg(unix)]
+pub use fd_link::{FdStreamLink, FdStreamLinkRx, FdStreamLinkTx};
+
 /// A [`Link`] over a byte stream with length-prefix framing.
 ///
 /// Wraps an `AsyncRead + AsyncWrite` pair. Each message is framed as

--- a/rust/vox-types/src/conduit.rs
+++ b/rust/vox-types/src/conduit.rs
@@ -86,6 +86,17 @@ pub trait ConduitRx {
     /// Returns `Ok(None)` when the peer has closed.
     fn recv(&mut self)
     -> impl Future<Output = RecvResult<Self::Msg, Self::Error>> + MaybeSend + '_;
+
+    /// Take the file descriptors that arrived with the frame returned by the
+    /// most recent [`recv`](Self::recv).
+    ///
+    /// The session threads these alongside the message (the same rail as the
+    /// schema tracker) to the typed-payload decode site, where they are
+    /// installed as the [`provide_fds`](crate::provide_fds) source. The
+    /// default is none; off-Unix [`FrameFds`](crate::FrameFds) is `()`.
+    fn take_frame_fds(&mut self) -> crate::FrameFds {
+        crate::FrameFds::default()
+    }
 }
 
 /// Yields new conduits from inbound connections.

--- a/rust/vox-types/src/fd.rs
+++ b/rust/vox-types/src/fd.rs
@@ -9,7 +9,7 @@
 //!
 //! The send/recv side-channel is plumbed through two thread-locals
 //! ([`collect_fds`] / [`provide_fds`]), installed around (de)serialization —
-//! exactly the shape of the channel binder in [`crate::channel`].
+//! exactly the shape of the channel binder in [`mod@crate::channel`].
 //!
 //! [`Fd`] itself is Unix-only (codegen refuses it for non-local / non-Rust
 //! targets). [`FrameFds`], [`collect_fds`] and [`provide_fds`] are portable

--- a/rust/vox-types/src/fd.rs
+++ b/rust/vox-types/src/fd.rs
@@ -1,0 +1,362 @@
+//! `Fd` — a file descriptor that travels across a vox connection.
+//!
+//! On the wire an [`Fd`] is encoded as a small varint *index* into a
+//! per-message fd table; the descriptors themselves travel out-of-band in
+//! `SCM_RIGHTS` ancillary data on a Unix-domain socket. This mirrors the
+//! `Tx<T>` → [`ChannelId`](crate::ChannelId) indirection: the bytes on the
+//! wire are just an index, the real resource is carried out-of-band and
+//! re-associated at the peer.
+//!
+//! The send/recv side-channel is plumbed through two thread-locals
+//! ([`collect_fds`] / [`provide_fds`]), installed around (de)serialization —
+//! exactly the shape of the channel binder in [`crate::channel`].
+//!
+//! [`Fd`] itself is Unix-only (codegen refuses it for non-local / non-Rust
+//! targets). [`FrameFds`], [`collect_fds`] and [`provide_fds`] are portable
+//! — on non-Unix targets `FrameFds` is `()` and the helpers are pass-throughs
+//! — so the message-routing rail and generated client code need no `cfg`.
+
+/// The descriptors carried with one frame. `Vec<OwnedFd>` on Unix; `()`
+/// elsewhere (no transport can pass descriptors off-Unix).
+#[cfg(unix)]
+pub type FrameFds = Vec<std::os::fd::OwnedFd>;
+/// The descriptors carried with one frame (none off-Unix).
+#[cfg(not(unix))]
+pub type FrameFds = ();
+
+// ===========================================================================
+// Non-Unix: portable no-op surface.
+// ===========================================================================
+
+#[cfg(not(unix))]
+mod portable {
+    /// No collector off-Unix: run `f`, gather nothing.
+    pub fn collect_fds<R>(f: impl FnOnce() -> R) -> (R, super::FrameFds) {
+        (f(), ())
+    }
+
+    /// No source off-Unix: descriptors cannot arrive, just run `f`.
+    pub fn provide_fds<R>(_fds: super::FrameFds, f: impl FnOnce() -> R) -> R {
+        f()
+    }
+}
+
+#[cfg(not(unix))]
+pub use portable::{collect_fds, provide_fds};
+
+/// Number of descriptors in a frame's fd set (0 off-Unix).
+#[cfg(unix)]
+pub fn frame_fds_len(fds: &FrameFds) -> usize {
+    fds.len()
+}
+/// Number of descriptors in a frame's fd set (0 off-Unix).
+#[cfg(not(unix))]
+pub fn frame_fds_len(_fds: &FrameFds) -> usize {
+    0
+}
+
+// ===========================================================================
+// Unix: the real implementation.
+// ===========================================================================
+
+#[cfg(unix)]
+mod unix {
+    use std::cell::{Cell, RefCell};
+    use std::os::fd::{AsFd, AsRawFd, BorrowedFd, IntoRawFd, OwnedFd, RawFd};
+
+    use facet::{Facet, FacetOpaqueAdapter, OpaqueDeserialize, OpaqueSerialize, PtrConst};
+
+    use super::FrameFds;
+
+    /// Maximum number of descriptors carried in a single `SCM_RIGHTS` control
+    /// message. The kernel hard-caps this (`SCM_MAX_FD`); we surface a clean
+    /// error rather than silently chunking across `sendmsg` calls.
+    pub const SCM_MAX_FD: usize = 253;
+
+    /// `wire_index` sentinel: this `Fd` has not been pushed into a collector.
+    /// Also the value encoded when an outgoing `Fd` carries no descriptor, so
+    /// the peer's `take_fd` fails cleanly instead of the encoder aborting
+    /// across `extern "C"`.
+    const NOT_COLLECTED: u32 = u32::MAX;
+
+    /// A file descriptor that can be sent across a vox connection.
+    ///
+    /// Construct one with [`Fd::new`] from anything that owns a descriptor
+    /// (`OwnedFd`, `File`, `UnixStream`, …). After the value has been
+    /// received on the far side, take ownership with [`Fd::into_owned_fd`]
+    /// or borrow it with [`Fd::as_raw_fd`].
+    ///
+    /// Serializing an `Fd` *duplicates* its descriptor into the transport's
+    /// `SCM_RIGHTS` batch (the source `Fd` keeps ownership), so a response
+    /// may be encoded more than once — the operation store's replay-seal
+    /// pass and the wire pass — and the encoder's size/write double-call is
+    /// deduped by the `Fd` value's address.
+    #[derive(Facet)]
+    #[facet(opaque = FdAdapter, traits(Debug))]
+    pub struct Fd {
+        /// The descriptor. `Some` for an outgoing `Fd`; `Some` for an
+        /// incoming `Fd` built by `deserialize_build`; `None` once taken.
+        inner: Cell<Option<OwnedFd>>,
+        /// Scratch the adapter points `OpaqueSerialize` at. Holds
+        /// `NOT_COLLECTED` until the first `serialize_map`, then the index
+        /// assigned by the send collector. Serialized as a postcard varint.
+        wire_index: Cell<u32>,
+    }
+
+    impl Fd {
+        /// Wrap an owned descriptor for sending.
+        pub fn new(fd: impl Into<OwnedFd>) -> Self {
+            Self {
+                inner: Cell::new(Some(fd.into())),
+                wire_index: Cell::new(NOT_COLLECTED),
+            }
+        }
+
+        /// Borrow the raw descriptor without taking ownership. `None` if it
+        /// has already been taken.
+        pub fn as_raw_fd(&self) -> Option<RawFd> {
+            let taken = self.inner.take();
+            let raw = taken.as_ref().map(|f| f.as_raw_fd());
+            self.inner.set(taken);
+            raw
+        }
+
+        /// Take the owned descriptor out of this `Fd`.
+        pub fn into_owned_fd(self) -> Option<OwnedFd> {
+            self.inner.take()
+        }
+
+        /// Take the descriptor as a raw, *owned* `RawFd`. The caller is
+        /// responsible for closing it.
+        pub fn into_raw_fd(self) -> Option<RawFd> {
+            self.inner.take().map(IntoRawFd::into_raw_fd)
+        }
+    }
+
+    impl std::fmt::Debug for Fd {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self.as_raw_fd() {
+                Some(raw) => f.debug_tuple("Fd").field(&raw).finish(),
+                None => f.debug_tuple("Fd").field(&"<consumed>").finish(),
+            }
+        }
+    }
+
+    // SAFETY: `Cell<Option<OwnedFd>>` / `Cell<u32>` are `Send` (contents are
+    // `Send`); `Fd` is moved, never shared, so `!Sync` is fine — matching
+    // `Payload`'s send-only stance.
+    unsafe impl Send for Fd {}
+
+    // -----------------------------------------------------------------------
+    // Thread-local fd side-channel — same install-around-(de)serialize shape
+    // as `CHANNEL_BINDER` (`channel.rs`).
+    // -----------------------------------------------------------------------
+
+    /// Descriptors gathered while encoding one message, with a dedup map so
+    /// the encoder's size pass + write pass (which both run `serialize_map`
+    /// for the same value) duplicate each descriptor exactly once.
+    struct FdCollector {
+        fds: Vec<OwnedFd>,
+        /// `Fd` value address → assigned index, scoped to this collector.
+        seen: std::collections::HashMap<usize, u32>,
+    }
+
+    std::thread_local! {
+        static FD_COLLECTOR: RefCell<Option<FdCollector>> = const { RefCell::new(None) };
+        static FD_SOURCE: RefCell<Option<Vec<Option<OwnedFd>>>> = const { RefCell::new(None) };
+    }
+
+    /// Install an empty fd collector for the duration of `f`, returning what
+    /// `f` produced together with the descriptors it gathered.
+    ///
+    /// Descriptors are *duplicated* into the collector, so the source `Fd`
+    /// keeps ownership and the same response can be encoded more than once
+    /// (the operation store's replay-seal pass and the wire pass).
+    pub fn collect_fds<R>(f: impl FnOnce() -> R) -> (R, FrameFds) {
+        struct Restore(Option<FdCollector>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                FD_COLLECTOR.with(|c| *c.borrow_mut() = self.0.take());
+            }
+        }
+        let fresh = FdCollector {
+            fds: Vec::new(),
+            seen: std::collections::HashMap::new(),
+        };
+        let _restore = Restore(FD_COLLECTOR.with(|c| c.borrow_mut().replace(fresh)));
+        let out = f();
+        let fds = FD_COLLECTOR
+            .with(|c| c.borrow_mut().as_mut().map(|col| std::mem::take(&mut col.fds)))
+            .unwrap_or_default();
+        (out, fds)
+    }
+
+    /// Provide the descriptors received with a frame for the duration of `f`
+    /// (typed payload decoding). Each [`Fd`] decoded inside claims one by
+    /// index.
+    pub fn provide_fds<R>(fds: FrameFds, f: impl FnOnce() -> R) -> R {
+        struct Restore(Option<Vec<Option<OwnedFd>>>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                FD_SOURCE.with(|c| *c.borrow_mut() = self.0.take());
+            }
+        }
+        let slots = fds.into_iter().map(Some).collect();
+        let _restore = Restore(FD_SOURCE.with(|c| c.borrow_mut().replace(slots)));
+        f()
+    }
+
+    /// Duplicate `fd` into the active collector, returning its stable index.
+    ///
+    /// `key` is the source `Fd`'s value address: repeated calls for the same
+    /// value within one collector (size pass then write pass) return the
+    /// same index and duplicate the descriptor only once. Returns
+    /// `NOT_COLLECTED` — never panics — when no collector is installed (e.g.
+    /// the operation store's seal pre-encode: an fd response is inherently
+    /// non-replayable) or if `dup` fails; a panic here would abort the
+    /// process across the `extern "C"` encoder trampolines.
+    fn collect_fd(key: usize, fd: BorrowedFd<'_>) -> u32 {
+        FD_COLLECTOR.with(|c| {
+            let mut slot = c.borrow_mut();
+            let Some(col) = slot.as_mut() else {
+                return NOT_COLLECTED;
+            };
+            if let Some(&idx) = col.seen.get(&key) {
+                return idx;
+            }
+            let Ok(dup) = fd.try_clone_to_owned() else {
+                return NOT_COLLECTED;
+            };
+            let idx = col.fds.len() as u32;
+            col.fds.push(dup);
+            col.seen.insert(key, idx);
+            idx
+        })
+    }
+
+    /// Claim descriptor `index` from the active source.
+    fn take_fd(index: u32) -> Result<OwnedFd, String> {
+        if index == NOT_COLLECTED {
+            return Err("Fd was sent without a descriptor".to_string());
+        }
+        FD_SOURCE.with(|c| {
+            let mut slot = c.borrow_mut();
+            let vec = slot
+                .as_mut()
+                .ok_or_else(|| "Fd decoded with no fd source installed".to_string())?;
+            let len = vec.len();
+            let cell = vec
+                .get_mut(index as usize)
+                .ok_or_else(|| format!("Fd wire index {index} out of range ({len})"))?;
+            cell.take()
+                .ok_or_else(|| format!("Fd wire index {index} already claimed"))
+        })
+    }
+
+    /// Adapter that bridges [`Fd`] through the opaque field contract
+    /// (modelled on `PayloadAdapter` in `message.rs`).
+    pub struct FdAdapter;
+
+    impl FacetOpaqueAdapter for FdAdapter {
+        type Error = String;
+        type SendValue<'a> = Fd;
+        type RecvValue<'de> = Fd;
+
+        fn serialize_map(value: &Self::SendValue<'_>) -> OpaqueSerialize {
+            // Borrow (don't consume): `collect_fd` dups, so the same response
+            // can be encoded more than once (seal pass + wire pass) and the
+            // size/write double-call is deduped by the `Fd` value address.
+            // `Cell` has no `&` accessor for non-`Copy` contents, so swap
+            // out and back.
+            let taken = value.inner.take();
+            let idx = match taken.as_ref() {
+                Some(owned) => collect_fd(value as *const Fd as usize, owned.as_fd()),
+                None => NOT_COLLECTED,
+            };
+            value.inner.set(taken);
+            value.wire_index.set(idx);
+            OpaqueSerialize {
+                ptr: PtrConst::new(value.wire_index.as_ptr().cast::<u8>()),
+                shape: <u32 as Facet>::SHAPE,
+            }
+        }
+
+        fn deserialize_build<'de>(
+            input: OpaqueDeserialize<'de>,
+        ) -> Result<Self::RecvValue<'de>, Self::Error> {
+            let bytes = match &input {
+                OpaqueDeserialize::Borrowed(b) => *b,
+                OpaqueDeserialize::Owned(b) => b.as_slice(),
+            };
+            let mut cursor = vox_postcard::decode::Cursor::new(bytes);
+            let index = cursor
+                .read_varint()
+                .map_err(|e| format!("Fd index varint: {e}"))? as u32;
+            let owned = take_fd(index)?;
+            Ok(Fd {
+                inner: Cell::new(Some(owned)),
+                wire_index: Cell::new(index),
+            })
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::io::{Read, Seek, Write};
+
+        fn temp_file_with(seed: &[u8]) -> std::fs::File {
+            let mut path = std::env::temp_dir();
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            path.push(format!("vox-fd-test-{}-{nanos}", std::process::id()));
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(true)
+                .open(&path)
+                .unwrap();
+            let _ = std::fs::remove_file(&path);
+            f.write_all(seed).unwrap();
+            f.rewind().unwrap();
+            f
+        }
+
+        #[test]
+        fn fd_round_trips_through_postcard() {
+            let file = temp_file_with(b"vox-fd-payload");
+            let msg = Fd::new(OwnedFd::from(file));
+
+            let (bytes, collected) = collect_fds(|| vox_postcard::to_vec(&msg).expect("encode"));
+            assert_eq!(collected.len(), 1, "one fd collected");
+            assert_eq!(&bytes[..4], &1u32.to_le_bytes());
+            assert_eq!(bytes[4], 0);
+
+            let decoded: Fd = provide_fds(collected, || {
+                vox_postcard::from_slice(&bytes).expect("decode")
+            });
+
+            let mut f = std::fs::File::from(decoded.into_owned_fd().expect("owned fd"));
+            let mut got = String::new();
+            f.read_to_string(&mut got).unwrap();
+            assert_eq!(got, "vox-fd-payload");
+        }
+
+        #[test]
+        fn missing_source_is_a_clean_error() {
+            let msg = Fd::new(OwnedFd::from(temp_file_with(b"x")));
+            let (bytes, _fds) = collect_fds(|| vox_postcard::to_vec(&msg).unwrap());
+            let r = std::panic::catch_unwind(|| vox_postcard::from_slice::<Fd>(&bytes));
+            assert!(
+                r.is_err() || r.unwrap().is_err(),
+                "decoding an Fd with no source must fail"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+pub use unix::{Fd, FdAdapter, SCM_MAX_FD, collect_fds, provide_fds};

--- a/rust/vox-types/src/lib.rs
+++ b/rust/vox-types/src/lib.rs
@@ -165,7 +165,7 @@ pub struct WithTracker<T> {
     pub tracker: std::sync::Arc<SchemaRecvTracker>,
     /// Descriptors that arrived with this response frame (`SCM_RIGHTS`).
     /// The generated client installs these as the
-    /// [`provide_fds`](crate::provide_fds) source around the typed-return
+    /// [`provide_fds`] source around the typed-return
     /// decode. `()` off-Unix.
     pub fds: crate::FrameFds,
 }

--- a/rust/vox-types/src/lib.rs
+++ b/rust/vox-types/src/lib.rs
@@ -143,6 +143,11 @@ pub use calls::*;
 pub mod channel;
 pub use channel::*;
 
+pub mod fd;
+pub use fd::{FrameFds, collect_fds, frame_fds_len, provide_fds};
+#[cfg(unix)]
+pub use fd::{Fd, FdAdapter, SCM_MAX_FD};
+
 mod shape_classify;
 pub use shape_classify::*;
 
@@ -158,6 +163,11 @@ pub use schema::*;
 pub struct WithTracker<T> {
     pub value: T,
     pub tracker: std::sync::Arc<SchemaRecvTracker>,
+    /// Descriptors that arrived with this response frame (`SCM_RIGHTS`).
+    /// The generated client installs these as the
+    /// [`provide_fds`](crate::provide_fds) source around the typed-return
+    /// decode. `()` off-Unix.
+    pub fds: crate::FrameFds,
 }
 
 impl<T> std::fmt::Debug for WithTracker<T> {

--- a/rust/vox-types/src/link.rs
+++ b/rust/vox-types/src/link.rs
@@ -96,6 +96,38 @@ pub trait LinkTx: MaybeSend + MaybeSync + 'static {
     fn close(self) -> impl Future<Output = std::io::Result<()>> + MaybeSend
     where
         Self: Sized;
+
+    /// Whether this transport can carry file descriptors (`SCM_RIGHTS` over a
+    /// Unix-domain socket). Only such links may carry [`Fd`](crate::fd::Fd)
+    /// values; everything else (TCP, WebSocket, wasm) returns `false` and the
+    /// encoder refuses fd-bearing messages.
+    fn supports_fd_passing(&self) -> bool {
+        false
+    }
+
+    /// Send one payload that carries `fds` out-of-band via `SCM_RIGHTS`.
+    ///
+    /// The default errors if any fds are present (a transport that cannot
+    /// pass descriptors must never be handed one); with no fds it is exactly
+    /// [`send`](Self::send), so existing transports need no change. Off-Unix
+    /// [`FrameFds`](crate::FrameFds) is `()` and this is always plain
+    /// [`send`](Self::send).
+    fn send_with_fds(
+        &self,
+        bytes: Vec<u8>,
+        fds: crate::FrameFds,
+    ) -> impl Future<Output = std::io::Result<()>> + MaybeSend + '_ {
+        async move {
+            #[cfg(unix)]
+            if !fds.is_empty() {
+                return Err(std::io::Error::other(
+                    "transport does not support fd passing",
+                ));
+            }
+            let _ = &fds;
+            self.send(bytes).await
+        }
+    }
 }
 
 /// Receiving half of a [`Link`].
@@ -118,6 +150,18 @@ pub trait LinkRx: MaybeSend + 'static {
     fn recv(
         &mut self,
     ) -> impl Future<Output = Result<Option<Backing>, Self::Error>> + MaybeSend + '_;
+
+    /// Take the file descriptors that arrived with the frame returned by the
+    /// most recent [`recv`](Self::recv).
+    ///
+    /// Descriptors travel out-of-band in `SCM_RIGHTS`; an fd-capable link
+    /// attributes each batch to the frame whose bytes completed it (one
+    /// fd-bearing frame == one `sendmsg`). The default returns none, so
+    /// non-fd transports need no change. The conduit threads these to the
+    /// typed-decode site as the [`provide_fds`](crate::provide_fds) source.
+    fn take_frame_fds(&mut self) -> crate::FrameFds {
+        crate::FrameFds::default()
+    }
 }
 
 /// A [`Link`] assembled from pre-split Tx and Rx halves.

--- a/rust/vox/src/lib.rs
+++ b/rust/vox/src/lib.rs
@@ -229,6 +229,13 @@ pub use vox_types::{
     observe_reply,
 };
 
+// File-descriptor passing. `FrameFds`/`collect_fds`/`provide_fds` are
+// portable (no-ops off-Unix) so generated client code needs no `cfg`;
+// `Fd` itself is Unix-only.
+pub use vox_types::{FrameFds, collect_fds, frame_fds_len, provide_fds};
+#[cfg(unix)]
+pub use vox_types::{Fd, FdAdapter, SCM_MAX_FD};
+
 // ── vox-core: curated public API ──────────────────────────────────────
 
 // Session establishment — builder entry points
@@ -320,6 +327,11 @@ pub mod transport {
             LocalStream, connect, endpoint_exists, local_link_source, path_to_pipe_name,
             remove_endpoint,
         };
+
+        /// Descriptor-passing Unix-domain link (`SCM_RIGHTS`). The only
+        /// transport over which [`Fd`](crate::Fd) values may travel.
+        #[cfg(unix)]
+        pub use vox_stream::{FdStreamLink, FdStreamLinkRx, FdStreamLinkTx};
     }
 
     /// WebSocket transport (`vox-websocket`).

--- a/rust/vox/tests/fd_passing_tests.rs
+++ b/rust/vox/tests/fd_passing_tests.rs
@@ -1,0 +1,144 @@
+//! End-to-end `vox::Fd` passing through a real `#[vox::service]`.
+//!
+//! A descriptor returned by a service method must arrive on the client as a
+//! working file descriptor (proven by reading an *unlinked* temp file
+//! through it — only the descriptor keeps the inode alive). Also covers
+//! multi-fd, the `SCM_MAX_FD` hard cap, and a non-fd transport refusing to
+//! carry an `Fd`.
+#![cfg(unix)]
+
+use std::io::{Read, Seek, Write};
+use std::os::fd::OwnedFd;
+
+use vox::Fd;
+use vox::transport::local::FdStreamLink;
+use vox::transport::tcp::StreamLink;
+
+/// Fresh, immediately-unlinked temp file seeded with `seed`, positioned at 0.
+/// Reading it back through a transported fd proves the *descriptor* moved,
+/// not the path.
+fn temp_blob(seed: &[u8]) -> std::fs::File {
+    let mut path = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    path.push(format!("vox-fdpass-it-{}-{nanos}", std::process::id()));
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .unwrap();
+    let _ = std::fs::remove_file(&path);
+    f.write_all(seed).unwrap();
+    f.rewind().unwrap();
+    f
+}
+
+fn read_fd(fd: Fd) -> String {
+    let mut f = std::fs::File::from(fd.into_owned_fd().expect("owned fd"));
+    let mut s = String::new();
+    f.read_to_string(&mut s).unwrap();
+    s
+}
+
+#[vox::service]
+trait FdVault {
+    /// Hand the caller a descriptor to a freshly-created (already unlinked)
+    /// blob containing `tag`-derived bytes.
+    async fn open_blob(&self, tag: u32) -> Fd;
+    /// Hand back several descriptors at once.
+    async fn open_many(&self, n: u32) -> Vec<Fd>;
+}
+
+#[derive(Clone)]
+struct Vault;
+
+impl FdVault for Vault {
+    async fn open_blob(&self, tag: u32) -> Fd {
+        Fd::new(OwnedFd::from(temp_blob(format!("blob-{tag}").as_bytes())))
+    }
+
+    async fn open_many(&self, n: u32) -> Vec<Fd> {
+        (0..n)
+            .map(|i| Fd::new(OwnedFd::from(temp_blob(format!("m{i}").as_bytes()))))
+            .collect()
+    }
+}
+
+async fn fd_pair() -> (FdVaultClient, vox::NoopClient) {
+    let (client_link, server_link) = FdStreamLink::pair().unwrap();
+    let server = tokio::spawn(async move {
+        vox::acceptor_on(server_link)
+            .on_connection(FdVaultDispatcher::new(Vault))
+            .establish::<vox::NoopClient>()
+            .await
+            .expect("server establish")
+    });
+    let client = vox::initiator_on(client_link, vox::TransportMode::Bare)
+        .establish::<FdVaultClient>()
+        .await
+        .expect("client establish");
+    let server_guard = server.await.expect("server task");
+    (client, server_guard)
+}
+
+#[tokio::test]
+async fn single_fd_round_trips_through_service() {
+    let (client, _server) = fd_pair().await;
+    let fd = client.open_blob(7).await.expect("open_blob call");
+    assert_eq!(read_fd(fd), "blob-7");
+}
+
+#[tokio::test]
+async fn multiple_fds_in_one_response() {
+    let (client, _server) = fd_pair().await;
+    let fds = client.open_many(4).await.expect("open_many call");
+    assert_eq!(fds.len(), 4);
+    let got: Vec<String> = fds.into_iter().map(read_fd).collect();
+    assert_eq!(got, vec!["m0", "m1", "m2", "m3"]);
+}
+
+#[tokio::test]
+async fn exceeding_scm_max_fd_is_an_error_not_a_crash() {
+    let (client, _server) = fd_pair().await;
+    // 300 > SCM_MAX_FD (253): the server's send must fail cleanly and the
+    // call surfaces an error rather than corrupting the stream.
+    let result = client.open_many(300).await;
+    assert!(
+        result.is_err(),
+        "a response with >253 fds must error, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn non_fd_transport_refuses_to_carry_an_fd() {
+    // TCP `StreamLink` advertises no fd support; returning an `Fd` over it
+    // must fail at send rather than silently dropping the descriptor.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        vox::acceptor_on(StreamLink::tcp(sock))
+            .on_connection(FdVaultDispatcher::new(Vault))
+            .establish::<vox::NoopClient>()
+            .await
+            .expect("server establish")
+    });
+
+    let client_sock = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let client = vox::initiator_on(StreamLink::tcp(client_sock), vox::TransportMode::Bare)
+        .establish::<FdVaultClient>()
+        .await
+        .expect("client establish");
+    let _server = server.await.expect("server task");
+
+    let result = client.open_blob(1).await;
+    assert!(
+        result.is_err(),
+        "TCP transport must refuse an Fd-bearing response, got {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds first-class file-descriptor passing to vox. A `vox::Fd` is a newtype over an `OwnedFd` that wire-encodes as a **varint index** into a per-message fd array; the descriptors themselves travel out-of-band in **SCM_RIGHTS** ancillary data on a Unix-domain socket and are re-associated at the peer. This mirrors the existing `Tx<T>`→`ChannelId` indirection — the on-wire bytes are just an index, the real resource rides beside the frame.

A method returning `vox::Fd` now works **end-to-end through an ordinary `#[vox::service]`** over a `LocalLink`, with no bespoke socket protocol. (Motivation: a privileged Linux daemon can hand `perf_event_open` fds to an unprivileged peer with the same structural shape as its macOS counterpart.)

## How it works

Reuses three existing vox patterns so the (de)serializer and codegen barely change:

- **Opaque adapter** `FdAdapter` (like `Payload`): `serialize_map` *dups* the fd into a thread-local `FD_COLLECTOR` and emits the index; `deserialize_build` pulls fd #n from `FD_SOURCE`. Routes through the existing opaque path in both postcard and JIT. The adapter dups (never consumes) so it is idempotent across the JIT size+write passes **and** the operation-store seal re-encode, and returns a sentinel rather than panicking when crossing the `extern "C"` boundary with no collector.
- **Portable `FrameFds`** (`Vec<OwnedFd>` on unix, `()` elsewhere) so the deep connection/per-message threading and generated client code need zero `#[cfg]`.
- **`PreparedFrame { bytes, fds }`** threaded through the conduit; `prepare_send` installs the collector around encode, `send_prepared` routes to a new fd-aware `LinkTx::send_with_fds`.

## Transport

- New **`FdStreamLink`** (unix-only) over `tokio::net::UnixStream`. Frames as `[u32 body_len][u32 fd_count][body]`; the writer emits each fd-bearing frame in its own `sendmsg` carrying SCM_RIGHTS, the reader drains every `recvmsg`'s cmsg into an ordered FIFO and pops `fd_count` per frame. Counted-FIFO + arrival order makes fd→frame attribution deterministic regardless of how the kernel chunks bytes vs control messages (positional attribution is unreliable across recvmsg boundaries). `LocalLink`/`LocalLinkAcceptor` use it on unix.
- `MemoryLink` carries the `OwnedFd`s directly alongside the bytes (no SCM_RIGHTS needed in-process).
- `LinkTx::supports_fd_passing()` (default `false`; `true` only on `FdStreamLink`/`MemoryLink`) plus a defaulted `send_with_fds` that hard-errors on any incapable transport. `BareConduitTx::send_prepared` fails fast if a message collected fds but the link can't carry them.

## Deliberate limits

- **>253 fds (`SCM_MAX_FD`) in one message → clean error**, no cross-`sendmsg` chunking. Same-host-only simplification.
- The `#[repr(C)]` transport prologue and `TRANSPORT_VERSION` are **left untouched**: fd capability is a local link property (zero wire bytes), not a prologue bit decided too early.

## Tests

`rust/vox/tests/fd_passing_tests.rs` (4, all green):
- single `Fd` round-trips through a `#[vox::service]` and reads the same bytes on the far side
- `Vec<Fd>` multi-fd in one response
- exceeding `SCM_MAX_FD` is a clean error, not a crash
- a non-fd transport (TCP) refuses to carry an `Fd`

Plus unit coverage in vox-types / vox-fdpass / vox-stream, and regenerated vox-macros-core snapshots for the `provide_fds`-wrapped client decode. `vox-fdpass` also gains generalized `send_msg_with_fds`/`recv_msg`.

## Follow-ups (tracked, not blockers)

- Server-side `Fd` **args** decode (`handle_request` Call branch currently drops `fds`).
- `ConnectionSettings.fd_passing` advertisement — builder refactor, see #323. Safety is already enforced link-side + (future) codegen.
- `vox::Fd` codegen refusal for non-Rust / non-local targets.