### PR TITLE
Fix post-phon release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,9 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter "@bearcove/vox-playwright-tests" exec playwright install --with-deps chromium
 
+      - name: Build Rust WebSocket peer server
+        run: cargo build -p peer-server --bin ws-peer-server
+
       - name: Run TypeScript browser tests
         run: pnpm --filter "@bearcove/vox-playwright-tests" run test
 
@@ -361,6 +364,9 @@ jobs:
 
       - name: Install Playwright browsers
         run: pnpm --filter "@bearcove/vox-wasm-playwright-tests" exec playwright install --with-deps chromium
+
+      - name: Build Rust WebSocket peer server
+        run: cargo build -p peer-server --bin ws-peer-server
 
       - name: Run Wasm browser tests
         env:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Authenticate to crates.io (OIDC)
         id: crates-io-auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@v1.0.4
 
       - name: Run release-plz
         uses: release-plz/action@v0.5

--- a/docs/templates/section.html
+++ b/docs/templates/section.html
@@ -9,8 +9,7 @@
 <div class="layout">
     <aside class="sidebar">
         <nav class="sidebar-nav">
-            {% for sub_path in root_section.subsections %}
-            {% set sub = get_section(path=sub_path) %}
+            {% for sub in root_section.subsections %}
             <div class="sidebar-section">
                 <h3><a href="{{ sub.permalink }}"{% if section.path == sub.path %} class="active"{% endif %}>{{ sub.title }}</a></h3>
                 <ul>


### PR DESCRIPTION
## Summary

Fix the post-merge failures from the phon-codec release run.

- Prebuild the Rust WebSocket peer server before the TypeScript and Wasm Playwright browser suites so cold CI runs do not spend Playwright beforeAll time compiling, then retry into Cargo build locks.
- Update the docs section sidebar template to use section objects directly, matching the other templates and current Dodeca data shape.
- Pin rust-lang/crates-io-auth-action to v1.0.4, whose action metadata uses Node 24 instead of the moving v1 tag currently resolving to Node 20.

## Testing

- actionlint .github/workflows/ci.yml .github/workflows/release-plz.yml
- cargo build -p peer-server --bin ws-peer-server
- ~/.cargo/bin/ddc build
- pnpm --filter "@bearcove/vox-playwright-tests" run test
- VOX_SKIP_WASM_PACK_BUILD=1 pnpm --filter "@bearcove/vox-wasm-playwright-tests" run test
- cargo publish -p vox-phon --dry-run

## Release note

crates.io still does not have vox-phon, and the release workflow failed because trusted-publishing tokens cannot create a brand new crate. The dry-run publish for vox-phon v0.9.0-rc.0 succeeds, and registry checks show vox-phon is the only publishable workspace crate missing on crates.io. It needs one manual first publish before rerunning the Release / Publish job.